### PR TITLE
fix: fix data dictionary basiccell component to render boolean values as string (#474)

### DIFF
--- a/src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsx
+++ b/src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsx
@@ -2,15 +2,19 @@ import { Typography } from "@mui/material";
 import { CellContext, RowData } from "@tanstack/react-table";
 import React, { ReactNode } from "react";
 import { TYPOGRAPHY_PROPS } from "../../../../../../styles/common/mui/typography";
+import { parseValue } from "./utils";
 
-export const BasicCell = <T extends RowData, TValue>({
+export const BasicCell = <
+  T extends RowData,
+  TValue extends ReactNode = ReactNode
+>({
   getValue,
 }: CellContext<T, TValue>): JSX.Element | null => {
   const value = getValue();
   if (value === undefined || value === null) return null;
   return (
     <Typography variant={TYPOGRAPHY_PROPS.VARIANT.INHERIT}>
-      {value as ReactNode}
+      {parseValue(value)}
     </Typography>
   );
 };

--- a/src/components/DataDictionary/components/Table/components/BasicCell/utils.ts
+++ b/src/components/DataDictionary/components/Table/components/BasicCell/utils.ts
@@ -2,8 +2,10 @@ import { ReactNode } from "react";
 
 /**
  * Returns a parsed value based on the original value.
+ * If the value is a boolean, it is converted to its string representation ("true" or "false").
+ * For all other types of ReactNode, the value is returned unchanged.
  * @param value - The original value.
- * @returns Parsed value.
+ * @returns Parsed value or original value.
  */
 export function parseValue(value: ReactNode): ReactNode {
   if (typeof value === "boolean") return value.toString();

--- a/src/components/DataDictionary/components/Table/components/BasicCell/utils.ts
+++ b/src/components/DataDictionary/components/Table/components/BasicCell/utils.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+/**
+ * Returns a parsed value based on the original value.
+ * @param value - The original value.
+ * @returns Parsed value.
+ */
+export function parseValue(value: ReactNode): ReactNode {
+  if (typeof value === "boolean") return value.toString();
+  return value;
+}


### PR DESCRIPTION
Closes #474.

This pull request refactors the `BasicCell` component in the `DataDictionary` table to improve type safety and enhance value rendering. The main changes include extending the `BasicCell` component's type definitions and introducing a utility function to handle value parsing.

### Changes to `BasicCell` component:

* Updated the `BasicCell` component to extend the `TValue` type parameter, defaulting it to `ReactNode`, for improved type safety and flexibility. (`src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsx`, [src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsxR5-R17](diffhunk://#diff-3f04d2aba4efa174314604d83028ecc60a273fcbd9c78b81e8c4859d436296f3R5-R17))
* Replaced direct value rendering with a call to the newly introduced `parseValue` utility function for consistent handling of different value types. (`src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsx`, [src/components/DataDictionary/components/Table/components/BasicCell/basicCell.tsxR5-R17](diffhunk://#diff-3f04d2aba4efa174314604d83028ecc60a273fcbd9c78b81e8c4859d436296f3R5-R17))

### Addition of `parseValue` utility:

* Added a `parseValue` function to handle special cases, such as converting boolean values to strings, ensuring consistent rendering of cell values. (`src/components/DataDictionary/components/Table/components/BasicCell/utils.ts`, [src/components/DataDictionary/components/Table/components/BasicCell/utils.tsR1-R11](diffhunk://#diff-5664fb59cee47dcf14e3532a1e0b3a30c45b1ffbfdccd00ef2028c49a8a95b40R1-R11))