### PR TITLE
feat!: make data dictionary config generic with attribute as default (#476)

### DIFF
--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -1,5 +1,4 @@
-import { ColumnDef } from "@tanstack/react-table";
-import { GridTrackSize } from "../config/entities";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 
 /**
  * Model of a value of a metadata class.
@@ -20,11 +19,6 @@ export interface Attribute {
 }
 
 /**
- * Model of attribute key types; used mostly when building data dictionary column definitions.
- */
-export type AttributeValueTypes<TValue = unknown> = TValue;
-
-/**
  * Filterable metadata keys.
  */
 export type CategoryKey = string;
@@ -41,8 +35,8 @@ export interface CategoryTag {
 /**
  * Model of a metadata class, to be specified manually or built from LinkML schema.
  */
-export interface Class {
-  attributes: Attribute[];
+export interface Class<T extends RowData = Attribute> {
+  attributes: T[];
   description: string;
   name: string; // Programmatic name or key (e.g. cell, sample)
   title: string; // Display name
@@ -62,11 +56,11 @@ export type DataDictionaryPrefix = Record<string, string>;
 /**
  * Model of a metadata dictionary containing a set of classes and their definitions.
  */
-export interface DataDictionary {
+export interface DataDictionary<T extends RowData = Attribute> {
   annotations?: {
     [key in keyof DataDictionaryPrefix]: string; // Prefix to title e.g. "cxg": "CELLxGENE"
   };
-  classes: Class[];
+  classes: Class<T>[];
   description?: string; // Free text description of data dictionary
   name: string; // Programmatic name or key (e.g. tier1, hca)
   prefixes?: DataDictionaryPrefix;
@@ -74,29 +68,12 @@ export interface DataDictionary {
 }
 
 /**
- * Display model of a data dictionary column.
- */
-export interface DataDictionaryColumnDef {
-  attributeAccessorFnName?: string; // Name of accessor function to map to.
-  attributeCellName?: string; // Name of cell renderer component to map to.
-  attributeDisplayName: string;
-  attributeSlotName: string;
-  // Adding width here for now; possibly revisit separating column def and UI.
-  width:
-    | Omit<GridTrackSize, "GridTrackMinMax">
-    | {
-        max: string;
-        min: string;
-      };
-}
-
-/**
  * Configuration of data dictionary; contains schema definition (that is, the actual data
  * dictionary) as well as column def for displaying the data dictionary.
  */
-export interface DataDictionaryConfig {
-  columnDefs: ColumnDef<Attribute, AttributeValueTypes>[];
-  dataDictionary: DataDictionary;
+export interface DataDictionaryConfig<T extends RowData = Attribute> {
+  columnDefs: ColumnDef<T, T[keyof T]>[];
+  dataDictionary: DataDictionary<T>;
 }
 
 /**

--- a/src/components/DataDictionary/components/Entities/entities.tsx
+++ b/src/components/DataDictionary/components/Entities/entities.tsx
@@ -1,20 +1,22 @@
 import { Grid } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
 import React from "react";
+import { Attribute } from "../../../../common/entities";
 import { Entity } from "../Entity/entity";
 import { GRID_PROPS } from "./constants";
 import { ClassesProps } from "./types";
 
-export const Entities = ({
+export const Entities = <T extends RowData = Attribute>({
   classes,
   columnDefs,
   spacing,
-}: ClassesProps): JSX.Element => {
+}: ClassesProps<T>): JSX.Element => {
   return (
     <Grid {...GRID_PROPS}>
-      {classes.map((classData) => (
+      {classes.map((cls) => (
         <Entity
-          key={classData.name}
-          class={classData}
+          key={cls.name}
+          class={cls}
           columnDefs={columnDefs}
           spacing={spacing}
         />

--- a/src/components/DataDictionary/components/Entities/types.ts
+++ b/src/components/DataDictionary/components/Entities/types.ts
@@ -1,13 +1,9 @@
-import { ColumnDef } from "@tanstack/react-table";
-import {
-  Attribute,
-  AttributeValueTypes,
-  Class,
-} from "../../../../common/entities";
+import { ColumnDef, RowData } from "@tanstack/react-table";
+import { Attribute, Class } from "../../../../common/entities";
 import { LayoutSpacing } from "../../hooks/UseLayoutSpacing/types";
 
-export interface ClassesProps {
-  classes: Class[];
-  columnDefs: ColumnDef<Attribute, AttributeValueTypes>[];
+export interface ClassesProps<T extends RowData = Attribute> {
+  classes: Class<T>[];
+  columnDefs: ColumnDef<T, T[keyof T]>[];
   spacing?: LayoutSpacing;
 }

--- a/src/components/DataDictionary/components/Entity/entity.tsx
+++ b/src/components/DataDictionary/components/Entity/entity.tsx
@@ -1,5 +1,7 @@
 import { Grid, Typography } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
 import React from "react";
+import { Attribute } from "../../../../common/entities";
 import { TYPOGRAPHY_PROPS } from "../../../../styles/common/mui/typography";
 import { AnchorLink } from "../../../common/AnchorLink/anchorLink";
 import { useTable } from "../Table/hook";
@@ -8,29 +10,29 @@ import { GRID_PROPS } from "./constants";
 import { StyledTypography } from "./entity.styles";
 import { EntityProps } from "./types";
 
-export const Entity = ({
-  class: classData,
+export const Entity = <T extends RowData = Attribute>({
+  class: cls,
   columnDefs,
   spacing,
-}: EntityProps): JSX.Element => {
-  const table = useTable(classData.attributes, columnDefs);
+}: EntityProps<T>): JSX.Element => {
+  const table = useTable<T>(cls.attributes, columnDefs);
   return (
     <Grid {...GRID_PROPS} rowGap={4}>
       <Grid {...GRID_PROPS} rowGap={1}>
         <StyledTypography
           component="h3"
-          id={classData.name}
+          id={cls.name}
           variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_SMALL}
           {...spacing}
         >
-          {classData.title} <AnchorLink anchorLink={classData.name} />
+          {cls.title} <AnchorLink anchorLink={cls.name} />
         </StyledTypography>
         <Typography
           color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
           component="div"
           variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400_2_LINES}
         >
-          {classData.description}
+          {cls.description}
         </Typography>
       </Grid>
       <Table table={table} />

--- a/src/components/DataDictionary/components/Entity/types.ts
+++ b/src/components/DataDictionary/components/Entity/types.ts
@@ -1,13 +1,9 @@
-import { ColumnDef } from "@tanstack/react-table";
-import {
-  Attribute,
-  AttributeValueTypes,
-  Class,
-} from "../../../../common/entities";
+import { ColumnDef, RowData } from "@tanstack/react-table";
+import { Attribute, Class } from "../../../../common/entities";
 import { LayoutSpacing } from "../../hooks/UseLayoutSpacing/types";
 
-export interface EntityProps {
-  class: Class;
-  columnDefs: ColumnDef<Attribute, AttributeValueTypes>[];
+export interface EntityProps<T extends RowData = Attribute> {
+  class: Class<T>;
+  columnDefs: ColumnDef<T, T[keyof T]>[];
   spacing?: LayoutSpacing;
 }

--- a/src/components/DataDictionary/components/Outline/utils.ts
+++ b/src/components/DataDictionary/components/Outline/utils.ts
@@ -1,4 +1,5 @@
-import { Class } from "../../../../common/entities";
+import { RowData } from "@tanstack/react-table";
+import { Attribute, Class } from "../../../../common/entities";
 import { OutlineItem } from "../../../Layout/components/Outline/types";
 
 /**
@@ -6,7 +7,9 @@ import { OutlineItem } from "../../../Layout/components/Outline/types";
  * @param classes - Class entities.
  * @returns Outline items.
  */
-export function buildClassesOutline(classes: Class[]): OutlineItem[] {
+export function buildClassesOutline<T extends RowData = Attribute>(
+  classes: Class<T>[]
+): OutlineItem[] {
   return classes.map(({ name, title }) => {
     return {
       depth: 2,

--- a/src/components/DataDictionary/components/Table/hook.ts
+++ b/src/components/DataDictionary/components/Table/hook.ts
@@ -1,13 +1,21 @@
-import { ColumnDef, Table, useReactTable } from "@tanstack/react-table";
-import { Attribute, AttributeValueTypes } from "../../../../common/entities";
+import {
+  ColumnDef,
+  RowData,
+  Table,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Attribute } from "../../../../common/entities";
 import { useTableOptions } from "./options/hook";
 
-export const useTable = (
-  data: Attribute[],
-  columnDefs: ColumnDef<Attribute, AttributeValueTypes>[]
-): Table<Attribute> => {
-  const tableOptions = useTableOptions();
-  return useReactTable<Attribute>({
+export const useTable = <T extends RowData = Attribute>(
+  data: T[],
+  columnDefs: ColumnDef<T, T[keyof T]>[]
+): Table<T> => {
+  // Table options.
+  const tableOptions = useTableOptions<T>();
+
+  // Table instance.
+  return useReactTable<T>({
     ...tableOptions,
     columns: columnDefs,
     data,

--- a/src/components/DataDictionary/components/Table/options/core/constants.ts
+++ b/src/components/DataDictionary/components/Table/options/core/constants.ts
@@ -1,10 +1,9 @@
-import { CoreOptions, getCoreRowModel } from "@tanstack/react-table";
-import { Attribute } from "../../../../../../common/entities";
+import { CoreOptions, getCoreRowModel, RowData } from "@tanstack/react-table";
 import { ROW_POSITION } from "../../../../../Table/features/RowPosition/constants";
 import { ROW_PREVIEW } from "../../../../../Table/features/RowPreview/constants";
 
 export const CORE_OPTIONS: Pick<
-  CoreOptions<Attribute>,
+  CoreOptions<RowData>,
   "_features" | "getCoreRowModel"
 > = {
   _features: [ROW_POSITION, ROW_PREVIEW],

--- a/src/components/DataDictionary/components/Table/options/hook.ts
+++ b/src/components/DataDictionary/components/Table/options/hook.ts
@@ -1,10 +1,10 @@
-import { TableOptions } from "@tanstack/react-table";
+import { RowData, TableOptions } from "@tanstack/react-table";
 import { Attribute } from "../../../../../common/entities";
 import { CORE_OPTIONS } from "./core/constants";
 import { SORTING_OPTIONS } from "./sorting/constants";
 
-export const useTableOptions = (): Omit<
-  TableOptions<Attribute>,
+export const useTableOptions = <T extends RowData = Attribute>(): Omit<
+  TableOptions<T>,
   "columns" | "data"
 > => {
   return {

--- a/src/components/DataDictionary/components/Table/options/sorting/constants.ts
+++ b/src/components/DataDictionary/components/Table/options/sorting/constants.ts
@@ -1,9 +1,5 @@
-import { SortingOptions } from "@tanstack/react-table";
-import { Attribute } from "../../../../../../common/entities";
+import { RowData, SortingOptions } from "@tanstack/react-table";
 
-export const SORTING_OPTIONS: Pick<
-  SortingOptions<Attribute>,
-  "enableSorting"
-> = {
+export const SORTING_OPTIONS: Pick<SortingOptions<RowData>, "enableSorting"> = {
   enableSorting: false,
 };

--- a/src/components/DataDictionary/components/Table/table.tsx
+++ b/src/components/DataDictionary/components/Table/table.tsx
@@ -1,4 +1,5 @@
 import { TableContainer } from "@mui/material";
+import { RowData } from "@tanstack/react-table";
 import React from "react";
 import { TableBody } from "../../../Detail/components/Table/components/TableBody/tableBody";
 import { ROW_DIRECTION } from "../../../Table/common/entities";
@@ -9,7 +10,9 @@ import { GridPaper } from "../../../common/Paper/paper.styles";
 import { StyledRoundedPaper } from "./table.styles";
 import { TableProps } from "./types";
 
-export const Table = ({ table }: TableProps): JSX.Element => {
+export const Table = <T extends RowData>({
+  table,
+}: TableProps<T>): JSX.Element => {
   return (
     <StyledRoundedPaper variant="table">
       <GridPaper>

--- a/src/components/DataDictionary/components/Table/types.ts
+++ b/src/components/DataDictionary/components/Table/types.ts
@@ -1,6 +1,5 @@
-import { Table } from "@tanstack/react-table";
-import { Attribute } from "../../../../common/entities";
+import { RowData, Table } from "@tanstack/react-table";
 
-export interface TableProps {
-  table: Table<Attribute>;
+export interface TableProps<T extends RowData> {
+  table: Table<T>;
 }

--- a/src/components/DataDictionary/dataDictionary.tsx
+++ b/src/components/DataDictionary/dataDictionary.tsx
@@ -1,4 +1,6 @@
+import { RowData } from "@tanstack/react-table";
 import React, { useMemo } from "react";
+import { Attribute } from "../../common/entities";
 import { Entities } from "./components/Entities/entities";
 import { EntitiesLayout as DefaultEntitiesLayout } from "./components/Layout/components/EntitiesLayout/entitiesLayout";
 import { OutlineLayout as DefaultOutlineLayout } from "./components/Layout/components/OutlineLayout/outlineLayout";
@@ -11,7 +13,7 @@ import { useDataDictionary } from "./hooks/UseDataDictionary/hook";
 import { useLayoutSpacing } from "./hooks/UseLayoutSpacing/hook";
 import { DataDictionaryProps } from "./types";
 
-export const DataDictionary = ({
+export const DataDictionary = <T extends RowData = Attribute>({
   className,
   EntitiesLayout = DefaultEntitiesLayout,
   Outline = DefaultOutline,
@@ -19,7 +21,7 @@ export const DataDictionary = ({
   Title = DefaultTitle,
   TitleLayout = DefaultTitleLayout,
 }: DataDictionaryProps): JSX.Element => {
-  const { classes, columnDefs } = useDataDictionary();
+  const { classes, columnDefs } = useDataDictionary<T>();
   const { spacing } = useLayoutSpacing();
   const outline = useMemo(() => buildClassesOutline(classes), [classes]);
   return (

--- a/src/components/DataDictionary/hooks/UseDataDictionary/hook.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionary/hook.ts
@@ -1,13 +1,20 @@
+import { RowData } from "@tanstack/react-table";
 import { useMemo } from "react";
+import { Attribute, DataDictionaryConfig } from "../../../../common/entities";
 import { useConfig } from "../../../../hooks/useConfig";
 import { UseDataDictionary } from "./types";
 
-export const useDataDictionary = (): UseDataDictionary => {
+export const useDataDictionary = <
+  T extends RowData = Attribute
+>(): UseDataDictionary<T> => {
   const {
     config: { dataDictionaries: dataDictionaryConfigs },
   } = useConfig();
 
-  const dataDictionaryConfig = dataDictionaryConfigs?.[0]; // TODO: Handle multiple data dictionaries
+  const dataDictionaryConfig = dataDictionaryConfigs?.[0] as
+    | DataDictionaryConfig<T>
+    | undefined; // TODO: Handle multiple data dictionaries
+
   return useMemo(() => {
     const classes = dataDictionaryConfig?.dataDictionary?.classes || [];
     const columnDefs = dataDictionaryConfig?.columnDefs || [];

--- a/src/components/DataDictionary/hooks/UseDataDictionary/types.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionary/types.ts
@@ -1,11 +1,7 @@
-import { ColumnDef } from "@tanstack/react-table";
-import {
-  Attribute,
-  AttributeValueTypes,
-  Class,
-} from "../../../../common/entities";
+import { ColumnDef, RowData } from "@tanstack/react-table";
+import { Attribute, Class } from "../../../../common/entities";
 
-export interface UseDataDictionary {
-  classes: Class[];
-  columnDefs: ColumnDef<Attribute, AttributeValueTypes>[];
+export interface UseDataDictionary<T extends RowData = Attribute> {
+  classes: Class<T>[];
+  columnDefs: ColumnDef<T, T[keyof T]>[];
 }

--- a/src/components/Table/components/TableCell/components/ChipCell/chipCell.tsx
+++ b/src/components/Table/components/TableCell/components/ChipCell/chipCell.tsx
@@ -1,14 +1,16 @@
 import { Chip, ChipProps } from "@mui/material";
 import { CellContext, RowData } from "@tanstack/react-table";
 import React from "react";
+import { BaseComponentProps } from "../../../../../types";
 
 export const ChipCell = <
   T extends RowData,
   TValue extends ChipProps = ChipProps
 >({
+  className,
   getValue,
-}: CellContext<T, TValue>): JSX.Element | null => {
+}: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {
   const props = getValue();
   if (!props) return null;
-  return <Chip {...props} />;
+  return <Chip className={className} {...props} />;
 };

--- a/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
+++ b/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
@@ -11,13 +11,13 @@ export const LinkCell = <
   T extends RowData,
   TValue extends LinkProps = LinkProps
 >({
+  className,
   getValue,
 }: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {
   const props = getValue();
   if (!props) return null;
   const {
     children,
-    className,
     color,
     href = "",
     rel,


### PR DESCRIPTION
Closes #476.

This pull request introduces a significant refactor to the data dictionary components, enabling support for generic row data types (`RowData`) across the system. The changes primarily focus on improving type safety, reusability, and extensibility by replacing hardcoded `Attribute` types with generics and updating related interfaces, components, and hooks accordingly.

### Core Type System Enhancements:
* Updated the `Class` and `DataDictionary` interfaces in `src/common/entities.ts` to support generic row data types (`RowData`), making them more flexible and reusable. [[1]](diffhunk://#diff-55072a7254a52c5566b398a27313fb8df9f811f660083311d883d1beeb911d6cL44-R39) [[2]](diffhunk://#diff-55072a7254a52c5566b398a27313fb8df9f811f660083311d883d1beeb911d6cL65-R76)
* Removed the `AttributeValueTypes` type and replaced it with a more generic approach using `T[keyof T]` for column definitions. [[1]](diffhunk://#diff-55072a7254a52c5566b398a27313fb8df9f811f660083311d883d1beeb911d6cL22-L26) [[2]](diffhunk://#diff-55072a7254a52c5566b398a27313fb8df9f811f660083311d883d1beeb911d6cL65-R76)

### Component Refactoring for Generics:
* Refactored the `Entities` and `Entity` components to support generic row data types, allowing them to handle different data structures dynamically. [[1]](diffhunk://#diff-d2f7623d383318c9100fc01c701c7ff61338f520fdfcefdc261a7d8bc6e27dd5R2-R19) [[2]](diffhunk://#diff-fa0a70bc311fb3279f9fe96c4e72f4b90214da9c2020d8b9a5c05b0d39b09855L11-R35)
* Updated the `Table` component and its related hooks (`useTable`, `useTableOptions`) to use generics, enabling type-safe table operations for various row data types. [[1]](diffhunk://#diff-9b67651974278ec4c1b24b6ce19b277cc3fe6e76cc8d55f35490568f03147b1eL1-R18) [[2]](diffhunk://#diff-ddb27ecef9abd5540ef4255303a5754fba8af799bee017c64c86a9db166abc81L1-R7) [[3]](diffhunk://#diff-4764775786fddeeb789131b5732379710f66adba31e74344f777edd1d6c79b26L12-R15)

### Hook and Utility Updates:
* Modified the `useDataDictionary` hook to support generic row data types, ensuring compatibility with the updated `DataDictionaryConfig` interface. [[1]](diffhunk://#diff-7fee40131b7ba113c3909791e2aecbe48535a0be4224bf66ba07e3aef92be2e1R1-R17) [[2]](diffhunk://#diff-dac775329d4565ecb0865e3c298c059528d97c728fa07960e5903d033615ccaaL1-R6)
* Updated utility functions like `buildClassesOutline` to handle generic row data types, ensuring consistent behavior across the system.

### Miscellaneous Updates:
* Enhanced table cell components (`ChipCell`, `LinkCell`) to include additional props like `className` and support generic row data types for better customization. [[1]](diffhunk://#diff-419a745ebef4a83658b741e0839ceb051b914df69bf3d6c6ac7adc31a7d6f4c9R4-R15) [[2]](diffhunk://#diff-66fef8c3a577ebf3c49f845a04adb41745b6b61c606bc83485e49b0030e6fddbR14-L20)
* Replaced redundant imports and adjusted type references across multiple files to align with the new generic type system. [[1]](diffhunk://#diff-4bdb87f2619f46d9efc1f74c5137b705eaa5acb6fde101233ece3e78377b7c81L1-R7) [[2]](diffhunk://#diff-bb0125f62e0271782f4199142cac6b5f94055d4a60f8637826efadd9106b1a06L1-R6) [[3]](diffhunk://#diff-967b32584d74dba38007635b3d1a6e6e94c5a1ea378c4f5ac139d4a73406507aL1-R3)

These changes collectively make the system more modular and adaptable, paving the way for handling diverse data structures while maintaining type safety and clarity.