### PR TITLE
feat: create step label component (#360)

### DIFF
--- a/src/components/Stepper/components/Step/components/StepIcon/stepIcon.stories.tsx
+++ b/src/components/Stepper/components/Step/components/StepIcon/stepIcon.stories.tsx
@@ -11,9 +11,6 @@ const meta: Meta<typeof StepIcon> = {
       </div>
     ),
   ],
-  parameters: {
-    layout: "centered",
-  },
   title: "Components/Stepper/StepIcon",
 };
 

--- a/src/components/Stepper/components/Step/components/StepIcon/stories/stepIcon.stories.tsx
+++ b/src/components/Stepper/components/Step/components/StepIcon/stories/stepIcon.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { Fragment } from "react";
-import { StepIcon } from "./stepIcon";
+import { StepIcon } from "../stepIcon";
 
 const meta: Meta<typeof StepIcon> = {
   component: StepIcon,

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/constants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/constants.ts
@@ -1,0 +1,14 @@
+import { Info } from "@mui/icons-material";
+import { SvgIconProps, TooltipProps } from "@mui/material";
+import { SVG_ICON_PROPS as MUI_SVG_ICON_PROPS } from "../../../../../../../../../../styles/common/mui/svgIcon";
+
+export const SVG_ICON_PROPS: SvgIconProps = {
+  color: MUI_SVG_ICON_PROPS.COLOR.INK_LIGHT,
+  component: Info,
+  fontSize: MUI_SVG_ICON_PROPS.FONT_SIZE.XSMALL,
+};
+
+export const TOOLTIP_PROPS: Omit<TooltipProps, "children" | "title"> = {
+  disableInteractive: true,
+  slotProps: { tooltip: { sx: { maxWidth: 196, textAlign: "center" } } },
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/icon.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/icon.tsx
@@ -1,0 +1,13 @@
+import { SvgIcon, Tooltip } from "@mui/material";
+import React from "react";
+import { SVG_ICON_PROPS, TOOLTIP_PROPS } from "./constants";
+import { IconProps } from "./types";
+
+export const Icon = ({ slotProps }: IconProps): JSX.Element | null => {
+  if (!slotProps?.tooltip?.title) return null;
+  return (
+    <Tooltip {...TOOLTIP_PROPS} {...slotProps?.tooltip}>
+      <SvgIcon {...SVG_ICON_PROPS} {...slotProps?.svgIcon} />
+    </Tooltip>
+  );
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/stories/contants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/stories/contants.ts
@@ -1,0 +1,6 @@
+import { ComponentProps } from "react";
+import { Icon } from "../icon";
+
+export const DISABLED_CONTROLS: (keyof ComponentProps<typeof Icon>)[] = [
+  "slotProps",
+];

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/stories/icon.stories.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/stories/icon.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps } from "react";
+import { getDisabledControls } from "../../../../../../../../../../../storybook/controls/utils";
+import { LOREM_IPSUM } from "../../../../../../../../../../../storybook/loremIpsum";
+import { Icon } from "../icon";
+import { DISABLED_CONTROLS } from "./contants";
+
+const meta: Meta<typeof Icon> = {
+  argTypes: getDisabledControls<ComponentProps<typeof Icon>>(DISABLED_CONTROLS),
+  component: Icon,
+  title: "Components/Stepper/StepLabel/Icon",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    slotProps: {
+      tooltip: {
+        title: LOREM_IPSUM.SHORT,
+      },
+    },
+  },
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/types.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/components/Icon/types.ts
@@ -1,0 +1,8 @@
+import { SvgIconProps, TooltipProps } from "@mui/material";
+
+export interface IconProps {
+  slotProps?: {
+    svgIcon?: SvgIconProps;
+    tooltip?: Omit<TooltipProps, "children">;
+  };
+}

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/constants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/constants.ts
@@ -1,0 +1,8 @@
+import { TypographyProps } from "@mui/material";
+import { TYPOGRAPHY_PROPS as MUI_TYPOGRAPHY_PROPS } from "../../../../../../../../styles/common/mui/typography";
+
+export const TYPOGRAPHY_PROPS: TypographyProps = {
+  color: MUI_TYPOGRAPHY_PROPS.COLOR.INK_MAIN,
+  component: "div",
+  variant: MUI_TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL,
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/label.styles.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/label.styles.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { Typography } from "@mui/material";
+
+export const StyledTypography = styled(Typography)`
+  align-items: center;
+  display: flex;
+  gap: 4px;
+`;

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/label.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/label.tsx
@@ -1,0 +1,10 @@
+import { TypographyProps } from "@mui/material";
+import React from "react";
+import { TYPOGRAPHY_PROPS } from "./constants";
+import { StyledTypography } from "./label.styles";
+
+export const Label = ({
+  ...props /* MuiTypographyProps */
+}: TypographyProps): JSX.Element => {
+  return <StyledTypography {...TYPOGRAPHY_PROPS} {...props} />;
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Label/stories/label.stories.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Label/stories/label.stories.tsx
@@ -1,0 +1,31 @@
+import { composeStories, type Meta, type StoryObj } from "@storybook/react";
+import React from "react";
+import * as stories from "../components/Icon/stories/icon.stories";
+import { Label } from "../label";
+
+const { Default: Icon } = composeStories(stories);
+
+const meta: Meta<typeof Label> = {
+  component: Label,
+  parameters: { controls: { disable: true } },
+  title: "Components/Stepper/StepLabel/Label",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: "Annotation Files" },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        Annotation Files
+        <Icon />
+      </>
+    ),
+  },
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Optional/constants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Optional/constants.ts
@@ -1,0 +1,7 @@
+import { TypographyProps } from "@mui/material";
+import { TYPOGRAPHY_PROPS as MUI_TYPOGRAPHY_PROPS } from "../../../../../../../../styles/common/mui/typography";
+
+export const TYPOGRAPHY_PROPS: TypographyProps = {
+  color: MUI_TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
+  variant: MUI_TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400,
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/components/Optional/optional.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/components/Optional/optional.tsx
@@ -1,0 +1,9 @@
+import { Typography, TypographyProps } from "@mui/material";
+import React from "react";
+import { TYPOGRAPHY_PROPS } from "./constants";
+
+export const Optional = ({
+  ...props /* MuiTypographyProps */
+}: TypographyProps): JSX.Element => {
+  return <Typography {...TYPOGRAPHY_PROPS} {...props} />;
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/constants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/constants.ts
@@ -1,0 +1,10 @@
+import { StepLabelProps } from "@mui/material";
+import { StepIcon } from "../StepIcon/stepIcon";
+import { Label } from "./components/Label/label";
+
+export const STEP_LABEL_PROPS: StepLabelProps = {
+  slots: {
+    label: Label,
+    stepIcon: StepIcon,
+  },
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/stepLabel.styles.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/stepLabel.styles.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { StepLabel } from "@mui/material";
+
+export const StyledStepLabel = styled(StepLabel)`
+  .MuiStepLabel-iconContainer {
+    padding-right: 16px;
+  }
+
+  .MuiStepLabel-labelContainer {
+    display: grid;
+    gap: 4px;
+  }
+`;

--- a/src/components/Stepper/components/Step/components/StepLabel/stepLabel.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/stepLabel.tsx
@@ -1,0 +1,10 @@
+import { StepLabelProps } from "@mui/material";
+import React from "react";
+import { STEP_LABEL_PROPS } from "./constants";
+import { StyledStepLabel } from "./stepLabel.styles";
+
+export const StepLabel = ({
+  ...props /* MuiStepLabelProps */
+}: StepLabelProps): JSX.Element => {
+  return <StyledStepLabel {...STEP_LABEL_PROPS} {...props} />;
+};

--- a/src/components/Stepper/components/Step/components/StepLabel/stories/contants.ts
+++ b/src/components/Stepper/components/Step/components/StepLabel/stories/contants.ts
@@ -1,0 +1,19 @@
+import { ComponentProps } from "react";
+import { MUI_CONTROLS } from "../../../../../../../storybook/controls/constants";
+import { StepLabel } from "../stepLabel";
+
+export const DISABLED_CONTROLS: (keyof ComponentProps<typeof StepLabel>)[] = [
+  ...MUI_CONTROLS,
+  "children",
+  "error",
+  "icon",
+  "optional",
+  "slotProps",
+  "slots",
+];
+
+export const EXCLUDED_CONTROLS: (keyof ComponentProps<typeof StepLabel>)[] = [
+  "componentsProps", // deprecated
+  "StepIconComponent", // deprecated
+  "StepIconProps", // deprecated
+];

--- a/src/components/Stepper/components/Step/components/StepLabel/stories/stepLabel.stories.tsx
+++ b/src/components/Stepper/components/Step/components/StepLabel/stories/stepLabel.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, StoryObj, composeStories } from "@storybook/react";
+import React, { ComponentProps } from "react";
+import { getDisabledControls } from "storybook/controls/utils";
+import * as stories from "../components/Label/stories/label.stories";
+import { Optional } from "../components/Optional/optional";
+import { StepLabel } from "../stepLabel";
+import { DISABLED_CONTROLS, EXCLUDED_CONTROLS } from "./contants";
+
+const { Default: Label, WithIcon: LabelWithIcon } = composeStories(stories);
+
+const meta: Meta<typeof StepLabel> = {
+  argTypes:
+    getDisabledControls<ComponentProps<typeof StepLabel>>(DISABLED_CONTROLS),
+  component: StepLabel,
+  parameters: { controls: { exclude: EXCLUDED_CONTROLS } },
+  title: "Components/Stepper/StepLabel",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: {
+    children: <LabelWithIcon />,
+    icon: 1,
+    slotProps: { stepIcon: { active: true } },
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    children: <LabelWithIcon />,
+    icon: 1,
+    optional: <Optional>3 files selected</Optional>,
+    slotProps: { stepIcon: { completed: true } },
+  },
+};
+
+export const Default: Story = {
+  args: {
+    children: <Label />,
+    icon: 1,
+  },
+};

--- a/src/storybook/controls/constants.ts
+++ b/src/storybook/controls/constants.ts
@@ -1,0 +1,1 @@
+export const MUI_CONTROLS = ["classes", "className", "ref", "sx"] as const;

--- a/src/storybook/controls/utils.ts
+++ b/src/storybook/controls/utils.ts
@@ -1,0 +1,14 @@
+import { Args, ArgTypes } from "@storybook/react";
+
+/**
+ * Returns an object of ArgTypes with the specified keys disabled.
+ * @param keys - A list of arg keys.
+ * @returns An object of ArgTypes with the specified keys disabled.
+ */
+export function getDisabledControls<TArg = Args>(
+  keys: (keyof TArg)[]
+): Partial<ArgTypes<TArg>> {
+  return Object.fromEntries(
+    keys.map((key) => [key, { control: false }])
+  ) as Partial<ArgTypes<TArg>>;
+}

--- a/src/storybook/loremIpsum.ts
+++ b/src/storybook/loremIpsum.ts
@@ -1,0 +1,4 @@
+export const LOREM_IPSUM = {
+  SHORT:
+    "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.",
+};

--- a/src/styles/common/mui/svgIcon.ts
+++ b/src/styles/common/mui/svgIcon.ts
@@ -1,0 +1,35 @@
+import { SvgIconProps } from "@mui/material";
+
+type SvgIconPropsOptions = {
+  COLOR: typeof COLOR;
+  FONT_SIZE: typeof FONT_SIZE;
+};
+
+const COLOR: Record<string, SvgIconProps["color"]> = {
+  ACTION: "action",
+  DISABLED: "disabled",
+  ERROR: "error",
+  INFO: "info",
+  INHERIT: "inherit",
+  INK_LIGHT: "inkLight",
+  INK_MAIN: "inkMain",
+  PRIMARY: "primary",
+  SECONDARY: "secondary",
+  SUCCESS: "success",
+  WARNING: "warning",
+};
+
+const FONT_SIZE: Record<string, SvgIconProps["fontSize"]> = {
+  INHERIT: "inherit",
+  LARGE: "large",
+  MEDIUM: "medium",
+  SMALL: "small",
+  XSMALL: "xsmall",
+  XXLARGE: "xxlarge",
+  XXSMALL: "xxsmall",
+};
+
+export const SVG_ICON_PROPS: SvgIconPropsOptions = {
+  COLOR,
+  FONT_SIZE,
+};

--- a/tests/stepIcon.test.tsx
+++ b/tests/stepIcon.test.tsx
@@ -2,7 +2,7 @@ import { composeStories } from "@storybook/react";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { STEP_ICON_TEST_ID } from "../src/components/Stepper/components/Step/components/StepIcon/constants";
-import * as stories from "../src/components/Stepper/components/Step/components/StepIcon/stepIcon.stories";
+import * as stories from "../src/components/Stepper/components/Step/components/StepIcon/stories/stepIcon.stories";
 import { MUI_CLASSES } from "../src/tests/mui/constants";
 import { getClassNames, getTagName } from "../src/utils/tests";
 


### PR DESCRIPTION
Closes #360.

StepLabel component displays:
- A step indicator.
- A title, with optional tooltip.
- An optional sub-title (e.g. an ID or some extra info) when the step is completed.

Tests not required on this component.

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/ca7ccd50-6252-43b8-a4ab-5d1764f6c0fa" />

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/991d6a41-dc45-48a6-91c7-04340f85f1aa" />
