### PR TITLE
fix: imports in usebeforepopstate utils (#491)

### DIFF
--- a/src/providers/exploreState/hooks/UseBeforePopState/utils.ts
+++ b/src/providers/exploreState/hooks/UseBeforePopState/utils.ts
@@ -1,5 +1,5 @@
-import { SelectedFilter } from "common/entities";
-import { SyncStateFromUrlPayload } from "providers/exploreState/actions/syncStateFromUrl/types";
+import { SelectedFilter } from "../../../../common/entities";
+import { SyncStateFromUrlPayload } from "../../../exploreState/actions/syncStateFromUrl/types";
 import { EXPLORE_URL_PARAMS } from "../../../exploreState/constants";
 
 /**


### PR DESCRIPTION
Fixes #491.

This pull request includes a minor change to the import paths in `src/providers/exploreState/hooks/UseBeforePopState/utils.ts` to use relative paths instead of module-alias paths.

Path adjustments:

* Updated the import paths for `SelectedFilter` and `SyncStateFromUrlPayload` to use relative paths, ensuring consistency and compatibility with the project's module resolution setup.