### PR TITLE
feat: create data dictionary tooltip component (#317)

### DIFF
--- a/src/components/DataDictionary/components/Tooltip/components/Title/constants.ts
+++ b/src/components/DataDictionary/components/Tooltip/components/Title/constants.ts
@@ -1,0 +1,11 @@
+import { StackProps, TypographyProps } from "@mui/material";
+
+export const STACK_PROPS: StackProps = {
+  spacing: 2,
+  useFlexGap: true,
+};
+
+export const TYPOGRAPHY_PROPS: TypographyProps = {
+  color: "ink.light",
+  component: "div",
+};

--- a/src/components/DataDictionary/components/Tooltip/components/Title/title.tsx
+++ b/src/components/DataDictionary/components/Tooltip/components/Title/title.tsx
@@ -1,0 +1,19 @@
+import { Stack, Typography } from "@mui/material";
+import React from "react";
+import { TEXT_BODY_LARGE_500 } from "../../../../../../theme/common/typography";
+import { BaseComponentProps } from "../../../../../types";
+import { STACK_PROPS, TYPOGRAPHY_PROPS } from "./constants";
+import { TitleProps } from "./types";
+
+export const Title = ({
+  className,
+  description,
+  title,
+}: BaseComponentProps & Required<TitleProps>): JSX.Element => {
+  return (
+    <Stack {...STACK_PROPS} className={className}>
+      <Typography variant={TEXT_BODY_LARGE_500}>{title}</Typography>
+      <Typography {...TYPOGRAPHY_PROPS}>{description}</Typography>
+    </Stack>
+  );
+};

--- a/src/components/DataDictionary/components/Tooltip/components/Title/types.ts
+++ b/src/components/DataDictionary/components/Tooltip/components/Title/types.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from "react";
+
+export interface TitleProps {
+  description?: ReactNode;
+  title: ReactNode;
+}

--- a/src/components/DataDictionary/components/Tooltip/constants.ts
+++ b/src/components/DataDictionary/components/Tooltip/constants.ts
@@ -1,0 +1,26 @@
+import { TooltipProps } from "@mui/material";
+import { TEXT_BODY_SMALL_400_2_LINES } from "../../../../theme/common/typography";
+
+export const TOOLTIP_PROPS: Omit<TooltipProps, "children" | "title"> = {
+  arrow: true,
+  disableInteractive: true,
+  enterNextDelay: 250,
+  slotProps: {
+    arrow: { sx: (theme) => ({ color: theme.palette.common.white }) },
+    popper: {
+      modifiers: [
+        { name: "offset", options: { offset: [0, 2] } },
+        { name: "preventOverflow", options: { padding: 8 } },
+      ],
+    },
+    tooltip: {
+      sx: (theme) => ({
+        ...theme.typography[TEXT_BODY_SMALL_400_2_LINES],
+        backgroundColor: theme.palette.common.white,
+        borderRadius: 2,
+        color: theme.palette.ink.main,
+        padding: 4,
+      }),
+    },
+  },
+};

--- a/src/components/DataDictionary/components/Tooltip/tooltip.tsx
+++ b/src/components/DataDictionary/components/Tooltip/tooltip.tsx
@@ -1,0 +1,25 @@
+import { Tooltip as MTooltip, TooltipProps } from "@mui/material";
+import React from "react";
+import { BaseComponentProps } from "../../../types";
+import { Title } from "./components/Title/title";
+import { TitleProps } from "./components/Title/types";
+import { TOOLTIP_PROPS } from "./constants";
+
+export const Tooltip = ({
+  children,
+  className,
+  description,
+  title,
+  ...props
+}: BaseComponentProps & TitleProps & TooltipProps): JSX.Element => {
+  return (
+    <MTooltip
+      {...TOOLTIP_PROPS}
+      className={className}
+      title={description && <Title description={description} title={title} />}
+      {...props}
+    >
+      <span>{children}</span>
+    </MTooltip>
+  );
+};

--- a/src/components/DataDictionary/components/Tooltip/tooltip.tsx
+++ b/src/components/DataDictionary/components/Tooltip/tooltip.tsx
@@ -1,9 +1,10 @@
-import { Tooltip as MTooltip, TooltipProps } from "@mui/material";
+import { Tooltip as MTooltip } from "@mui/material";
 import React from "react";
 import { BaseComponentProps } from "../../../types";
 import { Title } from "./components/Title/title";
 import { TitleProps } from "./components/Title/types";
 import { TOOLTIP_PROPS } from "./constants";
+import { TooltipProps } from "./types";
 
 export const Tooltip = ({
   children,

--- a/src/components/DataDictionary/components/Tooltip/types.ts
+++ b/src/components/DataDictionary/components/Tooltip/types.ts
@@ -1,0 +1,10 @@
+import { TooltipProps as MTooltipProps } from "@mui/material";
+import { ReactNode } from "react";
+
+// `children` is defined as a `ReactNode` instead of an `Element`
+// because the Data Dictionary `Tooltip` component wraps its child in a `span` element.
+// This ensures that `children` can hold a ref properly (see https://mui.com/material-ui/api/tooltip/#props).
+
+export type TooltipProps = Omit<MTooltipProps, "children"> & {
+  children: ReactNode;
+};


### PR DESCRIPTION
Closes #317.

### Definition of Done

- Added MUI-based tooltip that takes two props: title and description.
- Component matches [mock](https://www.figma.com/design/JOUDXkKfgivRNFdBsWDPEH/AnVIL?node-id=8090-8475&t=ZpL4Obac6SeJyfCT-0).

### Example Usage:

```
<Tooltip description={description} title={title}><Button>Project Title</Button></Tooltip>
```

![image](https://github.com/user-attachments/assets/d246f122-3791-466d-a29c-313162e970cf)

![image](https://github.com/user-attachments/assets/7cf04079-53a3-4833-ba13-0061cfcf972b)
