### PR TITLE
fix: fix observable plot y-scale warning caused by numeric strings (#449)

### DIFF
--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
@@ -105,6 +105,7 @@ export function getPlotOptions(
       paddingOuter: getYPaddingOuter(),
       tickFormat: () => "",
       tickSize: 0,
+      type: "band",
     },
   };
 }

--- a/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
+++ b/src/components/Index/components/EntitiesView/components/ChartView/components/Chart/barX/plot.ts
@@ -105,7 +105,7 @@ export function getPlotOptions(
       paddingOuter: getYPaddingOuter(),
       tickFormat: () => "",
       tickSize: 0,
-      type: "band",
+      type: "band", // Treats number-like strings as categorical labels to prevent numeric scale warnings.
     },
   };
 }


### PR DESCRIPTION
Closes #449.

This pull request introduces a minor update to the `getPlotOptions` function in `plot.ts`. Specifically, it adds a `type` property with the value `"band"` to the configuration object for improved chart rendering.