### PR TITLE
fix: update explorestate provider updateentityfilters action: update filters when tabvalue matches entitylisttype (#486)

### DIFF
--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -620,6 +620,13 @@ function exploreReducer(
           categoryGroupConfigKey
         ),
         rowPreview: closeRowPreview(state.rowPreview),
+        ...(payload.entityListType === state.tabValue
+          ? {
+              filterCount: getFilterCount(filterState),
+              filterState,
+              paginationState: { ...resetPage(state.paginationState), rows: 0 },
+            }
+          : {}),
       };
     }
     /**


### PR DESCRIPTION
Closes #486.

This pull request introduces a conditional update to the `exploreReducer` function in `src/providers/exploreState.tsx`. The update ensures that when the `payload.entityListType` matches the current `state.tabValue`, the filter count, filter state, and pagination state are reset appropriately. 

Key change:

* [`src/providers/exploreState.tsx`](diffhunk://#diff-e34f716996efb33d7b4fe80b9f5590e3cccedfb4e9027207e3c02641dd542e11R623-R629): Added logic to conditionally update `filterCount`, `filterState`, and `paginationState` when `payload.entityListType` matches `state.tabValue`. This helps maintain consistency in the state when switching between entity list types.