### PR TITLE
feat: update chart ui to make charts more compact (#429)

### DIFF
--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/constants.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/constants.ts
@@ -1,4 +1,4 @@
-export const BAR_GAP = 40;
+export const BAR_GAP = 8;
 
 export const BAR_HEIGHT = 24;
 
@@ -7,6 +7,8 @@ export const DATA_FIELD = {
   LABEL: "label",
   SELECTED: "selected",
 } as const;
+
+export const MARGIN_LEFT = 136;
 
 export const TEXT_PADDING = 8;
 

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
@@ -3,7 +3,7 @@ import { PlotOptions } from "@observablehq/plot";
 import { SelectCategoryValueView } from "../../../../../../../../../common/entities";
 import { PALETTE } from "../../../../../../../../../styles/common/constants/palette";
 import { formatCountSize } from "../../../../../../../../../utils/formatCountSize";
-import { DATA_FIELD, TEXT_PADDING } from "./constants";
+import { DATA_FIELD, MARGIN_LEFT, TEXT_PADDING } from "./constants";
 import {
   getCategoryValueText,
   getCategoryValueTextFill,
@@ -32,6 +32,7 @@ export function getPlotOptions(
     height: getPlotHeight(selectCategoryValueViews.length),
     margin: 0,
     marginBottom: 32,
+    marginLeft: MARGIN_LEFT,
     marks: [
       Plot.axisX({
         className: "x-axis",
@@ -56,13 +57,15 @@ export function getPlotOptions(
       }),
       Plot.text(selectCategoryValueViews, {
         className: "text-category-label",
-        dx: 16,
-        dy: -28,
+        dx: -TEXT_PADDING,
+        dy: -2,
         fill: (d) => getCategoryValueTextFill(d, isCategorySelected),
-        lineWidth: width / 13, // "em" unit; font-size is 13px.
+        lineHeight: 0.8125,
+        lineWidth: (MARGIN_LEFT - TEXT_PADDING) / 13, // "em" unit; font-size is 13px.
         text: getCategoryValueText,
-        textAnchor: "start",
+        textAnchor: "end",
         textOverflow: "ellipsis",
+        title: getCategoryValueText,
         x: 0,
         y: DATA_FIELD.LABEL,
       }),

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
@@ -7,7 +7,13 @@ import {
 } from "@observablehq/plot";
 import { SelectCategoryValueView } from "../../../../../../../../../common/entities";
 import { PALETTE } from "../../../../../../../../../styles/common/constants/palette";
-import { BAR_GAP, BAR_HEIGHT, TEXT_PADDING, TICKS } from "./constants";
+import {
+  BAR_GAP,
+  BAR_HEIGHT,
+  MARGIN_LEFT,
+  TEXT_PADDING,
+  TICKS,
+} from "./constants";
 
 /**
  * Returns the text for the category value point.
@@ -210,7 +216,7 @@ export function renderText(
       const bBox = textEl.getBBox();
       if (!ctm || !bBox) continue;
       // If the text doesn't fit inside the bar, reposition it outside.
-      if (ctm.e - bBox.width - TEXT_PADDING < 0) {
+      if (ctm.e - bBox.width - TEXT_PADDING < MARGIN_LEFT) {
         const [tx, ty] = parseTranslate(textEl.getAttribute("transform"));
         // Translate by the width of the bar plus padding on each side.
         textEl.setAttribute(


### PR DESCRIPTION
Closes #429.

<img width="2360" alt="image" src="https://github.com/user-attachments/assets/7af9d5da-b96a-4bc9-a3ea-3334be40ff92" />

This pull request introduces several changes to improve the chart rendering and its associated tests. Key updates include adjustments to chart layout constants, modifications to text rendering logic, and enhancements to test coverage for better validation of chart behavior.

### Chart Layout and Rendering Updates:
* Updated `BAR_GAP` from `40` to `8` and introduced a new constant `MARGIN_LEFT` with a value of `136` in `barX/constants.ts`. These changes refine the spacing and alignment of chart elements. [[1]](diffhunk://#diff-f768cecbea466761e82e404aea54c227bb80be0ad185931255b43da4ad3fb039L1-R1) [[2]](diffhunk://#diff-f768cecbea466761e82e404aea54c227bb80be0ad185931255b43da4ad3fb039R11-R12)
* Adjusted `getPlotOptions` in `barX/plot.ts` to use `MARGIN_LEFT` for `marginLeft` and updated text rendering properties like `dx`, `dy`, `textAnchor`, and `lineWidth` for improved label positioning and alignment. [[1]](diffhunk://#diff-ef828432276c7a2122572b11fcc65c58c158b976800c6f8179fc4c38cd36cb5eR35) [[2]](diffhunk://#diff-ef828432276c7a2122572b11fcc65c58c158b976800c6f8179fc4c38cd36cb5eL59-R68)
* Updated `renderText` in `barX/utils.ts` to reposition text elements outside the bar if they do not fit, now considering `MARGIN_LEFT` for alignment.

### Test Enhancements:
* Introduced `CLASSNAMES` constants in `chart.test.tsx` to centralize class name references, improving maintainability.
* Enhanced test cases for category labels to validate both `textContent` and `title` attributes, ensuring proper rendering of labels and tooltips. [[1]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL34-R58) [[2]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL64-R90)
* Added utility functions `findTextNode` and `stripTrailingEllipsis` in `chart.test.tsx` to handle SVG text node extraction and ellipsis removal, supporting more robust test assertions. [[1]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abR143-R151) [[2]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abR244-R252)