### PR TITLE
feat!: create table cell for displaying links (#468)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
+        "@emotion/jest": "^11.13.0",
         "@mui/types": "^7.4.0",
         "@next/eslint-plugin-next": "^14.2.28",
         "@storybook/addon-actions": "^8.6.4",
@@ -2406,6 +2407,16 @@
         "stylis": "4.2.0"
       }
     },
+    "node_modules/@emotion/css-prettifier": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css-prettifier/-/css-prettifier-1.2.0.tgz",
+      "integrity": "sha512-p+9m/5fp61i90CGUT+516glGBXWoEHgSelybqR+5vlX6Kb+Z0rkOfEMFqTBwYMRxXZTitibZERl32n2yPma7Dw==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "stylis": "4.2.0"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
@@ -2421,11 +2432,35 @@
         "@emotion/memoize": "^0.9.0"
       }
     },
+    "node_modules/@emotion/jest": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.13.0.tgz",
+      "integrity": "sha512-XyoUbJ9fthKdlXjTvjzd6aQ8yVWe68InZawFdGTFkJQRW44rsLHK1qjKB/+L7RiGgdm0BYFv7+tz8znQzRQOBw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/css-prettifier": "^1.1.4",
+        "chalk": "^4.1.0",
+        "specificity": "^0.4.1",
+        "stylis": "4.2.0"
+      },
+      "peerDependencies": {
+        "@types/jest": "^26.0.14 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "enzyme-to-json": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/jest": {
+          "optional": true
+        },
+        "enzyme-to-json": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "peer": true
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/react": {
       "version": "11.13.3",
@@ -18662,6 +18697,15 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "node_modules/specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true,
+      "bin": {
+        "specificity": "bin/specificity"
+      }
+    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -19043,8 +19087,7 @@
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "peer": true
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -22142,6 +22185,16 @@
         "stylis": "4.2.0"
       }
     },
+    "@emotion/css-prettifier": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css-prettifier/-/css-prettifier-1.2.0.tgz",
+      "integrity": "sha512-p+9m/5fp61i90CGUT+516glGBXWoEHgSelybqR+5vlX6Kb+Z0rkOfEMFqTBwYMRxXZTitibZERl32n2yPma7Dw==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.9.0",
+        "stylis": "4.2.0"
+      }
+    },
     "@emotion/hash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
@@ -22157,11 +22210,23 @@
         "@emotion/memoize": "^0.9.0"
       }
     },
+    "@emotion/jest": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.13.0.tgz",
+      "integrity": "sha512-XyoUbJ9fthKdlXjTvjzd6aQ8yVWe68InZawFdGTFkJQRW44rsLHK1qjKB/+L7RiGgdm0BYFv7+tz8znQzRQOBw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/css-prettifier": "^1.1.4",
+        "chalk": "^4.1.0",
+        "specificity": "^0.4.1",
+        "stylis": "4.2.0"
+      }
+    },
     "@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "peer": true
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "@emotion/react": {
       "version": "11.13.3",
@@ -33732,6 +33797,12 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -34011,8 +34082,7 @@
     "stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "peer": true
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
+    "@emotion/jest": "^11.13.0",
     "@mui/types": "^7.4.0",
     "@next/eslint-plugin-next": "^14.2.28",
     "@storybook/addon-actions": "^8.6.4",

--- a/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
+++ b/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
@@ -1,0 +1,63 @@
+import { LinkProps, Link as MLink, Typography } from "@mui/material";
+import { CellContext, RowData } from "@tanstack/react-table";
+import { BaseComponentProps } from "components/types";
+import React from "react";
+import { isValidUrl } from "../../../../../../common/utils";
+import { TYPOGRAPHY_PROPS } from "../../../../../../styles/common/mui/typography";
+import { isClientSideNavigation } from "../../../../../Links/common/utils";
+import { getComponent, getRelAttribute, getTargetAttribute } from "./utils";
+
+export const LinkCell = <
+  T extends RowData,
+  TValue extends LinkProps = LinkProps
+>({
+  getValue,
+}: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {
+  const props = getValue();
+  const {
+    children,
+    className,
+    color,
+    href = "",
+    rel,
+    target,
+    underline,
+    ...linkProps
+  } = props;
+
+  // Determine if the href should use client-side navigation.
+  const isClientSide = isClientSideNavigation(href);
+
+  // Determine if the href is valid.
+  const isValid = isClientSide || isValidUrl(href);
+
+  // If the href is invalid, return a Typography component.
+  if (!isValid)
+    return (
+      <Typography
+        className={className}
+        color={TYPOGRAPHY_PROPS.COLOR.INHERIT}
+        component="span"
+        variant={TYPOGRAPHY_PROPS.VARIANT.INHERIT}
+        {...linkProps}
+      >
+        {children}
+      </Typography>
+    );
+
+  // If the href is valid, return a Link component.
+  return (
+    <MLink
+      className={className}
+      color={color}
+      component={getComponent(href, isClientSide)}
+      href={href}
+      rel={getRelAttribute(rel, isClientSide)}
+      target={getTargetAttribute(target, isClientSide)}
+      underline={underline}
+      {...linkProps}
+    >
+      {children}
+    </MLink>
+  );
+};

--- a/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
+++ b/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
@@ -14,6 +14,7 @@ export const LinkCell = <
   getValue,
 }: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {
   const props = getValue();
+  if (!props) return null;
   const {
     children,
     className,

--- a/src/components/Table/components/TableCell/components/LinkCell/stories/args.ts
+++ b/src/components/Table/components/TableCell/components/LinkCell/stories/args.ts
@@ -1,0 +1,35 @@
+import { ComponentProps } from "react";
+import { TYPOGRAPHY_PROPS } from "../../../../../../../styles/common/mui/typography";
+import { LinkCell } from "../linkCell";
+import { GetValue } from "./types";
+
+export const CLIENT_SIDE_ARGS: Partial<ComponentProps<typeof LinkCell>> = {
+  getValue: (() => ({
+    children: "Explore",
+    href: "/",
+  })) as GetValue,
+};
+
+export const EXTERNAL_ARGS: Partial<ComponentProps<typeof LinkCell>> = {
+  getValue: (() => ({
+    children: "Explore",
+    href: "https://www.example.com",
+  })) as GetValue,
+};
+
+export const INVALID_ARGS: Partial<ComponentProps<typeof LinkCell>> = {
+  getValue: (() => ({
+    children: "Explore",
+  })) as GetValue,
+};
+
+export const WITH_CUSTOM_STYLE_ARGS: Partial<ComponentProps<typeof LinkCell>> =
+  {
+    getValue: (() => ({
+      children: "Explore",
+      color: "success",
+      href: "/",
+      underline: "none",
+      variant: TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_SMALL_400,
+    })) as GetValue,
+  };

--- a/src/components/Table/components/TableCell/components/LinkCell/stories/linkCell.stories.tsx
+++ b/src/components/Table/components/TableCell/components/LinkCell/stories/linkCell.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { LinkCell } from "../linkCell";
+import {
+  CLIENT_SIDE_ARGS,
+  EXTERNAL_ARGS,
+  INVALID_ARGS,
+  WITH_CUSTOM_STYLE_ARGS,
+} from "./args";
+
+const meta: Meta<typeof LinkCell> = {
+  component: LinkCell,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ClientSide: Story = {
+  args: CLIENT_SIDE_ARGS,
+};
+
+export const External: Story = {
+  args: EXTERNAL_ARGS,
+};
+
+export const Invalid: Story = {
+  args: INVALID_ARGS,
+};
+
+export const WithCustomStyle: Story = {
+  args: WITH_CUSTOM_STYLE_ARGS,
+};

--- a/src/components/Table/components/TableCell/components/LinkCell/stories/types.ts
+++ b/src/components/Table/components/TableCell/components/LinkCell/stories/types.ts
@@ -1,0 +1,4 @@
+import { LinkProps } from "@mui/material";
+import { CellContext, RowData } from "@tanstack/react-table";
+
+export type GetValue = CellContext<RowData, LinkProps>["getValue"];

--- a/src/components/Table/components/TableCell/components/LinkCell/utils.ts
+++ b/src/components/Table/components/TableCell/components/LinkCell/utils.ts
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ElementType } from "react";
+import { isValidUrl } from "../../../../../../common/utils";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "../../../../../Links/common/entities";
+import {
+  assertAnchorRelAttribute,
+  assertAnchorTargetAttribute,
+} from "../../../../../common/Link/typeGuards";
+
+/**
+ * Returns the component to use for a link based on the given href and client-side navigation flag.
+ * @param href - The href attribute to use.
+ * @param isClientSide - Whether the link is a client-side navigation.
+ * @returns The component to use for the link.
+ */
+export function getComponent(href: string, isClientSide: boolean): ElementType {
+  if (isClientSide) return Link; // Use Next/Link for client-side navigation.
+  if (isValidUrl(href)) return "a"; // Use anchor tag for external links.
+  return "span"; // Use span for invalid links.
+}
+
+/**
+ * Returns the rel attribute for a link based on the given rel and client-side navigation flag.
+ * @param rel - The rel attribute to use.
+ * @param isClientSideNavigation - Whether the link is a client-side navigation.
+ * @returns The rel attribute for the link.
+ */
+export function getRelAttribute(
+  rel: string | undefined,
+  isClientSideNavigation: boolean
+): string {
+  if (rel) {
+    assertAnchorRelAttribute(rel);
+    return rel;
+  }
+  return isClientSideNavigation
+    ? REL_ATTRIBUTE.NO_OPENER
+    : REL_ATTRIBUTE.NO_OPENER_NO_REFERRER;
+}
+
+/**
+ * Returns the target attribute for a link based on the given target and client-side navigation flag.
+ * @param target - The target attribute to use.
+ * @param isClientSideNavigation - Whether the link is a client-side navigation.
+ * @returns The target attribute for the link.
+ */
+export function getTargetAttribute(
+  target: string | undefined,
+  isClientSideNavigation: boolean
+): string {
+  if (target) {
+    assertAnchorTargetAttribute(target);
+    return target;
+  }
+  return isClientSideNavigation ? ANCHOR_TARGET.SELF : ANCHOR_TARGET.BLANK;
+}

--- a/src/components/common/Link/typeGuards.ts
+++ b/src/components/common/Link/typeGuards.ts
@@ -1,0 +1,35 @@
+import { ANCHOR_TARGET, REL_ATTRIBUTE } from "../../Links/common/entities";
+
+/**
+ * Asserts that the given value is a valid REL_ATTRIBUTE.
+ * @param value - Value to assert.
+ * @throws Error if the value is not a valid REL_ATTRIBUTE.
+ */
+export function assertAnchorRelAttribute(
+  value: string
+): asserts value is REL_ATTRIBUTE {
+  if (!Object.values(REL_ATTRIBUTE).includes(value as REL_ATTRIBUTE)) {
+    throw new Error(
+      `Expecting rel attribute: ${value} to be one of ${Object.values(
+        REL_ATTRIBUTE
+      )}`
+    );
+  }
+}
+
+/**
+ * Asserts that the given value is a valid ANCHOR_TARGET.
+ * @param value - Value to assert.
+ * @throws Error if the value is not a valid ANCHOR_TARGET.
+ */
+export function assertAnchorTargetAttribute(
+  value: string
+): asserts value is ANCHOR_TARGET {
+  if (!Object.values(ANCHOR_TARGET).includes(value as ANCHOR_TARGET)) {
+    throw new Error(
+      `Expecting anchor target: ${value} to be one of ${Object.values(
+        ANCHOR_TARGET
+      )}`
+    );
+  }
+}

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -915,6 +915,11 @@ export const MuiLink: Components["MuiLink"] = {
       textDecorationSkipInk: "none",
       textUnderlinePosition: "from-font",
     },
+    underlineNone: {
+      "&:hover": {
+        textDecoration: "none",
+      },
+    },
   },
 };
 

--- a/tests/linkCell.test.tsx
+++ b/tests/linkCell.test.tsx
@@ -1,0 +1,91 @@
+import { matchers } from "@emotion/jest";
+import { composeStories } from "@storybook/react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "../src/components/Links/common/entities";
+import * as stories from "../src/components/Table/components/TableCell/components/LinkCell/stories/linkCell.stories";
+
+expect.extend(matchers);
+
+const { ClientSide, External, Invalid, WithCustomStyle } =
+  composeStories(stories);
+
+const STYLE_RULE_PROPERTIES = {
+  TEXT_DECORATION: "text-decoration",
+};
+
+const STYLE_RULE_VALUES = {
+  NONE: "none",
+  UNDERLINE: "underline",
+};
+
+describe("TableCell, LinkCell", () => {
+  afterEach(() => {});
+
+  it("renders client-side link", async () => {
+    render(<ClientSide />);
+    const anchorEl = screen.getByText("Explore");
+    expect(anchorEl).toBeDefined();
+    expect(anchorEl?.getAttribute("href")).toBe("/");
+    expect(anchorEl?.getAttribute("rel")).toBe(REL_ATTRIBUTE.NO_OPENER);
+    expect(anchorEl?.getAttribute("target")).toBe(ANCHOR_TARGET.SELF);
+    // Expect MuiLink-underlineAlways class and underline style.
+    expect(anchorEl).toHaveClass("MuiLink-underlineAlways");
+    expect(anchorEl).toHaveStyleRule(
+      STYLE_RULE_PROPERTIES.TEXT_DECORATION,
+      STYLE_RULE_VALUES.UNDERLINE
+    );
+  });
+
+  it("renders external link", async () => {
+    render(<External />);
+    const anchorEl = screen.getByText("Explore");
+    expect(anchorEl).toBeDefined();
+    expect(anchorEl?.getAttribute("href")).toBe("https://www.example.com");
+    expect(anchorEl?.getAttribute("rel")).toBe(
+      REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+    );
+    expect(anchorEl?.getAttribute("target")).toBe(ANCHOR_TARGET.BLANK);
+    // Expect MuiLink-underlineAlways class and underline style.
+    expect(anchorEl).toHaveClass("MuiLink-underlineAlways");
+    expect(anchorEl).toHaveStyleRule(
+      STYLE_RULE_PROPERTIES.TEXT_DECORATION,
+      STYLE_RULE_VALUES.UNDERLINE
+    );
+  });
+
+  it("renders plain text for invalid link", () => {
+    render(<Invalid />);
+    const spanEl = screen.getByText("Explore");
+    expect(spanEl.tagName).toBe("SPAN");
+    expect(spanEl.getAttribute("href")).toBeNull();
+    expect(spanEl.getAttribute("rel")).toBeNull();
+    expect(spanEl.getAttribute("target")).toBeNull();
+    // Expect no MuiLink-root class and no underline style.
+    expect(spanEl).not.toHaveClass("MuiLink-root");
+    expect(spanEl).not.toHaveStyleRule(
+      STYLE_RULE_PROPERTIES.TEXT_DECORATION,
+      STYLE_RULE_VALUES.UNDERLINE
+    );
+  });
+
+  it("renders link with custom link props", async () => {
+    render(<WithCustomStyle />);
+    const anchorEl = screen.getByText("Explore");
+    // Expect MuiLink-underlineNone class and no underline style.
+    expect(anchorEl).toHaveClass("MuiLink-underlineNone");
+    expect(anchorEl).toHaveStyleRule(
+      STYLE_RULE_PROPERTIES.TEXT_DECORATION,
+      STYLE_RULE_VALUES.NONE
+    );
+    expect(anchorEl).toHaveStyleRule(
+      STYLE_RULE_PROPERTIES.TEXT_DECORATION,
+      STYLE_RULE_VALUES.NONE,
+      { target: ":hover" }
+    );
+  });
+});

--- a/tests/linkCell.test.tsx
+++ b/tests/linkCell.test.tsx
@@ -24,8 +24,6 @@ const STYLE_RULE_VALUES = {
 };
 
 describe("TableCell, LinkCell", () => {
-  afterEach(() => {});
-
   it("renders client-side link", async () => {
     render(<ClientSide />);
     const anchorEl = screen.getByText("Explore");


### PR DESCRIPTION
Closes #468.

This pull request introduces a new `LinkCell` component for rendering links in a table cell, along with supporting utilities, stories, and tests. The changes focus on adding functionality for client-side and external navigation, handling invalid links gracefully, and providing customization options.

### New `LinkCell` Component and Utilities:
* Added the `LinkCell` component to render links or fallback to plain text for invalid URLs, with support for client-side navigation using `next/link` (`src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx`).
* Introduced utility functions (`getComponent`, `getRelAttribute`, `getTargetAttribute`) to determine the appropriate link component, `rel`, and `target` attributes based on navigation type (`src/components/Table/components/TableCell/components/LinkCell/utils.ts`).
* Added type guards (`assertAnchorRelAttribute`, `assertAnchorTargetAttribute`) to validate `rel` and `target` attributes (`src/components/common/Link/typeGuards.ts`).

### Stories for `LinkCell`:
* Created Storybook stories for different use cases of the `LinkCell` component, including client-side, external, invalid links, and custom styles (`src/components/Table/components/TableCell/components/LinkCell/stories/linkCell.stories.tsx`).
* Added reusable arguments for the stories to simplify configuration (`src/components/Table/components/TableCell/components/LinkCell/stories/args.ts`).

### Testing:
* Added comprehensive unit tests for the `LinkCell` component to verify rendering behavior for client-side links, external links, invalid links, and custom styles (`tests/linkCell.test.tsx`).

### Styling Enhancements:
* Updated the `MuiLink` theme to support a `underlineNone` style that removes underline on hover (`src/theme/common/components.ts`).

### Dependency Updates:
* Added `@emotion/jest` as a development dependency for testing styled components (`package.json`).