### PR TITLE
fix!: fix keyvaluepairs component typography props (#367)

### DIFF
--- a/src/components/Loading/loading.stories.tsx
+++ b/src/components/Loading/loading.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { PAPER_PANEL_STYLE } from "../common/Paper/paper";
 import { Loading } from "./loading";
 
-const meta = {
+const meta: Meta<typeof Loading> = {
   argTypes: {
     appear: { control: "boolean" },
     iconSize: { control: "select", options: ["small", "medium", "large"] },
@@ -30,7 +30,7 @@ const meta = {
     ),
   ],
   title: "Components/Communication/Loading",
-} satisfies Meta<typeof Loading>;
+};
 
 export default meta;
 

--- a/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
+++ b/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
@@ -1,20 +1,19 @@
-import { Typography } from "@mui/material";
-import React, { ReactNode } from "react";
+import { Typography, TypographyProps } from "@mui/material";
+import React from "react";
+import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 
 /**
  * Basic KeyValuePairs "key" wrapper component.
  */
 
-export interface KeyElTypeProps {
-  children: ReactNode;
-}
-
 export const KeyElType = ({
   children,
-  ...props /* Spread props to allow for Mui TypographyProps specific prop overrides e.g. "variant". */
-}: KeyElTypeProps): JSX.Element => {
+  color = TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
+  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
+  ...props /* MuiTypographyProps */
+}: TypographyProps): JSX.Element => {
   return (
-    <Typography color="ink.light" variant="text-body-400-2lines" {...props}>
+    <Typography color={color} variant={variant} {...props}>
       {children}
     </Typography>
   );

--- a/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
+++ b/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
@@ -10,7 +10,7 @@ export const KeyElType = ({
   children,
   color = TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
   component = "div",
-  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
+  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES,
   ...props /* MuiTypographyProps */
 }: TypographyProps): JSX.Element => {
   return (

--- a/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
+++ b/src/components/common/KeyValuePairs/components/KeyElType/keyElType.tsx
@@ -9,11 +9,17 @@ import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 export const KeyElType = ({
   children,
   color = TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
+  component = "div",
   variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
   ...props /* MuiTypographyProps */
 }: TypographyProps): JSX.Element => {
   return (
-    <Typography color={color} variant={variant} {...props}>
+    <Typography
+      color={color}
+      component={component}
+      variant={variant}
+      {...props}
+    >
       {children}
     </Typography>
   );

--- a/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
+++ b/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
@@ -1,20 +1,18 @@
-import { Typography } from "@mui/material";
-import React, { ReactNode } from "react";
+import { Typography, TypographyProps } from "@mui/material";
+import React from "react";
+import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 
 /**
  * Basic KeyValuePairs "value" wrapper component.
  */
 
-export interface ValueElTypeProps {
-  children: ReactNode;
-}
-
 export const ValueElType = ({
   children,
-  ...props /* Spread props to allow for Mui TypographyProps specific prop overrides e.g. "variant". */
-}: ValueElTypeProps): JSX.Element => {
+  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
+  ...props /* MuiTypographyProps */
+}: TypographyProps): JSX.Element => {
   return (
-    <Typography variant="text-body-400-2lines" {...props}>
+    <Typography variant={variant} {...props}>
       {children}
     </Typography>
   );

--- a/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
+++ b/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
@@ -9,7 +9,7 @@ import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 export const ValueElType = ({
   children,
   component = "div",
-  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
+  variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES,
   ...props /* MuiTypographyProps */
 }: TypographyProps): JSX.Element => {
   return (

--- a/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
+++ b/src/components/common/KeyValuePairs/components/ValueElType/valueElType.tsx
@@ -8,11 +8,12 @@ import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 
 export const ValueElType = ({
   children,
+  component = "div",
   variant = TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2LINES,
   ...props /* MuiTypographyProps */
 }: TypographyProps): JSX.Element => {
   return (
-    <Typography variant={variant} {...props}>
+    <Typography component={component} variant={variant} {...props}>
       {children}
     </Typography>
   );


### PR DESCRIPTION
Closes #367.

Fixes `KeyValuePairs` component `KeyElType` and `ValueElType` to enable updates to any Mui TypographyProp.