### PR TITLE
fix: prevent table column def and data mismatch for client side filtering (#484)

### DIFF
--- a/src/components/Index/index.tsx
+++ b/src/components/Index/index.tsx
@@ -25,7 +25,7 @@ export const Index = ({
 }: IndexProps): JSX.Element => {
   const { onChange, viewMode, viewStatus } = useEntitiesView();
   const { dimensions } = useLayoutDimensions();
-  const { table } = useTable();
+  const { table } = useTable({ entityListType });
   return (
     <IndexLayout className={className} marginTop={dimensions.header.height}>
       <Hero SideBarButton={SideBarButton} Summaries={Summaries} title={title} />

--- a/src/components/Index/table/hook.ts
+++ b/src/components/Index/table/hook.ts
@@ -40,10 +40,12 @@ import { RowPreviewState } from "../../Table/features/RowPreview/entities";
 import { buildBaseColumnDef } from "../../TableCreator/common/utils";
 import { useTableOptions } from "../../TableCreator/options/hook";
 import { createCell } from "./coreOptions/columns/cellFactory";
-import { UseTable } from "./types";
+import { UseTable, UseTableProps } from "./types";
 
-// eslint-disable-next-line sonarjs/cognitive-complexity -- TODO fix component length / complexity
-export const useTable = <T extends RowData>(): UseTable<T> => {
+export const useTable = <T extends RowData>({
+  entityListType,
+}: // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO fix complexity
+UseTableProps): UseTable<T> => {
   const { entityConfig } = useConfig();
   const exploreMode = useExploreMode();
   const { exploreDispatch, exploreState } = useExploreState();
@@ -209,6 +211,7 @@ export const useTable = <T extends RowData>(): UseTable<T> => {
 
   // Process explore response - client-side filtering only.
   useEffect(() => {
+    if (entityListType !== tabValue) return;
     if (!listItems || listItems.length === 0) return;
     if (clientFiltering) {
       exploreDispatch({
@@ -229,9 +232,11 @@ export const useTable = <T extends RowData>(): UseTable<T> => {
     allColumns,
     clientFiltering,
     columnFilters,
+    entityListType,
     exploreDispatch,
     listItems,
     rows,
+    tabValue,
   ]);
 
   return { table };

--- a/src/components/Index/table/types.ts
+++ b/src/components/Index/table/types.ts
@@ -3,3 +3,7 @@ import { RowData, Table } from "@tanstack/react-table";
 export interface UseTable<T extends RowData> {
   table: Table<T>;
 }
+
+export interface UseTableProps {
+  entityListType: string;
+}


### PR DESCRIPTION
Closes #484.

This pull request introduces changes to the `useTable` hook in the `Index` component to support an `entityListType` parameter, enabling more flexible table configurations. The most important changes involve updating the `useTable` hook's signature, adding a new `UseTableProps` interface, and ensuring proper handling of `entityListType` in the hook's logic.

### Updates to `useTable` Hook:

* **Added `entityListType` parameter to `useTable` hook**: The `useTable` hook now accepts an `entityListType` parameter via the new `UseTableProps` interface, allowing for more dynamic table behavior. (`[[1]](diffhunk://#diff-328057e5d539dd2de86abcc3770c26e51e260a9d60ac303ef6762193827d7584L43-R48)`, `[[2]](diffhunk://#diff-fa9bd9113a8581a6c793f6bb86ec6512d87498fe58b6296b93de80fe8aba78d6R6-R9)`)
* **Updated `useTable` implementation**: Incorporated `entityListType` into the hook's logic, including adding it to the dependency array and handling it in the `useEffect` for explore response processing. (`[[1]](diffhunk://#diff-328057e5d539dd2de86abcc3770c26e51e260a9d60ac303ef6762193827d7584R214)`, `[[2]](diffhunk://#diff-328057e5d539dd2de86abcc3770c26e51e260a9d60ac303ef6762193827d7584R235-R239)`)

### Integration with `Index` Component:

* **Modified `Index` component to pass `entityListType` to `useTable`**: Updated the `Index` component to call the `useTable` hook with the `entityListType` parameter, ensuring the new functionality is utilized. (`[src/components/Index/index.tsxL28-R28](diffhunk://#diff-99271676d4c3bc2a74744c602b2563c4882ec49d633863f39c304e70810c407eL28-R28)`)