### PR TITLE
feat!: updated allowed annotation values #489

### DIFF
--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -5,7 +5,7 @@ import { ColumnDef, RowData } from "@tanstack/react-table";
  */
 export interface Attribute {
   // Prefix to fragment mapping, e.g. cxg: "batch_condition", or, general tags e.g. tier: "Tier 1" and bionetwork: ["gut"]
-  annotations?: Record<string, string | undefined>; // 'undefined' allows for mix of keys across attributes e.g. tier, or tier and cxg, or cxg
+  annotations?: Record<string, string | string[] | undefined>; // 'undefined' allows for mix of keys across attributes e.g. tier, or tier and cxg, or cxg
   description: string;
   example?: string; // Free text example of attribute
   multivalued: boolean; // True if attribute can have multiple values

--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -4,9 +4,8 @@ import { ColumnDef, RowData } from "@tanstack/react-table";
  * Model of a value of a metadata class.
  */
 export interface Attribute {
-  annotations?: {
-    [key in keyof DataDictionaryPrefix]: string; // Prefix to fragment mapping, e.g. cxg: "batch_condition".
-  };
+  // Prefix to fragment mapping, e.g. cxg: "batch_condition", or, general tags e.g. tier: "Tier 1" and bionetwork: ["gut"]
+  annotations?: Record<string, string | undefined>; // 'undefined' allows for mix of keys across attributes e.g. tier, or tier and cxg, or cxg
   description: string;
   example?: string; // Free text example of attribute
   multivalued: boolean; // True if attribute can have multiple values

--- a/src/components/DataDictionary/dataDictionary.tsx
+++ b/src/components/DataDictionary/dataDictionary.tsx
@@ -21,13 +21,13 @@ export const DataDictionary = <T extends RowData = Attribute>({
   Title = DefaultTitle,
   TitleLayout = DefaultTitleLayout,
 }: DataDictionaryProps): JSX.Element => {
-  const { classes, columnDefs } = useDataDictionary<T>();
+  const { classes, columnDefs, title } = useDataDictionary<T>();
   const { spacing } = useLayoutSpacing();
   const outline = useMemo(() => buildClassesOutline(classes), [classes]);
   return (
     <View className={className}>
       <TitleLayout {...spacing}>
-        <Title />
+        <Title title={title} />
       </TitleLayout>
       <OutlineLayout {...spacing}>
         <Outline outline={outline} />

--- a/src/components/DataDictionary/hooks/UseDataDictionary/hook.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionary/hook.ts
@@ -18,6 +18,7 @@ export const useDataDictionary = <
   return useMemo(() => {
     const classes = dataDictionaryConfig?.dataDictionary?.classes || [];
     const columnDefs = dataDictionaryConfig?.columnDefs || [];
-    return { classes, columnDefs };
+    const title = dataDictionaryConfig?.dataDictionary?.title || "";
+    return { classes, columnDefs, title };
   }, [dataDictionaryConfig]);
 };

--- a/src/components/DataDictionary/hooks/UseDataDictionary/types.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionary/types.ts
@@ -4,4 +4,5 @@ import { Attribute, Class } from "../../../../common/entities";
 export interface UseDataDictionary<T extends RowData = Attribute> {
   classes: Class<T>[];
   columnDefs: ColumnDef<T, T[keyof T]>[];
+  title: string;
 }

--- a/src/components/Layout/components/Header/header.styles.ts
+++ b/src/components/Layout/components/Header/header.styles.ts
@@ -4,6 +4,11 @@ import { AppBar as MAppBar } from "@mui/material";
 import { smokeMain } from "../../../../styles/common/mixins/colors";
 import { HEADER_HEIGHT } from "./common/constants";
 
+// See https://github.com/emotion-js/emotion/issues/1105.
+// See https://github.com/emotion-js/emotion/releases/tag/%40emotion%2Fcache%4011.10.2.
+const ignoreSsrWarning =
+  "/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */";
+
 export const AppBar = styled(MAppBar)`
   border-bottom: 1px solid ${smokeMain};
 
@@ -34,7 +39,7 @@ export const Left = styled.div`
   justify-content: flex-start;
 
   .MuiButton-navPrimary {
-    &:first-child {
+    &:first-child:not(style)${ignoreSsrWarning} { {
       margin-left: 24px;
     }
   }

--- a/src/components/Layout/components/Header/header.styles.ts
+++ b/src/components/Layout/components/Header/header.styles.ts
@@ -34,7 +34,7 @@ export const Left = styled.div`
   justify-content: flex-start;
 
   .MuiButton-navPrimary {
-    &:first-of-type {
+    &:first-child {
       margin-left: 24px;
     }
   }


### PR DESCRIPTION
This pull request introduces updates to the `DataDictionary` component and its related hooks, alongside a minor styling adjustment in the header component. The most significant changes include adding support for a `title` property in the `DataDictionary` component and updating the `annotations` type in the `Attribute` interface for greater flexibility.

### Updates to `Attribute` interface:

* **Enhanced `annotations` type**: Updated the `annotations` field in the `Attribute` interface to use `Record<string, string | undefined>` for improved flexibility in handling mixed keys and optional values. (`src/common/entities.ts`)

### Updates to `DataDictionary` component:

* **Support for `title` property**: Added a `title` field to the `useDataDictionary` hook and propagated it through the `DataDictionary` component to allow dynamic titles. This includes changes to the `UseDataDictionary` interface, the hook implementation, and the `Title` component usage. (`src/components/DataDictionary/dataDictionary.tsx`, `src/components/DataDictionary/hooks/UseDataDictionary/hook.ts`, `src/components/DataDictionary/hooks/UseDataDictionary/types.ts`) [[1]](diffhunk://#diff-b7171f2e8195fd9d15fa09d40aa102ece57386601f9fc46fecac60534af27723L24-R30) [[2]](diffhunk://#diff-7fee40131b7ba113c3909791e2aecbe48535a0be4224bf66ba07e3aef92be2e1L21-R22) [[3]](diffhunk://#diff-dac775329d4565ecb0865e3c298c059528d97c728fa07960e5903d033615ccaaR7)

### Styling adjustment:

* **Header button margin fix**: Replaced `:first-of-type` with `:first-child` for better CSS specificity and compatibility in the header component styles. (`src/components/Layout/components/Header/header.styles.ts`)