### PR TITLE
feat: chart view - change 'per' to 'by' in chart titles (#442)

### DIFF
--- a/src/components/Index/components/EntitiesView/components/ChartView/chartView.tsx
+++ b/src/components/Index/components/EntitiesView/components/ChartView/chartView.tsx
@@ -28,7 +28,7 @@ export const ChartView = ({
         {selectCategoryViews.map(({ key, label, values }) => (
           <StyledGridPaperSection key={key}>
             <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_SMALL}>
-              {entityName} per {label}
+              {entityName} by {label}
             </Typography>
             <Chart selectCategoryValueViews={values} width={width} />
           </StyledGridPaperSection>

--- a/tests/chartView.test.tsx
+++ b/tests/chartView.test.tsx
@@ -35,7 +35,7 @@ describe("ChartView", () => {
     } = Default;
     ["Biological Sex", "Genus Species"].forEach((category) => {
       expect(
-        screen.getByText(new RegExp(`${entityName} per ${category}`))
+        screen.getByText(new RegExp(`${entityName} by ${category}`))
       ).toBeDefined();
     });
   });


### PR DESCRIPTION
Closes #442.

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/93cb1f25-e9e1-4d54-a574-91909dedbbfd" />

This pull request updates the wording in the `ChartView` component and its associated test to improve clarity and consistency. The most important changes include modifying text displayed in the component and updating the test assertions to reflect the new wording.

**Text updates in the `ChartView` component:**
* [`src/components/Index/components/EntitiesView/components/ChartView/chartView.tsx`](diffhunk://#diff-fd62b377ad5ff710f43767b1cbd4077ab5799ed6efd6254daddc36b6d0d2b7cfL31-R31): Changed the text from "{entityName} per {label}" to "{entityName} by {label}" for better readability.

**Test updates for the `ChartView` component:**
* [`tests/chartView.test.tsx`](diffhunk://#diff-4930f91d268f85a2510ffd216d03579f92f761e32c3928cf9e22d9f61a969428L38-R38): Updated the regular expression in the test assertions to match the new wording "{entityName} by {category}" instead of "{entityName} per {category}".