### PR TITLE
fix: add dropdownicon to muiselect default props (#356)

### DIFF
--- a/src/components/common/Form/components/Select/select.tsx
+++ b/src/components/common/Form/components/Select/select.tsx
@@ -5,7 +5,6 @@ import {
 } from "@mui/material";
 import React, { ReactNode } from "react";
 import { TEXT_BODY_400 } from "../../../../../theme/common/typography";
-import { DropDownIcon } from "./components/DropDownIcon/dropDownIcon";
 import { InputFormControl } from "./select.styles";
 
 /**
@@ -30,13 +29,7 @@ export const Select = ({
   return (
     <InputFormControl className={className} isFilled={isFilled}>
       {label && <Typography variant={TEXT_BODY_400}>{label}</Typography>}
-      <MSelect
-        fullWidth
-        IconComponent={DropDownIcon}
-        inputProps={{ onBlur }}
-        size="small"
-        {...props}
-      >
+      <MSelect fullWidth inputProps={{ onBlur }} size="small" {...props}>
         {children}
       </MSelect>
     </InputFormControl>

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -1,4 +1,5 @@
 import { Components, Theme } from "@mui/material";
+import { DropDownIcon } from "../../components/common/Form/components/Select/components/DropDownIcon/dropDownIcon";
 import { CHIP_PROPS } from "../../styles/common/mui/chip";
 import { desktopUp, mobileUp, tabletUp } from "./breakpoints";
 import {
@@ -1179,6 +1180,9 @@ export const MuiRadio = (theme: Theme): Components["MuiRadio"] => {
  * MuiSelect Component
  */
 export const MuiSelect: Components["MuiSelect"] = {
+  defaultProps: {
+    IconComponent: DropDownIcon,
+  },
   styleOverrides: {
     select: {
       minHeight: "unset",


### PR DESCRIPTION
Tests pass with icon in Select default props in theme!

<img width="288" alt="image" src="https://github.com/user-attachments/assets/cbdf1a50-ca6e-4817-8d70-a4fb09837ec6" />
