### PR TITLE
refactor!: add css shadow variables to theme (#417)

### DIFF
--- a/src/components/Support/components/SupportRequest/components/Dialog/dialog.styles.ts
+++ b/src/components/Support/components/SupportRequest/components/Dialog/dialog.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Fab as MFab, Popover as MPopover } from "@mui/material";
 import { COLOR_MIXES } from "../../../../../../styles/common/constants/colorMixes";
+import { SHADOWS } from "../../../../../../styles/common/constants/shadows";
 import { mediaTabletUp } from "../../../../../../styles/common/mixins/breakpoints";
 import { smokeMain } from "../../../../../../styles/common/mixins/colors";
-import { shadows02 } from "../../../../../../styles/common/mixins/shadows";
 import { tabletUp } from "../../../../../../theme/common/breakpoints";
 
 interface Props {
@@ -12,7 +12,7 @@ interface Props {
 
 export const Fab = styled(MFab)<Props>`
   bottom: 16px;
-  box-shadow: ${shadows02};
+  box-shadow: ${SHADOWS["02"]};
   position: fixed;
   right: 16px;
   z-index: ${({ open }) => (open ? 1350 : 1050)}; // Above backdrop component.

--- a/src/components/Support/components/ViewSupport/viewSupport.styles.ts
+++ b/src/components/Support/components/ViewSupport/viewSupport.styles.ts
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
+import { SHADOWS } from "../../../../styles/common/constants/shadows";
 import { mediaTabletUp } from "../../../../styles/common/mixins/breakpoints";
 import {
   primaryDark,
   primaryMain,
   white,
 } from "../../../../styles/common/mixins/colors";
-import { shadows02 } from "../../../../styles/common/mixins/shadows";
 
 export const Fab = styled("a")`
   align-items: center;
@@ -13,7 +13,7 @@ export const Fab = styled("a")`
   border: none;
   border-radius: 50%;
   bottom: 16px;
-  box-shadow: ${shadows02};
+  box-shadow: ${SHADOWS["02"]};
   color: ${white};
   cursor: pointer;
   display: flex;

--- a/src/styles/common/constants/shadows.ts
+++ b/src/styles/common/constants/shadows.ts
@@ -1,0 +1,5 @@
+export const SHADOWS = {
+  "00": `var(--mui-shadows-0)`,
+  "01": `var(--mui-shadows-1)`,
+  "02": `var(--mui-shadows-2)`,
+};

--- a/src/styles/common/mixins/shadows.ts
+++ b/src/styles/common/mixins/shadows.ts
@@ -1,7 +1,0 @@
-import { ThemeProps } from "../../../theme/theme";
-
-// Elevation 01
-export const shadows01 = ({ theme }: ThemeProps): string => theme.shadows[1];
-
-// Elevation 02
-export const shadows02 = ({ theme }: ThemeProps): string => theme.shadows[2];

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -2,9 +2,9 @@ import { Components, Theme } from "@mui/material";
 import { DropDownIcon } from "../../components/common/Form/components/Select/components/DropDownIcon/dropDownIcon";
 import { COLOR_MIXES } from "../../styles/common/constants/colorMixes";
 import { PALETTE } from "../../styles/common/constants/palette";
+import { SHADOWS } from "../../styles/common/constants/shadows";
 import { CHIP_PROPS } from "../../styles/common/mui/chip";
 import { desktopUp, mobileUp, tabletUp } from "./breakpoints";
-import { strokeBottom, strokeTop } from "./shadows";
 import {
   TEXT_BODY_400,
   TEXT_BODY_400_2_LINES,
@@ -33,13 +33,13 @@ export const MuiAccordion = (theme: Theme): Components["MuiAccordion"] => {
     styleOverrides: {
       root: {
         backgroundColor: "transparent",
-        boxShadow: `${strokeTop} ${theme.palette.smoke.main}, ${strokeBottom} ${theme.palette.smoke.main}`,
+        boxShadow: `inset 0 1px 0 0 ${theme.palette.smoke.main}, inset 0 -1px 0 0 ${theme.palette.smoke.main}`,
         // eslint-disable-next-line sort-keys -- disabling key order for readability
         "&:before": {
           display: "none",
         },
         "&:nth-of-type(n+2)": {
-          boxShadow: `${strokeBottom} ${theme.palette.smoke.main}`,
+          boxShadow: `inset 0 -1px 0 0 ${theme.palette.smoke.main}`,
         },
       },
     },
@@ -578,20 +578,18 @@ export const MuiCssBaseline = (theme: Theme): Components["MuiCssBaseline"] => {
  * @param theme - Theme.
  * @returns MuiDialog component theme styles.
  */
-export const MuiDialog = (theme: Theme): Components["MuiDialog"] => {
-  return {
-    styleOverrides: {
-      paper: {
-        boxShadow: theme.shadows[2], // elevation02
-      },
-      root: {
-        // eslint-disable-next-line sort-keys -- disabling key order for readability
-        "& .MuiBackdrop-root": {
-          backgroundColor: COLOR_MIXES.INK_MAIN_60,
-        },
+export const MuiDialog: Components["MuiDialog"] = {
+  styleOverrides: {
+    paper: {
+      boxShadow: SHADOWS["02"],
+    },
+    root: {
+      // eslint-disable-next-line sort-keys -- disabling key order for readability
+      "& .MuiBackdrop-root": {
+        backgroundColor: COLOR_MIXES.INK_MAIN_60,
       },
     },
-  };
+  },
 };
 
 /**
@@ -1065,20 +1063,20 @@ export const MuiPaper = (theme: Theme): Components["MuiPaper"] => {
       {
         props: { elevation: 1 },
         style: {
-          boxShadow: theme.shadows[1], // elevation01
+          boxShadow: SHADOWS["01"],
         },
       },
       {
         props: { elevation: 2 },
         style: {
-          boxShadow: theme.shadows[2], // elevation02
+          boxShadow: SHADOWS["02"],
         },
       },
       {
         props: { variant: "footer" },
         style: {
           backgroundColor: theme.palette.smoke.light,
-          boxShadow: `${strokeTop} ${theme.palette.smoke.main}, ${strokeBottom} ${theme.palette.smoke.main}`,
+          boxShadow: `inset 0 1px 0 0 ${theme.palette.smoke.main}, inset 0 -1px 0 0 ${theme.palette.smoke.main}`,
         },
       },
       {
@@ -1088,7 +1086,7 @@ export const MuiPaper = (theme: Theme): Components["MuiPaper"] => {
           borderRadius: 8,
           borderStyle: "solid",
           borderWidth: 1,
-          boxShadow: theme.shadows[2], // elevation02
+          boxShadow: SHADOWS["02"],
         },
       },
       {
@@ -1097,7 +1095,7 @@ export const MuiPaper = (theme: Theme): Components["MuiPaper"] => {
           borderColor: theme.palette.smoke.main,
           borderStyle: "solid",
           borderWidth: 1,
-          boxShadow: theme.shadows[1], // elevation01
+          boxShadow: SHADOWS["01"],
         },
       },
       {
@@ -1108,7 +1106,7 @@ export const MuiPaper = (theme: Theme): Components["MuiPaper"] => {
           borderRadius: 0,
           borderStyle: "solid",
           borderWidth: "0 0 1px 0",
-          boxShadow: theme.shadows[1], // elevation01,
+          boxShadow: SHADOWS["01"],
           // eslint-disable-next-line sort-keys -- disabling key order for readability
           "&.MuiDialog-paper": {
             marginLeft: 0,
@@ -1124,7 +1122,7 @@ export const MuiPaper = (theme: Theme): Components["MuiPaper"] => {
           borderColor: theme.palette.smoke.main,
           borderStyle: "solid",
           borderWidth: 1,
-          boxShadow: theme.shadows[1], // elevation01
+          boxShadow: SHADOWS["01"],
         },
       },
     ],
@@ -1374,7 +1372,7 @@ export const MuiTabs = (theme: Theme): Components["MuiTabs"] => {
         height: 3,
       },
       root: {
-        boxShadow: `${strokeBottom} ${theme.palette.smoke.main}`,
+        boxShadow: `inset 0 -1px 0 0 ${theme.palette.smoke.main}`,
         minHeight: "unset",
         position: "relative", // Positions scroll fuzz.
       },
@@ -1495,7 +1493,7 @@ export const MuiTooltip = (theme: Theme): Components["MuiTooltip"] => {
       tooltip: {
         ...theme.typography[TEXT_BODY_SMALL_400],
         backgroundColor: theme.palette.ink.main,
-        boxShadow: theme.shadows[2], // elevation02
+        boxShadow: SHADOWS["02"],
         boxSizing: "content-box",
         padding: "8px 12px",
       },

--- a/src/theme/common/shadows.ts
+++ b/src/theme/common/shadows.ts
@@ -1,34 +1,29 @@
-/*
- * Elevation
- */
-enum ELEVATION {
-  E00 = "none",
-  E01 = "0 1px 4px 0 #00000012",
-  E02 = "0 8px 8px -4px #10182808, 0 20px 24px -4px #10182814",
-}
+import { Shadows } from "@mui/material";
 
-/**
- * Stroke
- */
-enum STROKE {
-  BOTTOM = "inset 0 -1px 0 0",
-  TOP = "inset 0 1px 0 0",
-}
-
-/**
- * Elevation constants
- */
-export const elevation00 = ELEVATION.E00;
-export const elevation01 = ELEVATION.E01;
-export const elevation02 = ELEVATION.E02;
-
-/**
- * Shadows constants
- */
-export const shadows = [elevation00, elevation01, elevation02];
-
-/**
- * Stroke constants
- */
-export const strokeBottom = STROKE.BOTTOM;
-export const strokeTop = STROKE.TOP;
+export const shadows: Shadows = [
+  "none",
+  "0 1px 4px 0 #00000012",
+  "0 8px 8px -4px #10182808, 0 20px 24px -4px #10182814",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+  "none",
+];

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme, Shadows, Theme, ThemeOptions } from "@mui/material";
+import { createTheme, Theme, ThemeOptions } from "@mui/material";
 import { deepmerge } from "@mui/utils";
 import * as B from "./common/breakpoints";
 import * as C from "./common/components";
@@ -42,6 +42,7 @@ export function createAppTheme(customOptions: ThemeOptions = {}): Theme {
           text: P.text,
           warning: P.warning,
         },
+        shadows,
         spacing: 4,
         typography: {
           [T.TEXT_BODY_400]: T.textBody400,
@@ -67,11 +68,6 @@ export function createAppTheme(customOptions: ThemeOptions = {}): Theme {
     )
   );
 
-  // Default shadow overrides.
-  theme.shadows = [...theme.shadows].map(
-    (shadow, s) => shadows[s] || shadow
-  ) as Shadows;
-
   // Theme components.
   theme.components = {
     MuiAccordion: C.MuiAccordion(theme),
@@ -90,7 +86,7 @@ export function createAppTheme(customOptions: ThemeOptions = {}): Theme {
     MuiChip: C.MuiChip(theme),
     MuiCircularProgress: C.MuiCircularProgress(theme),
     MuiCssBaseline: C.MuiCssBaseline(theme),
-    MuiDialog: C.MuiDialog(theme),
+    MuiDialog: C.MuiDialog,
     MuiDialogActions: C.MuiDialogActions,
     MuiDialogContent: C.MuiDialogContent(theme),
     MuiDialogTitle: C.MuiDialogTitle(theme),


### PR DESCRIPTION
Closes #417.

This pull request refactors the shadow system in the codebase to improve consistency and maintainability. The changes involve replacing individual shadow constants and methods with a centralized `SHADOWS` object, updating references across multiple files, and simplifying the theme configuration.

### Centralized Shadow Management:
* Introduced a new `SHADOWS` object in `src/styles/common/constants/shadows.ts` to centralize shadow definitions.
* Removed individual shadow methods (`shadows01`, `shadows02`) from `src/styles/common/mixins/shadows.ts`.
* Replaced `shadows02` with `SHADOWS["02"]` in `dialog.styles.ts` and `viewSupport.styles.ts` for consistency. [[1]](diffhunk://#diff-d30a5e84a26608f710cace5d2f6b851a27a11d3528872afd64916b6c1ac287bfL15-R15) [[2]](diffhunk://#diff-997b3d142bab86b65d71669d2724da281f15391c31cc81c55b10cbd5a2a24b60R2-R16)

### Theme Refactoring:
* Updated the `createAppTheme` function in `src/theme/theme.ts` to directly use the `shadows` array instead of overriding the MUI theme's `shadows` property. [[1]](diffhunk://#diff-af05c0fe942adbcf1130008615759d29199b736bba453ff241f25ca140dcfb8fR45) [[2]](diffhunk://#diff-af05c0fe942adbcf1130008615759d29199b736bba453ff241f25ca140dcfb8fL70-L74)
* Simplified the `MuiDialog` component definition by converting it to a constant and removing the theme parameter. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L595) [[2]](diffhunk://#diff-af05c0fe942adbcf1130008615759d29199b736bba453ff241f25ca140dcfb8fL93-R89)

### Component Updates:
* Replaced custom shadow constants (`strokeTop`, `strokeBottom`) with inline definitions directly in the `MuiAccordion`, `MuiPaper`, and `MuiTabs` components. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L36-R42) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1068-R1079) [[3]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1377-R1375)
* Updated shadow references in `MuiTooltip` and other components to use the new `SHADOWS` object. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1498-R1496) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1091-R1089)

These changes streamline shadow management, reduce redundancy, and enhance the maintainability of the theme and component styles.