### PR TITLE
feat: chart view add percentage to counts (#441)

### DIFF
--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
@@ -5,9 +5,11 @@ import { PALETTE } from "../../../../../../../../../styles/common/constants/pale
 import { formatCountSize } from "../../../../../../../../../utils/formatCountSize";
 import { DATA_FIELD, MARGIN_LEFT, TEXT_PADDING } from "./constants";
 import {
+  getCategoryTotalCount,
   getCategoryValueText,
   getCategoryValueTextFill,
   getColorRangeValue,
+  getCountText,
   getCountTextFill,
   getPlotHeight,
   getTicks,
@@ -23,6 +25,7 @@ export function getPlotOptions(
   width: number
 ): PlotOptions {
   const isCategorySelected = isAnyValueSelected(selectCategoryValueViews);
+  const totalCount = getCategoryTotalCount(selectCategoryValueViews);
   return {
     color: {
       domain: [false, true], // false = unselected, true = selected.
@@ -77,7 +80,7 @@ export function getPlotOptions(
         fontWeight: 500,
         lineHeight: 0.8125,
         render: renderText,
-        text: DATA_FIELD.COUNT,
+        text: (d) => getCountText(d, totalCount),
         textAnchor: "end",
         x: DATA_FIELD.COUNT,
         y: DATA_FIELD.LABEL,

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
@@ -69,9 +69,13 @@ export function getColorRangeValue(isCategorySelected: boolean): string {
 export function getCountPercentage(
   d: SelectCategoryValueView,
   total: number
-): number {
-  if (total === 0) return 0;
-  return Number((Math.round((d.count / total) * 1000) / 10).toFixed(1));
+): string {
+  if (total === 0) return "0";
+  const percentage = (d.count / total) * 100;
+  const roundedPercentage = Math.round(percentage * 10) / 10;
+  if (roundedPercentage < 0.1) return "< 0.1";
+  // Round to one decimal place.
+  return roundedPercentage.toFixed(1);
 }
 
 /**

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
@@ -70,6 +70,7 @@ export function getCountPercentage(
   d: SelectCategoryValueView,
   total: number
 ): number {
+  if (total === 0) return 0;
   return Number((Math.round((d.count / total) * 1000) / 10).toFixed(1));
 }
 

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts
@@ -16,6 +16,17 @@ import {
 } from "./constants";
 
 /**
+ * Calculates the total count of all category values from the provided array of category value views.
+ * @param selectCategoryValueViews - An array of objects representing category values, where each object contains a count property.
+ * @returns The total sum of the count property from all category value objects in the array.
+ */
+export function getCategoryTotalCount(
+  selectCategoryValueViews: SelectCategoryValueView[]
+): number {
+  return selectCategoryValueViews.reduce((acc, { count }) => acc + count, 0);
+}
+
+/**
  * Returns the text for the category value point.
  * @param d - Data point.
  * @returns Formatted text string.
@@ -47,6 +58,33 @@ export function getCategoryValueTextFill(
  */
 export function getColorRangeValue(isCategorySelected: boolean): string {
   return isCategorySelected ? PALETTE.SMOKE_LIGHT : "#C5E3FC";
+}
+
+/**
+ * Calculates the percentage representation of a count value relative to a total.
+ * @param d - Data point containing the count value to calculate the percentage for.
+ * @param total - The total value used as the denominator to compute the percentage.
+ * @returns The calculated percentage value, rounded to one decimal place.
+ */
+export function getCountPercentage(
+  d: SelectCategoryValueView,
+  total: number
+): number {
+  return Number((Math.round((d.count / total) * 1000) / 10).toFixed(1));
+}
+
+/**
+ * Returns the text for the count point.
+ * Includes the count and its percentage of the total.
+ * @param d - Data point.
+ * @param total - Total count.
+ * @returns Text string.
+ */
+export function getCountText(
+  d: SelectCategoryValueView,
+  total: number
+): string {
+  return `${d.count.toLocaleString()} (${getCountPercentage(d, total)}%)`;
 }
 
 /**

--- a/tests/chart.test.tsx
+++ b/tests/chart.test.tsx
@@ -2,7 +2,11 @@ import { composeStories } from "@storybook/react";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { SelectCategoryValueView } from "../src/common/entities";
-import { parseTranslate } from "../src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils";
+import {
+  getCategoryTotalCount,
+  getCountText,
+  parseTranslate,
+} from "../src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils";
 import { CHART_TEST_ID } from "../src/components/Index/components/EntitiesView/components/ChartView/components/Chart/constants";
 import * as stories from "../src/components/Index/components/EntitiesView/components/ChartView/components/Chart/stories/chart.stories";
 import { PALETTE } from "../src/styles/common/constants/palette";
@@ -16,6 +20,7 @@ const { Default, Selected } = composeStories(stories);
 
 const DATA = Default.args.selectCategoryValueViews || [];
 const SELECTED_DATA = Selected.args.selectCategoryValueViews || [];
+const TOTAL_COUNT = getCategoryTotalCount(DATA);
 
 describe("Chart", () => {
   describe("basic rendering", () => {
@@ -35,7 +40,7 @@ describe("Chart", () => {
   });
 
   describe("category labels and counts", () => {
-    const counts = DATA.map(mapCount);
+    const counts = DATA.map((d) => mapCount(d, TOTAL_COUNT));
     const labels = DATA.map(mapLabel);
     let countTextEls: NodeListOf<SVGElement>;
     let labelTextEls: NodeListOf<SVGElement>;
@@ -127,7 +132,9 @@ describe("Chart", () => {
     it("renders bars in descending order of count", () => {
       render(<Default testId={CHART_TEST_ID} />);
       // Order data by count in descending order.
-      const counts = [...DATA].sort(sortByCount).map(mapCount);
+      const counts = [...DATA]
+        .sort(sortByCount)
+        .map((d) => mapCount(d, TOTAL_COUNT));
       // Sort count <text> elements by their transform’s translate‑Y (vertical) value, since they’re rendered in data order.
       const countTextEls = getEls(CLASSNAMES.TEXT_COUNT, "text");
       const textContents = [...countTextEls]
@@ -200,12 +207,16 @@ function isFillPrimaryMain(element: Element): boolean {
 }
 
 /**
- * Maps the count of a category value view to a string.
- * @param categoryValueView - Category value view.
- * @returns Count as a string.
+ * Maps the count of a category value to a string representation.
+ * @param categoryValueView - The category value view to be processed.
+ * @param total - The total count associated with the category value.
+ * @returns The formatted count text for the category value.
  */
-function mapCount(categoryValueView: SelectCategoryValueView): string {
-  return categoryValueView.count.toLocaleString();
+function mapCount(
+  categoryValueView: SelectCategoryValueView,
+  total: number
+): string {
+  return getCountText(categoryValueView, total);
 }
 
 /**


### PR DESCRIPTION
Closes #441.

This pull request introduces enhancements to the bar chart component by adding percentage-based count representations and updating related utility functions and tests. The most important changes include introducing new utility functions to calculate percentages and format count text, updating the chart rendering logic to include these enhancements, and modifying tests to validate the new functionality.

### Chart Enhancements:
* Added `getCategoryTotalCount` and `getCountText` utility functions to calculate the total count of category values and format count text with percentages. These functions are now used in the chart rendering logic. (`src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/utils.ts`, [[1]](diffhunk://#diff-b8103196bd657795227e29091770bbffe2a96788726568751ac3c190209e36e4R18-R28) [[2]](diffhunk://#diff-b8103196bd657795227e29091770bbffe2a96788726568751ac3c190209e36e4R63-R89)
* Updated the `getPlotOptions` function to calculate the total count and use it to render count text with percentages instead of raw counts. (`src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts`, [[1]](diffhunk://#diff-ef828432276c7a2122572b11fcc65c58c158b976800c6f8179fc4c38cd36cb5eR28) [[2]](diffhunk://#diff-ef828432276c7a2122572b11fcc65c58c158b976800c6f8179fc4c38cd36cb5eL80-R83)

### Test Updates:
* Modified test utilities and test cases to validate the new count text format, including percentages. Updated the `mapCount` function to use `getCountText` and adjusted test data and assertions accordingly. (`tests/chart.test.tsx`, [[1]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL5-R9) [[2]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abR23) [[3]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL38-R43) [[4]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL130-R137) [[5]](diffhunk://#diff-314e8526e4dabc0d056025992274747d6491502e014a722fd6016799f0b6e2abL203-R219)

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/fb65952f-301c-4256-957f-d3381491ff23" />

<img width="691" alt="image" src="https://github.com/user-attachments/assets/2b294ee0-4db6-4152-a4b4-5a236e2f473e" />
