### PR TITLE
feat: create a new provider that returns header and footer dimensions (#344)

### DIFF
--- a/src/providers/layoutDimensions/constants.ts
+++ b/src/providers/layoutDimensions/constants.ts
@@ -1,0 +1,6 @@
+import { LayoutDimensions } from "./types";
+
+export const DEFAULT_LAYOUT_DIMENSIONS: LayoutDimensions = {
+  footer: { height: 0 },
+  header: { height: 0 },
+};

--- a/src/providers/layoutDimensions/context.tsx
+++ b/src/providers/layoutDimensions/context.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import { DEFAULT_LAYOUT_DIMENSIONS } from "./constants";
+import { LayoutDimensionsContextProps } from "./types";
+
+export const LayoutDimensionsContext =
+  createContext<LayoutDimensionsContextProps>({
+    dimensions: DEFAULT_LAYOUT_DIMENSIONS,
+  });

--- a/src/providers/layoutDimensions/hook.ts
+++ b/src/providers/layoutDimensions/hook.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { LayoutDimensionsContext } from "./context";
+import { LayoutDimensionsContextProps } from "./types";
+
+export const useLayoutDimensions = (): LayoutDimensionsContextProps => {
+  return useContext<LayoutDimensionsContextProps>(LayoutDimensionsContext);
+};

--- a/src/providers/layoutDimensions/provider.tsx
+++ b/src/providers/layoutDimensions/provider.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useRef } from "react";
+import { SELECTOR } from "../../common/selectors";
+import {
+  getBorderBoxSizeHeight,
+  useResizeObserver,
+} from "../../hooks/useResizeObserver";
+import { LayoutDimensionsContext } from "./context";
+import { LayoutDimensions, LayoutDimensionsProviderProps } from "./types";
+
+export const LayoutDimensionsProvider = ({
+  children,
+}: LayoutDimensionsProviderProps): JSX.Element => {
+  const footerRef = useRef<HTMLElement | null>(null);
+  const headerRef = useRef<HTMLElement | null>(null);
+  const footerRect = useResizeObserver(footerRef, getBorderBoxSizeHeight);
+  const headerRect = useResizeObserver(headerRef, getBorderBoxSizeHeight);
+
+  useEffect(() => {
+    footerRef.current = document.getElementById(SELECTOR.FOOTER);
+    headerRef.current = document.getElementById(SELECTOR.HEADER);
+  }, []);
+
+  const dimensions: LayoutDimensions = {
+    footer: { height: footerRect?.height ?? 0 },
+    header: { height: headerRect?.height ?? 0 },
+  };
+
+  return (
+    <LayoutDimensionsContext.Provider value={{ dimensions }}>
+      {children}
+    </LayoutDimensionsContext.Provider>
+  );
+};

--- a/src/providers/layoutDimensions/types.ts
+++ b/src/providers/layoutDimensions/types.ts
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+import { ElementRect } from "../../hooks/useResizeObserver";
+
+export interface LayoutDimensions {
+  footer: Pick<ElementRect, "height">;
+  header: Pick<ElementRect, "height">;
+}
+
+export interface LayoutDimensionsContextProps {
+  dimensions: LayoutDimensions;
+}
+
+export interface LayoutDimensionsProviderProps {
+  children: ReactNode | ReactNode[];
+}


### PR DESCRIPTION
Closes #344.