### PR TITLE
fix: fix incorrect labels on filters (#499)

### DIFF
--- a/src/common/categories/config/utils.ts
+++ b/src/common/categories/config/utils.ts
@@ -13,10 +13,11 @@ export function findCategoryConfig<V extends VIEW_KIND>(
   viewKind: V,
   key: Category["key"],
   configs: CategoryConfig[]
-): Extract<CategoryConfig, { viewKind: V }> | undefined {
+): Extract<CategoryConfig, { viewKind?: V }> | undefined {
   return configs.find(
-    (c): c is Extract<CategoryConfig, { viewKind: V }> =>
-      c.viewKind === viewKind && c.key === key
+    (c): c is Extract<CategoryConfig, { viewKind?: V }> =>
+      // An undefined `viewKind` will always be `SelectCategoryConfig`. Other view kinds will be explicitly checked.
+      (c.viewKind === undefined || c.viewKind === viewKind) && c.key === key
   );
 }
 

--- a/src/common/categories/config/utils.ts
+++ b/src/common/categories/config/utils.ts
@@ -16,7 +16,9 @@ export function findCategoryConfig<V extends VIEW_KIND>(
 ): Extract<CategoryConfig, { viewKind?: V }> | undefined {
   return configs.find(
     (c): c is Extract<CategoryConfig, { viewKind?: V }> =>
-      // An undefined `viewKind` will always be `SelectCategoryConfig`. Other view kinds will be explicitly checked.
+      // When `viewKind` is undefined, it corresponds to a `SelectCategoryConfig`.
+      // This predicate ensures that `viewKind` is either explicitly matched or treated as undefined
+      // for compatibility with `SelectCategoryConfig` and other explicitly defined view kinds.
       (c.viewKind === undefined || c.viewKind === viewKind) && c.key === key
   );
 }


### PR DESCRIPTION
Closes #499.

This pull request includes a modification to the `findCategoryConfig` function in `src/common/categories/config/utils.ts` to enhance flexibility when matching configurations by allowing `viewKind` to be optional.

### Updates to `findCategoryConfig` function:
* Updated the function signature to allow `viewKind` to be optional by changing its type to `viewKind?: V`. This enables matching configurations where `viewKind` is undefined.
* Adjusted the predicate in the `configs.find` method to account for cases where `viewKind` is undefined, ensuring it matches configurations with `viewKind` explicitly set to `undefined` or matching the provided `viewKind`.

<img width="1668" alt="image" src="https://github.com/user-attachments/assets/5b63a978-aab6-41bc-ac53-c48fdc83fe00" />
