### PR TITLE
fix: fix catalog and feature flag state in url on page refresh (#520)

### DIFF
--- a/src/providers/exploreState/entities/state.ts
+++ b/src/providers/exploreState/entities/state.ts
@@ -24,25 +24,28 @@ export function buildNextEntities(
     // Grab the entity key for the entity.
     const entityKey = entity.entityKey;
 
-    if (entityKey !== key) {
-      // For entities that do not share the same key, leave the context unchanged.
-      entities[entityPath] = entity;
-      continue;
-    }
-
     // Clone the entity context.
     const entityContext = { ...entity };
 
-    // Update entity context with "shared" context (e.g. filterState).
-    entityContext.query = buildQuery(entityPath, {
-      ...nextEntityState,
+    // Build the params object.
+    // All entities share the same catalog and feature flag state.
+    // Filter state is default to an empty array and updated below,
+    // if the entity key matches the current entity key.
+    const params: EntityState = {
       catalogState: state.catalogState,
       featureFlagState: state.featureFlagState,
-    });
+      filterState: [],
+    };
+
+    // Update entity context with "shared" context (e.g. filterState).
+    if (entityKey === key) {
+      Object.assign(params, nextEntityState);
+    }
 
     // At some point, we may need to update the entity context with additional properties that
     // are not "shared" (e.g. column grouping).
     // For now, this is not needed and so we update entities with the updated entity context and continue.
+    entityContext.query = buildQuery(entityPath, params);
     entities[entityPath] = entityContext;
   }
 


### PR DESCRIPTION
Closes #520.

This pull request refactors the `buildNextEntities` function in `src/providers/exploreState/entities/state.ts` to improve clarity and maintainability by restructuring how shared and entity-specific context is handled.

Key changes in the `buildNextEntities` function:

* Removed the conditional check for `entityKey !== key` and the associated logic to leave the context unchanged for non-matching entities. This simplifies the flow by consolidating context updates into a single block.
* Introduced a `params` object to encapsulate shared context (`catalogState`, `featureFlagState`, and `filterState`). This provides a clearer structure for managing shared and entity-specific properties.
* Updated the logic to modify `params` only when the `entityKey` matches the current key, ensuring that entity-specific state (`nextEntityState`) is applied correctly.
* Moved the `buildQuery` call to use the new `params` object, enhancing readability and reducing duplication.