### PR TITLE
fix: fix explore state entity list type error (#517)

### DIFF
--- a/src/providers/exploreState/initializer/utils.ts
+++ b/src/providers/exploreState/initializer/utils.ts
@@ -199,7 +199,7 @@ function initEntities(entityPageState: EntityPageStateMapper): EntitiesContext {
       ...acc,
       [entityPath]: {
         entityKey: entityPageState[entityPath].categoryGroupConfigKey,
-        query: {},
+        query: { entityListType: entityPath },
       },
     };
   }, {} as EntitiesContext);


### PR DESCRIPTION
Closes #517.

This pull request includes a small update to the `src/providers/exploreState/initializer/utils.ts` file. The change modifies the `query` property within the `initEntities` function to include an `entityListType` based on `entityPath` for better context initialization.

Fixes initialisation of the entities property in explore state!