### PR TITLE
refactor!: fix duplication of component type basecomponentprops (#420)

### DIFF
--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -9,15 +9,16 @@ import {
   SectionActions,
   SectionContent,
 } from "../../../common/Section/section.styles";
+import { TrackingProps } from "../../../types";
 import { ExportButton, SectionFootnote } from "./exportMethod.styles";
-export interface ExportMethodProps {
+
+export interface ExportMethodProps extends TrackingProps {
   buttonLabel: string;
   description: ReactNode;
   footnote?: ReactNode;
   isAccessible?: boolean;
   route: string;
   title: string;
-  trackingId?: string;
 }
 
 export const ExportMethod = ({

--- a/src/components/Login/components/Button/types.ts
+++ b/src/components/Login/components/Button/types.ts
@@ -1,4 +1,4 @@
 import { ButtonProps } from "@mui/material";
-import { BaseComponentProps } from "../../../../theme/common/entities";
+import { BaseComponentProps } from "../../../types";
 
 export type Props = BaseComponentProps & ButtonProps;

--- a/src/components/Login/components/Buttons/types.ts
+++ b/src/components/Login/components/Buttons/types.ts
@@ -1,7 +1,7 @@
 import { ButtonProps } from "@mui/material";
 import { ClientSafeProvider } from "next-auth/react";
 import { OAuthProvider } from "../../../../config/entities";
-import { BaseComponentProps } from "../../../../theme/common/entities";
+import { BaseComponentProps } from "../../../types";
 
 export interface Props<P> extends BaseComponentProps, ButtonProps {
   handleLogin: (providerId: string) => void;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -12,6 +12,10 @@ export interface ContentProps {
   content?: ReactNode;
 }
 
+export interface TrackingProps {
+  trackingId?: string;
+}
+
 export interface TestIdProps {
   testId?: string;
 }

--- a/src/theme/common/entities.ts
+++ b/src/theme/common/entities.ts
@@ -1,7 +1,0 @@
-export interface BaseComponentProps {
-  className?: string;
-}
-
-export interface TrackingComponentProps {
-  trackingId?: string;
-}


### PR DESCRIPTION
Closes #420.

This pull request refactors type definitions and consolidates shared interfaces into a centralized `types` file, improving code organization and maintainability. The most important changes include introducing a new `TrackingProps` interface, updating component props to use centralized types, and removing redundant definitions.

### Type Consolidation:

* [`src/components/types.ts`](diffhunk://#diff-9b909becd3cda72d27670f588ebcdb1ffd0aac1f515343b0ca4e64071b9045c4R15-R18): Added a new `TrackingProps` interface to centralize the `trackingId` property.
* [`src/theme/common/entities.ts`](diffhunk://#diff-a13173e58a314ff0e66477a15ff1a7cec06c0839d473406b89ae36f7173b1d38L1-L7): Removed redundant `BaseComponentProps` and `TrackingComponentProps` interfaces, as they are now defined in `src/components/types.ts`.

### Component Updates:

* [`src/components/Export/components/ExportMethod/exportMethod.tsx`](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59R12-L20): Updated `ExportMethodProps` to extend the new `TrackingProps` interface, removing the inline `trackingId` property.
* [`src/components/Login/components/Button/types.ts`](diffhunk://#diff-363d4a999cb8db963364e75c50bb62d3f3f27b1248969d79306bb63cd9dae281L2-R2): Updated the import path for `BaseComponentProps` to use the centralized `types` file.
* [`src/components/Login/components/Buttons/types.ts`](diffhunk://#diff-e5e1053263bb86e958e99fbe9026472711160642ccf49f94b4363c7e4ce9cd7dL4-R4): Updated the import path for `BaseComponentProps` to use the centralized `types` file.