### PR TITLE
feat: added and updated index export tracking (#222)

### DIFF
--- a/src/common/analytics/entities.ts
+++ b/src/common/analytics/entities.ts
@@ -10,19 +10,18 @@ export enum EVENT_NAME {
   ENTITY_TABLE_PAGINATED = "entity_table_paginated",
   ENTITY_TABLE_SORTED = "entity_table_sorted",
   FILTER_SELECTED = "filter_selected",
+  INDEX_ANALYZE_IN_TERRA_REQUESTED = "index_analyze_in_terra_requested",
+  INDEX_FILE_MANIFEST_REQUESTED = "index_file_manifest_requested",
 }
 
 /**
  * Set of analytics event parameters.
  */
 export enum EVENT_PARAM {
-  CATALOG = "catalog",
   COLUMN_NAME = "column_name",
-  CURRENT_QUERY = "current_query",
   ENTITY_NAME = "entity_name",
   FILTER_NAME = "filter_name",
   FILTER_VALUE = "filter_value",
-  INDEX = "index",
   PAGINATION_DIRECTION = "pagination_direction",
   SORT_DIRECTION = "sort_direction",
   TOOL_NAME = "tool_name",
@@ -49,9 +48,7 @@ export enum SORT_DIRECTION {
  */
 export type EventParams = {
   [EVENT_NAME.BULK_DOWNLOAD_REQUESTED]: {
-    [EVENT_PARAM.CATALOG]: string;
-    [EVENT_PARAM.CURRENT_QUERY]: string;
-    [EVENT_PARAM.INDEX]: string;
+    [EVENT_PARAM.ENTITY_NAME]: string;
     [EVENT_PARAM.TOOL_NAME]: string;
   };
   [EVENT_NAME.ENTITY_SELECTED]: { [EVENT_PARAM.ENTITY_NAME]: string };
@@ -67,5 +64,11 @@ export type EventParams = {
   [EVENT_NAME.FILTER_SELECTED]: {
     [EVENT_PARAM.FILTER_NAME]: string;
     [EVENT_PARAM.FILTER_VALUE]: string;
+  };
+  [EVENT_NAME.INDEX_ANALYZE_IN_TERRA_REQUESTED]: {
+    [EVENT_PARAM.ENTITY_NAME]: string;
+  };
+  [EVENT_NAME.INDEX_FILE_MANIFEST_REQUESTED]: {
+    [EVENT_PARAM.ENTITY_NAME]: string;
   };
 };

--- a/src/common/analytics/readme-analytics.md
+++ b/src/common/analytics/readme-analytics.md
@@ -6,13 +6,15 @@ See below a list of the currently available events.
 
 ### GA4 Event Inventory
 
-| Event                     | Parameters                                       | Description                                                     |
-| ------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
-| `bulk_download_requested` | `catalog`, `current_query`, `index`, `tool_name` | Runs when the HCA-DCP "Request curl command" button is selected |
-| `entity_selected`         | `entity_name`                                    | Runs when an entity (tab) is selected                           |
-| `entity_table_paginated`  | `entity_name`, `pagination_direction`            | Runs when the page forward/backwards buttons are clicked        |
-| `entity_table_sorted`     | `entity_name`, `column_name`, `sort_direction`   | Runs each time a column in the entity table is sorted           |
-| `filter_selected`         | `filter_name`, `filter_value`                    | Runs each time a filter is selected                             |
+| Event                              | Parameters                                     | Description                                                    |
+| ---------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| `bulk_download_requested`          | `entity_name`, `tool_name`                     | Runs when the index "Request curl command" button is selected  |
+| `index_analyze_in_terra_requested` | `entity_name`                                  | Runs when the index "Analyze in Terra" button is selected      |
+| `index_file_manifest_requested`    | `entity_name`                                  | Runs when the index "Request File Manifest" button is selected |
+| `entity_selected`                  | `entity_name`                                  | Runs when an entity (tab) is selected                          |
+| `entity_table_paginated`           | `entity_name`, `pagination_direction`          | Runs when the page forward/backwards buttons are clicked       |
+| `entity_table_sorted`              | `entity_name`, `column_name`, `sort_direction` | Runs each time a column in the entity table is sorted          |
+| `filter_selected`                  | `filter_name`, `filter_value`                  | Runs each time a filter is selected                            |
 
 ### Tracking-related ID Inventory
 

--- a/src/components/Export/common/tracking.ts
+++ b/src/components/Export/common/tracking.ts
@@ -17,15 +17,21 @@ export function bulkDownloadTracking(
   });
 }
 
+/**
+ * Executes event tracking for the file manifest export.
+ * @param entity_name - Entity (tab) name.
+ */
 export function fileManifestTracking(entity_name: string): void {
   // Track the file manifest requested event.
-  console.log("tracking file manifest requested event");
-  console.log(entity_name);
   track(EVENT_NAME.INDEX_FILE_MANIFEST_REQUESTED, {
     [EVENT_PARAM.ENTITY_NAME]: entity_name,
   });
 }
 
+/**
+ * Executes event tracking for the Terra export.
+ * @param entity_name - Entity (tab) name.
+ */
 export function exportToTerraTracking(entity_name: string): void {
   // Track the export to terra event.
   track(EVENT_NAME.INDEX_ANALYZE_IN_TERRA_REQUESTED, {

--- a/src/components/Export/common/tracking.ts
+++ b/src/components/Export/common/tracking.ts
@@ -3,27 +3,32 @@ import { EVENT_NAME, EVENT_PARAM } from "../../../common/analytics/entities";
 
 /**
  * Executes event tracking for bulk download.
- * @param index - Index.
+ * @param entity_name - Entity (tab) name.
  * @param toolName - Tool name.
- * @param requestParams - Request params.
  */
 export function bulkDownloadTracking(
-  index: string,
-  toolName: string,
-  requestParams?: URLSearchParams
+  entity_name: string,
+  toolName: string
 ): void {
-  if (!requestParams) {
-    return;
-  }
-  // Grab catalog and current query from the request params.
-  const catalog = requestParams.get("catalog") as string; // Catalog will be defined.
-  const currentQuery = requestParams.get("filters") as string; // Filters will be defined.
-
   // Track the bulk download requested event.
   track(EVENT_NAME.BULK_DOWNLOAD_REQUESTED, {
-    [EVENT_PARAM.CATALOG]: catalog,
-    [EVENT_PARAM.CURRENT_QUERY]: currentQuery,
-    [EVENT_PARAM.INDEX]: index,
+    [EVENT_PARAM.ENTITY_NAME]: entity_name,
     [EVENT_PARAM.TOOL_NAME]: toolName,
+  });
+}
+
+export function fileManifestTracking(entity_name: string): void {
+  // Track the file manifest requested event.
+  console.log("tracking file manifest requested event");
+  console.log(entity_name);
+  track(EVENT_NAME.INDEX_FILE_MANIFEST_REQUESTED, {
+    [EVENT_PARAM.ENTITY_NAME]: entity_name,
+  });
+}
+
+export function exportToTerraTracking(entity_name: string): void {
+  // Track the export to terra event.
+  track(EVENT_NAME.INDEX_ANALYZE_IN_TERRA_REQUESTED, {
+    [EVENT_PARAM.ENTITY_NAME]: entity_name,
   });
 }

--- a/src/components/Export/components/DownloadCurlCommand/downloadCurlCommand.tsx
+++ b/src/components/Export/components/DownloadCurlCommand/downloadCurlCommand.tsx
@@ -2,10 +2,7 @@ import React, { ElementType, useState } from "react";
 import { MANIFEST_DOWNLOAD_FORMAT } from "../../../../apis/azul/common/entities";
 import { Filters } from "../../../../common/entities";
 import { useExploreState } from "../../../../hooks/useExploreState";
-import {
-  FILE_MANIFEST_TYPE,
-  FileManifestType,
-} from "../../../../hooks/useFileManifest/common/entities";
+import { FileManifestType } from "../../../../hooks/useFileManifest/common/entities";
 import { useFileManifest } from "../../../../hooks/useFileManifest/useFileManifest";
 import { useRequestFileManifest } from "../../../../hooks/useFileManifest/useRequestFileManifest";
 import { FileLocation } from "../../../../hooks/useRequestFileLocation";
@@ -35,7 +32,6 @@ export const DownloadCurlCommand = ({
   DownloadCurlStart,
   DownloadCurlSuccess,
   fileManifestState,
-  fileManifestType,
   fileSummaryFacetName,
   filters,
   formFacet,
@@ -50,7 +46,6 @@ export const DownloadCurlCommand = ({
   const {
     exploreState: { tabValue: entityList },
   } = useExploreState();
-  const { requestParams } = fileManifestState;
   const { data, isLoading, run } = useFileManifest();
   const curlCommand = getBulkDownloadCurlCommand(data, executionEnvironment);
   return curlCommand ? (
@@ -68,12 +63,7 @@ export const DownloadCurlCommand = ({
       isLoading={isLoading}
       onRequestManifest={(): void => {
         // Execute GTM tracking.
-        track(
-          fileManifestType,
-          entityList,
-          executionEnvironment,
-          requestParams
-        );
+        bulkDownloadTracking(entityList, executionEnvironment);
         // Request manifest.
         run();
       }}
@@ -97,22 +87,4 @@ function getBulkDownloadCurlCommand(
     return;
   }
   return commandLine[executionEnvironment];
-}
-
-/**
- * Executes GTM tracking.
- * @param fileManifestType - File manifest type.
- * @param index - Index.
- * @param toolName - Execution environment.
- * @param requestParams - Request params.
- */
-function track(
-  fileManifestType: FileManifestType,
-  index: string,
-  toolName: string,
-  requestParams?: URLSearchParams
-): void {
-  if (fileManifestType === FILE_MANIFEST_TYPE.BULK_DOWNLOAD) {
-    bulkDownloadTracking(index, toolName, requestParams);
-  }
 }

--- a/src/components/Export/components/ExportToTerra/exportToTerra.tsx
+++ b/src/components/Export/components/ExportToTerra/exportToTerra.tsx
@@ -1,11 +1,13 @@
 import React, { ElementType } from "react";
 import { Filters } from "../../../../common/entities";
+import { useExploreState } from "../../../../hooks/useExploreState";
 import { useExportToTerraResponseURL } from "../../../../hooks/useExportToTerraResponseURL";
 import { FileManifestType } from "../../../../hooks/useFileManifest/common/entities";
 import { useFileManifest } from "../../../../hooks/useFileManifest/useFileManifest";
 import { useRequestFileManifest } from "../../../../hooks/useFileManifest/useRequestFileManifest";
 import { FileManifestState } from "../../../../providers/fileManifestState";
 import { FormFacet, ManifestDownloadFormat } from "../../common/entities";
+import { exportToTerraTracking } from "../../common/tracking";
 import { ExportToTerraNotStarted } from "./components/ExportToTerraNotStarted/exportToTerraNotStarted";
 import { ExportToTerraReady } from "./components/ExportToTerraReady/exportToTerraReady";
 
@@ -33,6 +35,9 @@ export const ExportToTerra = ({
   manifestDownloadFormat,
   manifestDownloadFormats,
 }: ExportToTerraProps): JSX.Element => {
+  const {
+    exploreState: { tabValue: entityList },
+  } = useExploreState();
   useRequestFileManifest(manifestDownloadFormat, filters, fileSummaryFacetName);
   const { requestParams } = fileManifestState;
   const { data, isLoading, run } = useFileManifest();
@@ -50,7 +55,12 @@ export const ExportToTerra = ({
       formFacet={formFacet}
       isLoading={isLoading}
       manifestDownloadFormats={manifestDownloadFormats}
-      onRequestManifest={run}
+      onRequestManifest={(): void => {
+        // Execute GA tracking
+        exportToTerraTracking(entityList);
+        // Request manifest
+        run();
+      }}
     />
   );
 };

--- a/src/components/Export/components/ManifestDownload/manifestDownload.tsx
+++ b/src/components/Export/components/ManifestDownload/manifestDownload.tsx
@@ -1,12 +1,14 @@
 import React, { ElementType } from "react";
 import { MANIFEST_DOWNLOAD_FORMAT } from "../../../../apis/azul/common/entities";
 import { Filters } from "../../../../common/entities";
+import { useExploreState } from "../../../../hooks/useExploreState";
 import { FileManifestType } from "../../../../hooks/useFileManifest/common/entities";
 import { useFileManifest } from "../../../../hooks/useFileManifest/useFileManifest";
 import { useRequestFileManifest } from "../../../../hooks/useFileManifest/useRequestFileManifest";
 import { FileLocation } from "../../../../hooks/useRequestFileLocation";
 import { FileManifestState } from "../../../../providers/fileManifestState";
 import { FormFacet } from "../../common/entities";
+import { fileManifestTracking } from "../../common/tracking";
 import { ManifestDownloadNotStarted } from "./components/ManifestDownloadNotStarted/manifestDownloadNotStarted";
 import { ManifestDownloadReady } from "./components/ManifestDownloadReady/manifestDownloadReady";
 
@@ -35,6 +37,9 @@ export const ManifestDownload = ({
     filters,
     fileSummaryFacetName
   );
+  const {
+    exploreState: { tabValue: entityList },
+  } = useExploreState();
   const { data, isLoading, run } = useFileManifest();
   const manifestURL = getManifestDownloadURL(data);
   return manifestURL ? (
@@ -49,7 +54,10 @@ export const ManifestDownload = ({
       fileManifestState={fileManifestState}
       formFacet={formFacet}
       isLoading={isLoading}
-      onRequestManifest={run}
+      onRequestManifest={(): void => {
+        fileManifestTracking(entityList);
+        run();
+      }}
     />
   );
 };


### PR DESCRIPTION
- Added event models as follows:
- Add the following event models
  - `index_analyze_in_terra_requested`
    - `entity_name`
  - `index_file_manifest_requested`
    - `entity_name`
 - Alter the existing `bulk_download_requested` model as follows
   -  Remove params for `catalog` and `current_query`
   -  Rename `index` to `entity_name`
 - Called events on clicking the request button
 - Documented changes in `readme-analytics.md` 