### PR TITLE
feat: add global 'beforepopstate' bus to intercept browser back/forward navigation (#509)

### DIFF
--- a/src/providers/services/provider.tsx
+++ b/src/providers/services/provider.tsx
@@ -1,0 +1,25 @@
+import React, { ReactNode } from "react";
+import { usePopStateBus } from "../../services/beforePopState/usePopStateBus";
+import { WasPopProvider } from "../services/wasPop/provider";
+
+/**
+ * ServicesProvider is a component that initializes and provides access to various service-related
+ * functionality throughout the application.
+ *
+ * This provider:
+ * 1. Registers the pop state bus to handle browser navigation events.
+ * 2. Provides the WasPopProvider context to track browser back/forward navigation
+ *
+ * This provider should be placed at the _app root level to ensure all components have access to these services.
+ */
+
+export function ServicesProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  // Register the pop state bus.
+  usePopStateBus();
+
+  return <WasPopProvider>{children}</WasPopProvider>;
+}

--- a/src/providers/services/wasPop/context.ts
+++ b/src/providers/services/wasPop/context.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import { WasPopContextProps } from "./types";
+
+export const WasPopContext = createContext<WasPopContextProps>({
+  wasPop: false,
+});

--- a/src/providers/services/wasPop/context.ts
+++ b/src/providers/services/wasPop/context.ts
@@ -2,5 +2,6 @@ import { createContext } from "react";
 import { WasPopContextProps } from "./types";
 
 export const WasPopContext = createContext<WasPopContextProps>({
-  wasPop: false,
+  onClearPopRef: () => {},
+  popRef: { current: undefined },
 });

--- a/src/providers/services/wasPop/hook.ts
+++ b/src/providers/services/wasPop/hook.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { WasPopContext } from "./context";
+import { WasPopContextProps } from "./types";
+
+export const useWasPop = (): WasPopContextProps => {
+  return useContext(WasPopContext);
+};

--- a/src/providers/services/wasPop/provider.tsx
+++ b/src/providers/services/wasPop/provider.tsx
@@ -1,0 +1,58 @@
+import { Router } from "next/router";
+import React, { ReactNode, useCallback, useEffect, useRef } from "react";
+import { useOnPopState } from "../../../services/beforePopState/useOnPopState";
+import { WasPopContext } from "./context";
+
+/**
+ * WasPopProvider tracks browser navigation events to determine if the current route change
+ * was triggered by a popstate event (browser back/forward navigation).
+ *
+ * This provider:
+ * 1. Registers callbacks for route change events.
+ * 2. Tracks when navigation occurs via browser back/forward buttons
+ * 3. Provides this state via context to child components
+ *
+ * This allows components to respond differently to user-initiated navigation versus
+ * browser history navigation.
+ */
+
+export function WasPopProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const wasPopRef = useRef<boolean>(false);
+
+  const onBeforePopState = useCallback(() => {
+    wasPopRef.current = true;
+    return true;
+  }, []);
+
+  const onRouteChangeComplete = useCallback(() => {
+    wasPopRef.current = false;
+  }, []);
+
+  const onRouteChangeStart = useCallback(() => {
+    if (wasPopRef.current) return;
+    wasPopRef.current = false;
+  }, []);
+
+  // Register the callback to be invoked before pop.
+  useOnPopState(onBeforePopState);
+
+  useEffect(() => {
+    Router.events.on("routeChangeStart", onRouteChangeStart);
+    Router.events.on("routeChangeComplete", onRouteChangeComplete);
+
+    return (): void => {
+      Router.events.off("routeChangeStart", onRouteChangeStart);
+      Router.events.off("routeChangeComplete", onRouteChangeComplete);
+    };
+  }, [onRouteChangeComplete, onRouteChangeStart]);
+
+  return (
+    <WasPopContext.Provider value={{ wasPop: wasPopRef.current }}>
+      {children}
+    </WasPopContext.Provider>
+  );
+}

--- a/src/providers/services/wasPop/provider.tsx
+++ b/src/providers/services/wasPop/provider.tsx
@@ -32,23 +32,16 @@ export function WasPopProvider({
     wasPopRef.current = false;
   }, []);
 
-  const onRouteChangeStart = useCallback(() => {
-    if (wasPopRef.current) return;
-    wasPopRef.current = false;
-  }, []);
-
   // Register the callback to be invoked before pop.
   useOnPopState(onBeforePopState);
 
   useEffect(() => {
-    Router.events.on("routeChangeStart", onRouteChangeStart);
     Router.events.on("routeChangeComplete", onRouteChangeComplete);
 
     return (): void => {
-      Router.events.off("routeChangeStart", onRouteChangeStart);
       Router.events.off("routeChangeComplete", onRouteChangeComplete);
     };
-  }, [onRouteChangeComplete, onRouteChangeStart]);
+  }, [onRouteChangeComplete]);
 
   return (
     <WasPopContext.Provider value={{ wasPop: wasPopRef.current }}>

--- a/src/providers/services/wasPop/provider.tsx
+++ b/src/providers/services/wasPop/provider.tsx
@@ -1,5 +1,5 @@
-import { Router } from "next/router";
-import React, { ReactNode, useCallback, useEffect, useRef } from "react";
+import React, { ReactNode, useCallback, useRef } from "react";
+import { NextHistoryState } from "../../../services/beforePopState/types";
 import { useOnPopState } from "../../../services/beforePopState/useOnPopState";
 import { WasPopContext } from "./context";
 
@@ -21,30 +21,24 @@ export function WasPopProvider({
 }: {
   children: ReactNode;
 }): JSX.Element {
-  const wasPopRef = useRef<boolean>(false);
+  const popRef = useRef<NextHistoryState | undefined>();
 
-  const onBeforePopState = useCallback(() => {
-    wasPopRef.current = true;
+  // Pop callback.
+  const onBeforePopState = useCallback((state: NextHistoryState) => {
+    popRef.current = state;
     return true;
   }, []);
 
-  const onRouteChangeComplete = useCallback(() => {
-    wasPopRef.current = false;
+  // Clear pop ref.
+  const onClearPopRef = useCallback(() => {
+    popRef.current = undefined;
   }, []);
 
   // Register the callback to be invoked before pop.
   useOnPopState(onBeforePopState);
 
-  useEffect(() => {
-    Router.events.on("routeChangeComplete", onRouteChangeComplete);
-
-    return (): void => {
-      Router.events.off("routeChangeComplete", onRouteChangeComplete);
-    };
-  }, [onRouteChangeComplete]);
-
   return (
-    <WasPopContext.Provider value={{ wasPop: wasPopRef.current }}>
+    <WasPopContext.Provider value={{ onClearPopRef, popRef }}>
       {children}
     </WasPopContext.Provider>
   );

--- a/src/providers/services/wasPop/types.ts
+++ b/src/providers/services/wasPop/types.ts
@@ -1,0 +1,3 @@
+export interface WasPopContextProps {
+  wasPop: boolean;
+}

--- a/src/providers/services/wasPop/types.ts
+++ b/src/providers/services/wasPop/types.ts
@@ -1,3 +1,7 @@
+import { MutableRefObject } from "react";
+import { NextHistoryState } from "../../../services/beforePopState/types";
+
 export interface WasPopContextProps {
-  wasPop: boolean;
+  onClearPopRef: () => void;
+  popRef: MutableRefObject<NextHistoryState | undefined>;
 }

--- a/src/services/beforePopState/popStateBus.ts
+++ b/src/services/beforePopState/popStateBus.ts
@@ -1,0 +1,64 @@
+import Router from "next/router";
+import { BeforePopStateCallback, NextHistoryState } from "./types";
+
+/**
+ * Pop‐State Event Bus
+ *
+ * Provides a centralized mechanism for components to intercept
+ * and optionally prevent Back/Forward navigation (Next.js beforePopState).
+ */
+
+/**
+ * A set of callback functions that will run before Next.js performs a pop.
+ * Each callback returns `true` to allow navigation or `false` to block.
+ */
+const beforePopCallbacks = new Set<BeforePopStateCallback>();
+
+/**
+ * Register a callback to be invoked immediately before any Next.js pop navigation.
+ * Return `false` from your callback to prevent the pop; otherwise return `true`.
+ * @param cb - The callback function to register.
+ */
+export function registerBeforePopCallback(cb: BeforePopStateCallback): void {
+  beforePopCallbacks.add(cb);
+}
+
+/**
+ * Unregister a previously registered “before pop” callback.
+ * @param cb - The callback function to unregister.
+ */
+export function unregisterBeforePopCallback(cb: BeforePopStateCallback): void {
+  beforePopCallbacks.delete(cb);
+}
+
+/**
+ * Ensures that we only hook into Next.js once. After install, any pop event
+ * will first invoke all registered callbacks and only proceed if all return true.
+ */
+let hasInstalledInterceptor = false;
+
+/**
+ * Install the global “before pop” interceptor into Next.js’s router.
+ * Subsequent calls to this function will be no‐ops.
+ *
+ * This method must be called once (e.g. in your app’s top‐level code)
+ * to enable the pop‐state bus.
+ */
+export function registerPopStateHandler(): void {
+  if (hasInstalledInterceptor) return;
+  hasInstalledInterceptor = true;
+
+  Router.beforePopState((state: NextHistoryState) => {
+    // Iteratively call every callback. If any returns false, block navigation.
+    let allAllow = true;
+    beforePopCallbacks.forEach((cb) => {
+      try {
+        if (cb(state) === false) allAllow = false;
+      } catch (e: unknown) {
+        console.error("Pop listener failed:", e);
+      }
+    });
+
+    return allAllow;
+  });
+}

--- a/src/services/beforePopState/types.ts
+++ b/src/services/beforePopState/types.ts
@@ -1,0 +1,15 @@
+import Router from "next/router";
+
+/**
+ * Type representing the callback function passed to beforePopState.
+ * Extracted from the Next.js Router.beforePopState API.
+ */
+export type BeforePopStateCallback = Parameters<
+  typeof Router.beforePopState
+>[0];
+
+/**
+ * Type representing the state passed to beforePopState.
+ * Extracted from the Next.js Router.beforePopState API.
+ */
+export type NextHistoryState = Parameters<BeforePopStateCallback>[0];

--- a/src/services/beforePopState/useOnPopState.ts
+++ b/src/services/beforePopState/useOnPopState.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import {
+  registerBeforePopCallback,
+  unregisterBeforePopCallback,
+} from "./popStateBus";
+import { BeforePopStateCallback } from "./types";
+
+export const useOnPopState = (cb: BeforePopStateCallback): void => {
+  useEffect(() => {
+    registerBeforePopCallback(cb);
+    return (): void => {
+      unregisterBeforePopCallback(cb);
+    };
+  }, [cb]);
+};

--- a/src/services/beforePopState/usePopStateBus.ts
+++ b/src/services/beforePopState/usePopStateBus.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { registerPopStateHandler } from "./popStateBus";
+
+/**
+ * Registers the single global `router.beforePopState` handler that
+ * fans out to all feature listeners.
+ * Safe to call multiple times - only the first invocation does the real install.
+ */
+
+export const usePopStateBus = (): void => {
+  useEffect(() => {
+    registerPopStateHandler();
+  }, []);
+};


### PR DESCRIPTION
Closes #509.

This pull request introduces a new navigation handling system that tracks browser back/forward navigation events and provides this state to components via context. The changes include creating a centralized pop-state event bus, a context provider for managing navigation state, and hooks for registering callbacks. These updates improve the application's ability to handle user-initiated navigation and provide consistent state management.

### Navigation State Management:

* [`src/providers/services/wasPop/context.ts`](diffhunk://#diff-85034b64986af3e4dbef824efe2276fdd433a5f78afdaaf379d054ab1f82afb5R1-R6): Added `WasPopContext` to provide a context for tracking whether navigation was triggered by a pop-state event.
* [`src/providers/services/wasPop/provider.tsx`](diffhunk://#diff-494b4ef7406ac84f882c40723308334a105a9aa6c46a1120513e97668d4a9c24R1-R58): Introduced `WasPopProvider` to manage and expose the `wasPop` state, tracking browser navigation events and providing this state to child components.
* [`src/providers/services/wasPop/hook.ts`](diffhunk://#diff-b0bc82b7d5af1b0a816ac78587648ccb0daff9c964ad2754c15343d8f531d7faR1-R7): Added `useWasPop` hook to allow components to consume the `wasPop` state from the context.
* [`src/providers/services/wasPop/types.ts`](diffhunk://#diff-fc9d0df5fc19e3b5628d170447eb6d39844820bb96ea2b599ae0b731f3ba5277R1-R3): Defined the `WasPopContextProps` interface to specify the shape of the `wasPop` context.

### Pop-State Event Bus:

* [`src/services/beforePopState/popStateBus.ts`](diffhunk://#diff-a0beae8a5f7c67c71a21a0ad4003af8f9903db75502dbd5682317ceb82c70e65R1-R64): Implemented a centralized pop-state event bus that allows components to register callbacks for handling browser back/forward navigation.
* [`src/services/beforePopState/types.ts`](diffhunk://#diff-cad12ff5fbfbaa7311940e1a07ac9087d9321e3b793799c5cd4aac0576beb6f7R1-R15): Added type definitions for `BeforePopStateCallback` and `NextHistoryState` to standardize callback signatures and state objects.
* [`src/services/beforePopState/useOnPopState.ts`](diffhunk://#diff-e399278e47ca72e54ab2f0f10619ee88e9711e19e8b559b6ff466928220e2237R1-R15): Created `useOnPopState` hook to register and unregister callbacks with the pop-state bus.
* [`src/services/beforePopState/usePopStateBus.ts`](diffhunk://#diff-f43a930f8cd1dc176196c723e9cd439bf8d352262ffe32571f48a6ba16991ae0R1-R14): Added `usePopStateBus` hook to initialize the global pop-state handler safely.

### High-Level Provider:

* [`src/providers/services/provider.tsx`](diffhunk://#diff-79349be897202122a8ab48050733c1ee0732de9104b0b7dfbf0cef74f7368931R1-R25): Added `ServicesProvider` to initialize and provide access to the navigation handling system by combining `usePopStateBus` and `WasPopProvider`. This ensures all components can access the navigation state.