### PR TITLE
fix: fix explore state actions initial explore state filters and the clear filters action (#60)

### DIFF
--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -41,6 +41,7 @@ import {
   getFilterCount,
   initExploreState,
   resetPage,
+  updateEntityPageState,
 } from "./exploreState/utils";
 
 export type CatalogState = string | undefined;
@@ -371,10 +372,17 @@ function exploreReducer(
      * Clear all filters
      **/
     case ExploreActionKind.ClearFilters: {
+      const filterCount = 0;
+      const filterState: SelectedFilter[] = [];
       return {
         ...state,
-        filterCount: 0,
-        filterState: [],
+        entityPageState: updateEntityPageState(
+          state.tabValue,
+          state.entityPageState,
+          { filterCount, filterState }
+        ),
+        filterCount,
+        filterState,
         paginationState: resetPage(state.paginationState),
       };
     }

--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -498,14 +498,11 @@ function exploreReducer(
       const filterCount = getFilterCount(filterState);
       return {
         ...state,
-        entityPageState: {
-          ...state.entityPageState,
-          [state.tabValue]: {
-            ...state.entityPageState[state.tabValue],
-            filterCount,
-            filterState,
-          },
-        },
+        entityPageState: updateEntityPageState(
+          state.tabValue,
+          state.entityPageState,
+          { filterCount, filterState }
+        ),
         filterCount,
         filterState,
         paginationState: resetPage(state.paginationState),
@@ -515,17 +512,13 @@ function exploreReducer(
      * Update sorting
      **/
     case ExploreActionKind.UpdateSorting: {
-      const currentEntity = state.tabValue;
-      const currentPageState = state.entityPageState[currentEntity];
       return {
         ...state,
-        entityPageState: {
-          ...state.entityPageState,
-          [currentEntity]: {
-            ...currentPageState,
-            sorting: payload,
-          },
-        },
+        entityPageState: updateEntityPageState(
+          state.tabValue,
+          state.entityPageState,
+          { sorting: payload }
+        ),
         paginationState: resetPage(state.paginationState),
       };
     }
@@ -533,17 +526,13 @@ function exploreReducer(
      * Update column visibility
      **/
     case ExploreActionKind.UpdateColumnVisibility: {
-      const currentEntity = state.tabValue;
-      const currentPageState = state.entityPageState[currentEntity];
       return {
         ...state,
-        entityPageState: {
-          ...state.entityPageState,
-          [currentEntity]: {
-            ...currentPageState,
-            columnsVisibility: payload,
-          },
-        },
+        entityPageState: updateEntityPageState(
+          state.tabValue,
+          state.entityPageState,
+          { columnsVisibility: payload }
+        ),
       };
     }
 

--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -465,10 +465,14 @@ function exploreReducer(
       if (payload === state.tabValue) {
         return state;
       }
+      const { entityPageState } = state;
+      const entityState = entityPageState[payload];
       return {
         ...state,
-        filterCount: state.entityPageState[payload].filterCount,
-        filterState: state.entityPageState[payload].filterState,
+        categoryGroupConfigs: entityState.categoryGroupConfigs,
+        categoryViews: entityState.categoryViews,
+        filterCount: entityState.filterCount,
+        filterState: entityState.filterState,
         listItems: [],
         loading: true,
         paginationState: resetPage(state.paginationState),

--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -421,13 +421,9 @@ function exploreReducer(
         ...state,
         categoryGroupConfigs: entityPageState[tabValue].categoryGroupConfigs,
         categoryViews: nextCategoryViews ?? categoryViews,
-        entityPageState: {
-          ...entityPageState,
-          [tabValue]: {
-            ...entityPageState[tabValue],
-            categoryViews: nextCategoryViews ?? categoryViews,
-          },
-        },
+        entityPageState: updateEntityPageState(tabValue, entityPageState, {
+          categoryViews: nextCategoryViews ?? categoryViews,
+        }),
         listItems: payload.loading ? [] : payload.listItems,
         loading: payload.loading,
         paginationState: {

--- a/src/providers/exploreState/utils.ts
+++ b/src/providers/exploreState/utils.ts
@@ -7,6 +7,7 @@ import {
 } from "../../config/entities";
 import { getDefaultSorting } from "../../config/utils";
 import {
+  EntityPageState,
   EntityPageStateMapper,
   ENTITY_VIEW,
   ExploreState,
@@ -46,7 +47,10 @@ export function initExploreState(
     ...INITIAL_STATE,
     catalogState: decodedCatalogParam,
     categoryGroupConfigs: entityPageState[entityListType].categoryGroupConfigs,
-    entityPageState: initEntityPageState(config),
+    entityPageState: updateEntityPageState(entityListType, entityPageState, {
+      filterCount,
+      filterState,
+    }),
     featureFlagState: decodedFeatureFlagParam,
     filterCount,
     filterState,
@@ -121,4 +125,25 @@ export function resetPage(paginationState: PaginationState): PaginationState {
   nextPaginationState.index = null;
   nextPaginationState.currentPage = 1;
   return nextPaginationState;
+}
+
+/**
+ * Updates entity page state for the given entity type.
+ * @param entityListType - Entity list type.
+ * @param entityPageState - Entity page state.
+ * @param nextEntityPageState - Partial next entity page state.
+ * @returns updated entity page state.
+ */
+export function updateEntityPageState(
+  entityListType: string,
+  entityPageState: EntityPageStateMapper,
+  nextEntityPageState: Partial<EntityPageState>
+): EntityPageStateMapper {
+  return {
+    ...entityPageState,
+    [entityListType]: {
+      ...entityPageState[entityListType],
+      ...nextEntityPageState,
+    },
+  };
 }


### PR DESCRIPTION
Closes #60.

- Explore State Action `ClearFilters` fixes clear all filters button for the entity list.
- Explore State Action `SelectEntityType` updates state values for the selected tab such as `categoryViews` and `categoryGroupConfigs`.
- Explore State Actions `ProcessExploreResponse`, `UpdateFilter`, `UpdateSorting`, and `UpdateColumnVisibility` use the new `updateEntityPageState` function to update the `entityPageState`.
- Initialisation of Explore State fixes the `entityPageState` - the current entity list's `entityPageState`'s `filterState` and `filterCount` are initialised by values from the decoded filter param.

 
