### PR TITLE
chore: removed entity_type parameter from bulk_download_requested event

### DIFF
--- a/src/common/analytics/entities.ts
+++ b/src/common/analytics/entities.ts
@@ -20,7 +20,6 @@ export enum EVENT_PARAM {
   COLUMN_NAME = "column_name",
   CURRENT_QUERY = "current_query",
   ENTITY_NAME = "entity_name",
-  ENTITY_TYPE = "entity_type",
   FILTER_NAME = "filter_name",
   FILTER_VALUE = "filter_value",
   INDEX = "index",
@@ -52,7 +51,6 @@ export type EventParams = {
   [EVENT_NAME.BULK_DOWNLOAD_REQUESTED]: {
     [EVENT_PARAM.CATALOG]: string;
     [EVENT_PARAM.CURRENT_QUERY]: string;
-    [EVENT_PARAM.ENTITY_TYPE]: string;
     [EVENT_PARAM.INDEX]: string;
     [EVENT_PARAM.TOOL_NAME]: string;
   };

--- a/src/components/Export/common/tracking.ts
+++ b/src/components/Export/common/tracking.ts
@@ -23,7 +23,6 @@ export function bulkDownloadTracking(
   track(EVENT_NAME.BULK_DOWNLOAD_REQUESTED, {
     [EVENT_PARAM.CATALOG]: catalog,
     [EVENT_PARAM.CURRENT_QUERY]: currentQuery,
-    [EVENT_PARAM.ENTITY_TYPE]: "Bulk Download",
     [EVENT_PARAM.INDEX]: index,
     [EVENT_PARAM.TOOL_NAME]: toolName,
   });


### PR DESCRIPTION
### Issue
#213 

### Changes
- Removed `entity_type` parameter from the model for the `bulk_download_requested` GA4 event, since it returned a hardcoded value