### PR TITLE
feat: use anchor tags for all header and footer links (#297)

### DIFF
--- a/src/components/Layout/components/Header/components/Content/components/Navigation/components/NavigationMenu/navigationMenu.tsx
+++ b/src/components/Layout/components/Header/components/Content/components/Navigation/components/NavigationMenu/navigationMenu.tsx
@@ -78,7 +78,7 @@ export const NavigationMenu = ({
           >
             <MPaper variant="menu">
               <MClickAwayListener onClickAway={onClose}>
-                <MMenuList>
+                <MMenuList component="div">
                   <NavigationMenuItems
                     closeMenu={(): void => {
                       onClose();

--- a/src/components/Layout/components/Header/components/Content/components/Navigation/components/NavigationMenuItems/navigationMenuItems.tsx
+++ b/src/components/Layout/components/Header/components/Content/components/Navigation/components/NavigationMenuItems/navigationMenuItems.tsx
@@ -2,9 +2,10 @@ import {
   Divider,
   ListItemIcon,
   ListItemText,
+  Link as MLink,
   MenuItem as MMenuItem,
 } from "@mui/material";
-import { useRouter } from "next/router";
+import Link from "next/link";
 import React, { Fragment, ReactNode } from "react";
 import {
   TEXT_BODY_400,
@@ -38,7 +39,6 @@ export const NavigationMenuItems = ({
   menuItems,
   pathname,
 }: NavLinkMenuProps): JSX.Element => {
-  const router = useRouter();
   return (
     <>
       {menuItems.map(
@@ -54,8 +54,9 @@ export const NavigationMenuItems = ({
             url,
           },
           i
-        ) =>
-          nestedMenuItems ? (
+        ) => {
+          const isClientSide = isClientSideNavigation(url);
+          return nestedMenuItems ? (
             <NavigationMenu
               key={i}
               closeAncestor={closeMenu}
@@ -69,18 +70,17 @@ export const NavigationMenuItems = ({
           ) : (
             <Fragment key={i}>
               <MMenuItem
+                component={isClientSide ? Link : MLink}
                 disabled={!url}
-                onClick={(): void => {
-                  closeMenu();
-                  isClientSideNavigation(url)
-                    ? router.push(url)
-                    : window.open(
-                        url,
-                        target,
-                        REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-                      );
-                }}
+                href={url}
+                onClick={(): void => closeMenu()}
+                rel={
+                  isClientSide
+                    ? REL_ATTRIBUTE.NO_OPENER
+                    : REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                }
                 selected={isNavigationLinkSelected(pathname, selectedPatterns)}
+                target={target}
               >
                 {icon && <ListItemIcon>{icon}</ListItemIcon>}
                 <ListItemText
@@ -100,7 +100,8 @@ export const NavigationMenuItems = ({
               </MMenuItem>
               {divider && <Divider />}
             </Fragment>
-          )
+          );
+        }
       )}
     </>
   );

--- a/src/components/Layout/components/Header/components/Content/components/Navigation/constants.ts
+++ b/src/components/Layout/components/Header/components/Content/components/Navigation/constants.ts
@@ -1,0 +1,1 @@
+export const NAVIGATION_TEST_ID = "navigation";

--- a/src/components/Layout/components/Header/components/Content/components/Navigation/navigation.tsx
+++ b/src/components/Layout/components/Header/components/Content/components/Navigation/navigation.tsx
@@ -1,5 +1,5 @@
-import { Button, Divider } from "@mui/material";
-import { useRouter } from "next/router";
+import { Button, Divider, Link as MLink } from "@mui/material";
+import Link from "next/link";
 import React, { CSSProperties, forwardRef, Fragment, ReactNode } from "react";
 import { BreakpointKey } from "../../../../../../../../hooks/useBreakpointHelper";
 import {
@@ -51,7 +51,6 @@ export const Navigation = forwardRef<HTMLDivElement, NavigationProps>(
     }: NavigationProps,
     ref
   ): JSX.Element {
-    const router = useRouter();
     return (
       <Links ref={ref} className={className} isMenuIn={isMenuIn} style={style}>
         {links.map(
@@ -65,8 +64,9 @@ export const Navigation = forwardRef<HTMLDivElement, NavigationProps>(
               url,
             },
             i
-          ) =>
-            menuItems ? (
+          ) => {
+            const isClientSide = isClientSideNavigation(url);
+            return menuItems ? (
               <Fragment key={i}>
                 {isMenuIn ? (
                   <NavigationDrawer
@@ -98,17 +98,16 @@ export const Navigation = forwardRef<HTMLDivElement, NavigationProps>(
             ) : (
               <Fragment key={i}>
                 <Button
+                  component={isClientSide ? Link : MLink}
                   disabled={!url}
-                  onClick={(): void => {
-                    closeAncestor?.();
-                    isClientSideNavigation(url)
-                      ? router.push(url)
-                      : window.open(
-                          url,
-                          target,
-                          REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-                        );
-                  }}
+                  href={url}
+                  onClick={(): void => closeAncestor?.()}
+                  rel={
+                    isClientSide
+                      ? REL_ATTRIBUTE.NO_OPENER
+                      : REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                  }
+                  target={target}
                   variant={
                     isNavigationLinkSelected(pathname, selectedPatterns)
                       ? "activeNav"
@@ -119,7 +118,8 @@ export const Navigation = forwardRef<HTMLDivElement, NavigationProps>(
                 </Button>
                 {divider && <Divider />}
               </Fragment>
-            )
+            );
+          }
         )}
       </Links>
     );

--- a/src/components/Layout/components/Header/components/Content/components/Navigation/navigation.tsx
+++ b/src/components/Layout/components/Header/components/Content/components/Navigation/navigation.tsx
@@ -7,6 +7,7 @@ import {
   REL_ATTRIBUTE,
 } from "../../../../../../../Links/common/entities";
 import { isClientSideNavigation } from "../../../../../../../Links/common/utils";
+import { TestIdProps } from "../../../../../../../types";
 import { SelectedMatch } from "../../../../common/entities";
 import { HeaderProps } from "../../../../header";
 import { isNavigationLinkSelected } from "./common/utils";
@@ -28,7 +29,7 @@ export interface NavLinkItem {
   visible?: Partial<Record<BreakpointKey, boolean>>;
 }
 
-export interface NavigationProps {
+export interface NavigationProps extends TestIdProps {
   className?: string;
   closeAncestor?: () => void;
   headerProps?: HeaderProps;
@@ -48,11 +49,18 @@ export const Navigation = forwardRef<HTMLDivElement, NavigationProps>(
       links,
       pathname,
       style,
+      testId,
     }: NavigationProps,
     ref
   ): JSX.Element {
     return (
-      <Links ref={ref} className={className} isMenuIn={isMenuIn} style={style}>
+      <Links
+        ref={ref}
+        className={className}
+        data-testid={testId}
+        isMenuIn={isMenuIn}
+        style={style}
+      >
         {links.map(
           (
             {

--- a/src/components/Layout/components/Header/header.tsx
+++ b/src/components/Layout/components/Header/header.tsx
@@ -21,6 +21,7 @@ import {
   renderIconButton as renderSearchIconButton,
   Search,
 } from "./components/Content/components/Actions/components/Search/search";
+import { NAVIGATION_TEST_ID } from "./components/Content/components/Navigation/constants";
 import { Navigation as DXNavigation } from "./components/Content/components/Navigation/navigation";
 import { Slogan } from "./components/Content/components/Slogan/slogan";
 import { Divider } from "./components/Content/components/Slogan/slogan.styles";
@@ -92,7 +93,11 @@ export const Header = ({ ...headerProps }: HeaderProps): JSX.Element => {
           <Center>
             {/* Center navigation */}
             {isIn.isCenterNavigationIn && (
-              <DXNavigation {...navigationProps} links={navItemsC} />
+              <DXNavigation
+                {...navigationProps}
+                testId={NAVIGATION_TEST_ID}
+                links={navItemsC}
+              />
             )}
           </Center>
         </Fade>


### PR DESCRIPTION
Closes #297.

- Header navigation links (main navigation, menu navigation, and drawer navigation) all use anchor tags instead of buttons.
- The anchor tags include the relevant `rel` attribute for internal / external urls.
- The anchor tags include the `target` attribute, if configured, otherwise remain as `_self`.
- External links use `MuiLink` and internal links use Next's `Link` component.

### Test

- A test for the `Navigation` is advisable, however the component itself will need refactoring to handle recursion all in one file rather than having a parent ↔ child import cycle.

<img width="2487" alt="image" src="https://github.com/user-attachments/assets/b3f8e887-594d-418c-aa0d-7d8620ed88af" />
