### PR TITLE
feat: update data dictionary view to be full width (#456)

### DIFF
--- a/src/components/DataDictionary/dataDictionary.styles.ts
+++ b/src/components/DataDictionary/dataDictionary.styles.ts
@@ -11,12 +11,11 @@ export const grid = css`
 export const View = styled("div")`
   ${grid};
   flex: 1;
-  margin: 0 auto;
-  max-width: min(calc(100vw - 48px), 1392px);
+  margin: 0 24px;
   position: relative;
 
   ${mediaTabletDown} {
     grid-template-columns: 1fr;
-    max-width: calc(100vw - 32px);
+    margin: 0 16px;
   }
 `;


### PR DESCRIPTION
Closes #456.

This pull request updates the styling of the `View` component in the `dataDictionary.styles.ts` file to improve layout consistency and responsiveness. The most notable changes involve adjustments to the margins and removal of the `max-width` property.

Styling updates to `View` component:

* Changed the `margin` property from `0 auto` to `0 24px` for better alignment and spacing.
* Removed the `max-width` property to simplify layout constraints and ensure the component adapts dynamically to its container.
* Updated the `margin` property within the `mediaTabletDown` query from `0 auto` to `0 16px` to maintain consistent spacing on smaller screens.

<img width="2460" alt="image" src="https://github.com/user-attachments/assets/b7a445bc-689b-4406-8480-332ac58ef018" />
