### PR TITLE
refactor: chart test (#432)

### DIFF
--- a/tests/chart.test.tsx
+++ b/tests/chart.test.tsx
@@ -52,7 +52,7 @@ describe("Chart", () => {
       expect(labelTextEls.length).toEqual(labels.length);
       expect(titleTextEls.length).toEqual(labels.length);
       labelTextEls.forEach((el, i) => {
-        const labelText = stripTrailingEllipsis(findTextNode(el)?.textContent);
+        const labelText = getLabelText(el);
         const titleText = titleTextEls[i].textContent || "";
         expect(labels.some((l) => l.includes(labelText))).toBeTruthy();
         expect(labels.includes(titleText)).toBeTruthy();
@@ -74,9 +74,7 @@ describe("Chart", () => {
       const textEls = getEls(CLASSNAMES.TEXT_CATEGORY_LABEL, "text");
       const titleEls = getEls(CLASSNAMES.TEXT_CATEGORY_LABEL, "title");
       SELECTED_DATA.forEach((selectedData, i) => {
-        const labelText = stripTrailingEllipsis(
-          findTextNode(textEls[i])?.textContent
-        );
+        const labelText = getLabelText(textEls[i]);
         const titleText = titleEls[i].textContent || "";
         if (selectedData.selected) {
           const expected = `${selectedData.label} (selected)`;
@@ -170,6 +168,15 @@ function getGroupEls(className: string): HTMLCollectionOf<Element> {
 function getEls(className: string, selectors: string): NodeListOf<SVGElement> {
   const gEls = getGroupEls(className);
   return gEls[0].querySelectorAll(selectors);
+}
+
+/**
+ * Retrieves the label text from a given SVGElement by extracting and processing its text content.
+ * @param el - The SVGElement from which the label text is to be retrieved.
+ * @returns The processed label text derived from the SVGElement.
+ */
+function getLabelText(el: SVGElement): string {
+  return stripTrailingEllipsis(findTextNode(el)?.textContent);
 }
 
 /**

--- a/tests/chart.test.tsx
+++ b/tests/chart.test.tsx
@@ -176,7 +176,9 @@ function getEls(className: string, selectors: string): NodeListOf<SVGElement> {
  * @returns The processed label text derived from the SVGElement.
  */
 function getLabelText(el: SVGElement): string {
-  return stripTrailingEllipsis(findTextNode(el)?.textContent);
+  const labelText = stripTrailingEllipsis(findTextNode(el)?.textContent);
+  expect(labelText).toBeDefined();
+  return labelText || "";
 }
 
 /**


### PR DESCRIPTION
Closes #432.

This pull request refactors the test code in `tests/chart.test.tsx` by introducing a helper function, `getLabelText`, to improve code readability and maintainability. The most important changes include replacing repeated logic with the new helper function and adding documentation for it.

### Refactoring for readability and maintainability:
* Replaced repeated logic for extracting and processing label text with a new helper function, `getLabelText`, in two test cases (`describe("Chart", () => {`) to simplify the code and reduce duplication. [[1]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL55-R55) [[2]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL77-R77)
* Introduced the `getLabelText` function, which retrieves and processes label text from an `SVGElement`, and added a detailed JSDoc comment to describe its purpose and usage.