### PR TITLE
fix: update table chipcell component interface (#471)

### DIFF
--- a/src/components/Table/components/TableCell/components/ChipCell/chipCell.tsx
+++ b/src/components/Table/components/TableCell/components/ChipCell/chipCell.tsx
@@ -1,8 +1,11 @@
-import { Chip } from "@mui/material";
+import { Chip, ChipProps } from "@mui/material";
 import { CellContext, RowData } from "@tanstack/react-table";
 import React from "react";
 
-export const ChipCell = <T extends RowData, TValue>({
+export const ChipCell = <
+  T extends RowData,
+  TValue extends ChipProps = ChipProps
+>({
   getValue,
 }: CellContext<T, TValue>): JSX.Element | null => {
   const props = getValue();


### PR DESCRIPTION
Closes #471.

This pull request updates the `ChipCell` component to enhance type safety and flexibility by introducing a generic type constraint for `ChipProps`.

Type safety and flexibility improvements:

* [`src/components/Table/components/TableCell/components/ChipCell/chipCell.tsx`](diffhunk://#diff-419a745ebef4a83658b741e0839ceb051b914df69bf3d6c6ac7adc31a7d6f4c9L1-R8): Updated the `ChipCell` component to extend the `TValue` generic type from `ChipProps`, ensuring that the `getValue` function returns properties compatible with the `Chip` component.