### PR TITLE
refactor!: refactor outline component with new hook handling state and disabled outline item (#346)

### DIFF
--- a/src/components/Layout/components/Outline/common/constants.ts
+++ b/src/components/Layout/components/Outline/common/constants.ts
@@ -1,3 +1,0 @@
-import { TabProps as MTabProps } from "@mui/material";
-
-export const DEFAULT_TAB_VALUE: MTabProps["value"] = "";

--- a/src/components/Layout/components/Outline/components/ContentsTab/contentsTab.styles.ts
+++ b/src/components/Layout/components/Outline/components/ContentsTab/contentsTab.styles.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
-import { Tab as MTab } from "@mui/material";
+import { Tab } from "@mui/material";
 import { inkLight } from "../../../../../../styles/common/mixins/colors";
 import { textUppercase500 } from "../../../../../../styles/common/mixins/fonts";
 import { tab } from "../../outline.styles";
 
-export const Tab = styled(MTab)`
+export const StyledTab = styled(Tab)`
   ${tab};
 
   && {

--- a/src/components/Layout/components/Outline/components/ContentsTab/contentsTab.tsx
+++ b/src/components/Layout/components/Outline/components/ContentsTab/contentsTab.tsx
@@ -1,24 +1,21 @@
-import { TabProps as MTabProps } from "@mui/material";
 import React from "react";
+import { FONT_SIZE } from "../../../../../../styles/common/mui/icon";
+import { TAB_PROPS } from "../../../../../../styles/common/mui/tab";
 import { Segment } from "../../../../../common/CustomIcon/components/Segment/segment";
-import { Tab } from "./contentsTab.styles";
-
-export interface ContentsTabProps extends Omit<MTabProps, "value"> {
-  className?: string;
-  value: string;
-}
+import { StyledTab } from "./contentsTab.styles";
+import { ContentsTabProps } from "./types";
 
 export const ContentsTab = ({
   className,
   value,
-  ...props /* Spread props to allow for Mui Tab specific prop overrides. */
+  ...props /* MuiTabProps. */
 }: ContentsTabProps): JSX.Element => {
   return (
-    <Tab
+    <StyledTab
       className={className}
       label="Contents"
-      icon={<Segment fontSize="small" />}
-      iconPosition="start"
+      icon={<Segment fontSize={FONT_SIZE.SMALL} />}
+      iconPosition={TAB_PROPS.ICON_POSITION.START}
       value={value}
       {...props}
     />

--- a/src/components/Layout/components/Outline/components/ContentsTab/types.ts
+++ b/src/components/Layout/components/Outline/components/ContentsTab/types.ts
@@ -1,0 +1,8 @@
+import { TabProps } from "@mui/material";
+import { BaseComponentProps } from "../../../../../types";
+
+export interface ContentsTabProps
+  extends BaseComponentProps,
+    Omit<TabProps, "value"> {
+  value: string;
+}

--- a/src/components/Layout/components/Outline/hooks/UseHash/hook.ts
+++ b/src/components/Layout/components/Outline/hooks/UseHash/hook.ts
@@ -1,0 +1,17 @@
+import { isSSR } from "../../../../../../utils/ssr";
+import { UseHash } from "./types";
+
+/**
+ * Hook to get the current URL hash without the leading '#' character.
+ *
+ * @description
+ * Extracts the hash from window.location.hash and removes the leading '#'.
+ * Returns empty string when running in SSR environment.
+ *
+ * @returns Object containing the hash without leading '#', or empty string if SSR.
+ */
+export function useHash(): UseHash {
+  if (isSSR()) return { hash: "" };
+  const { hash } = window.location;
+  return { hash: hash.replace(/^#/, "") };
+}

--- a/src/components/Layout/components/Outline/hooks/UseHash/types.ts
+++ b/src/components/Layout/components/Outline/hooks/UseHash/types.ts
@@ -1,0 +1,3 @@
+export interface UseHash {
+  hash: string;
+}

--- a/src/components/Layout/components/Outline/hooks/UseTabs/constants.ts
+++ b/src/components/Layout/components/Outline/hooks/UseTabs/constants.ts
@@ -1,0 +1,3 @@
+import { TabProps } from "@mui/material";
+
+export const DEFAULT_TAB_VALUE: TabProps["value"] = "";

--- a/src/components/Layout/components/Outline/hooks/UseTabs/hook.ts
+++ b/src/components/Layout/components/Outline/hooks/UseTabs/hook.ts
@@ -1,0 +1,32 @@
+import { TabsProps } from "@mui/material";
+import Router from "next/router";
+import { SyntheticEvent, useCallback, useEffect, useState } from "react";
+import { TABS_PROPS } from "../../../../../../styles/common/mui/tabs";
+import { OutlineItem } from "../../types";
+import { useHash } from "../UseHash/hook";
+import { DEFAULT_TAB_VALUE } from "./constants";
+import { getNextValue } from "./utils";
+
+export function useTabs(
+  outline: OutlineItem[]
+): Pick<TabsProps, "indicatorColor" | "onChange" | "orientation" | "value"> {
+  const [value, setValue] = useState<TabsProps["value"]>(DEFAULT_TAB_VALUE);
+  const { hash } = useHash();
+
+  const onChange = useCallback((_event: SyntheticEvent, hash: string): void => {
+    Router.push({ hash });
+  }, []);
+
+  useEffect(() => {
+    setValue(getNextValue(hash, outline));
+  }, [hash, outline]);
+
+  return {
+    indicatorColor: value
+      ? TABS_PROPS.INDICATOR_COLOR.PRIMARY
+      : TABS_PROPS.INDICATOR_COLOR.TRANSPARENT,
+    onChange,
+    orientation: TABS_PROPS.ORIENTATION.VERTICAL,
+    value,
+  };
+}

--- a/src/components/Layout/components/Outline/hooks/UseTabs/utils.ts
+++ b/src/components/Layout/components/Outline/hooks/UseTabs/utils.ts
@@ -1,0 +1,18 @@
+import { TabsProps } from "@mui/material";
+import { OutlineItem } from "../../types";
+import { DEFAULT_TAB_VALUE } from "./constants";
+
+/**
+ * Returns the tab value for navigation.
+ * @param hash - The current hash from the URL.
+ * @param outlineItems - Outline items.
+ * @returns The item's hash if found and enabled, otherwise returns the default tab value.
+ */
+export function getNextValue(
+  hash: string,
+  outlineItems: OutlineItem[]
+): TabsProps["value"] {
+  const item = outlineItems.find((item) => item.hash === hash);
+  if (!item || item.disabled) return DEFAULT_TAB_VALUE;
+  return item.hash;
+}

--- a/src/components/Layout/components/Outline/outline.styles.ts
+++ b/src/components/Layout/components/Outline/outline.styles.ts
@@ -24,7 +24,7 @@ export const tab = css`
   }
 `;
 
-export const Tabs = styled(MTabs)`
+export const StyledTabs = styled(MTabs)`
   align-self: flex-start;
   box-shadow: inset 1px 0 ${smokeMain};
   margin: 0;
@@ -46,7 +46,7 @@ export const Tabs = styled(MTabs)`
   }
 `;
 
-export const Tab = styled(MTab, {
+export const StyledTab = styled(MTab, {
   shouldForwardProp: (prop) => prop !== "depth",
 })<Props>`
   ${tab};

--- a/src/components/Layout/components/Outline/outline.tsx
+++ b/src/components/Layout/components/Outline/outline.tsx
@@ -1,72 +1,35 @@
-import { useRouter } from "next/router";
-import React, { ElementType, SyntheticEvent, useEffect, useState } from "react";
-import { DEFAULT_TAB_VALUE } from "./common/constants";
-import { ContentsTabProps } from "./components/ContentsTab/contentsTab";
-import { Tab, Tabs } from "./outline.styles";
-
-export interface OutlineItem {
-  depth: number;
-  hash: string;
-  value: string;
-}
-
-export interface OutlineProps {
-  className?: string;
-  Contents: ElementType<ContentsTabProps>;
-  outline: OutlineItem[];
-}
+import React from "react";
+import { DEFAULT_TAB_VALUE } from "./hooks/UseTabs/constants";
+import { useTabs } from "./hooks/UseTabs/hook";
+import { StyledTab, StyledTabs } from "./outline.styles";
+import { OutlineProps } from "./types";
 
 export const Outline = ({
   className,
   Contents,
   outline,
-  ...props /* Spread props to allow for Mui Tabs specific prop overrides. */
-}: OutlineProps): JSX.Element => {
-  const { asPath, push } = useRouter();
-  const [activeTab, setActiveTab] = useState<string>("");
-
-  // Callback fired when selected tab value changes.
-  const handleChange = (
-    _event: SyntheticEvent<Element, Event>,
-    tabValue: string
-  ): void => {
-    push(`#${tabValue}`);
-  };
-
-  // Update active tab when path changes.
-  useEffect(() => {
-    setActiveTab(getActiveTab(outline, asPath));
-  }, [asPath, outline]);
-
+  ...props /* MuiTabsProps */
+}: OutlineProps): JSX.Element | null => {
+  const { indicatorColor, onChange, orientation, value } = useTabs(outline);
   return (
-    <Tabs
+    <StyledTabs
       className={className}
-      indicatorColor={activeTab ? "primary" : "transparent"}
-      onChange={handleChange}
-      orientation="vertical"
-      value={activeTab}
+      indicatorColor={indicatorColor}
+      onChange={onChange}
+      orientation={orientation}
+      value={value}
       {...props}
     >
       <Contents value={DEFAULT_TAB_VALUE} />
-      {outline.map(({ depth, hash, value }) => (
-        <Tab key={hash} depth={depth} label={value} value={hash} />
+      {outline.map(({ depth, disabled, hash, value }) => (
+        <StyledTab
+          depth={depth}
+          disabled={disabled}
+          key={hash}
+          label={value}
+          value={hash}
+        />
       ))}
-    </Tabs>
+    </StyledTabs>
   );
 };
-
-/**
- * Initializes active tab.
- * @param outline - Outline items.
- * @param asPath - Current path.
- * @returns active tab.
- */
-function getActiveTab(outline: OutlineItem[], asPath: string): string {
-  if (asPath.includes("#")) {
-    const hashLink = asPath.split("#")[1];
-    if (outline.some(({ hash }) => hash === hashLink)) {
-      return hashLink;
-    }
-  }
-  return DEFAULT_TAB_VALUE;
-}

--- a/src/components/Layout/components/Outline/types.ts
+++ b/src/components/Layout/components/Outline/types.ts
@@ -1,0 +1,16 @@
+import { TabsProps } from "@mui/material";
+import { ElementType } from "react";
+import { BaseComponentProps } from "../../../types";
+import { ContentsTabProps } from "./components/ContentsTab/types";
+
+export interface OutlineItem {
+  depth: number;
+  disabled?: boolean;
+  hash: string;
+  value: string;
+}
+
+export interface OutlineProps extends BaseComponentProps, TabsProps {
+  Contents: ElementType<ContentsTabProps>;
+  outline: OutlineItem[];
+}

--- a/src/styles/common/mui/tab.ts
+++ b/src/styles/common/mui/tab.ts
@@ -1,0 +1,16 @@
+import { TabProps } from "@mui/material";
+
+type TabPropsOptions = {
+  ICON_POSITION: typeof ICON_POSITION;
+};
+
+const ICON_POSITION: Record<string, TabProps["iconPosition"]> = {
+  BOTTOM: "bottom",
+  END: "end",
+  START: "start",
+  TOP: "top",
+};
+
+export const TAB_PROPS: TabPropsOptions = {
+  ICON_POSITION,
+};

--- a/src/styles/common/mui/tabs.ts
+++ b/src/styles/common/mui/tabs.ts
@@ -1,0 +1,20 @@
+import { TabsProps } from "@mui/material";
+
+type TabsPropsOptions = {
+  INDICATOR_COLOR: typeof INDICATOR_COLOR;
+  ORIENTATION: typeof ORIENTATION;
+};
+
+const INDICATOR_COLOR: Record<string, TabsProps["indicatorColor"]> = {
+  PRIMARY: "primary",
+  TRANSPARENT: "transparent",
+};
+
+const ORIENTATION: Record<string, TabsProps["orientation"]> = {
+  VERTICAL: "vertical",
+};
+
+export const TABS_PROPS: TabsPropsOptions = {
+  INDICATOR_COLOR,
+  ORIENTATION,
+};


### PR DESCRIPTION
Closes #346.

#### Updates to the Outline Component

##### Breaking Change

- The `OutlineProps` have been moved to ./types and now extend Mui's `TabsProps`.
- A new hook, `useTabs`, has been introduced to manage Tabs state—built on existing component logic. Additionally, when the path changes, the update logic now checks if the selected entity is disabled; if so, it falls back to the default Tabs value.