### PR TITLE
feat: add table <code> element (#525)

### DIFF
--- a/src/components/Table/components/TableCell/components/CodeCell/codeCell.styles.ts
+++ b/src/components/Table/components/TableCell/components/CodeCell/codeCell.styles.ts
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+import { Chip } from "@mui/material";
+import { PALETTE } from "../../../../../../styles/common/constants/palette";
+
+export const StyledChip = styled(Chip)`
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px ${PALETTE.COMMON_WHITE};
+  height: auto;
+  justify-self: flex-start;
+  min-width: 0;
+
+  .MuiChip-label {
+    padding: 2px 8px;
+    white-space: normal;
+  }
+`;

--- a/src/components/Table/components/TableCell/components/CodeCell/codeCell.tsx
+++ b/src/components/Table/components/TableCell/components/CodeCell/codeCell.tsx
@@ -1,0 +1,21 @@
+import { CellContext, RowData } from "@tanstack/react-table";
+import React from "react";
+import { CHIP_PROPS } from "../../../../../../styles/common/mui/chip";
+import { BaseComponentProps } from "../../../../../types";
+import { StyledChip } from "./codeCell.styles";
+
+export const CodeCell = <T extends RowData, TValue extends string = string>({
+  className,
+  getValue,
+}: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {
+  const value = getValue();
+  if (!value) return null;
+  return (
+    <StyledChip
+      className={className}
+      color={CHIP_PROPS.COLOR.DEFAULT}
+      label={value}
+      size={CHIP_PROPS.SIZE.SMALL}
+    />
+  );
+};


### PR DESCRIPTION
Closes #525.

This pull request introduces a new `CodeCell` component to enhance the rendering of table cells with styled chips. It includes the creation of a reusable styled chip and the implementation of the `CodeCell` component using React.

### New Component Implementation:

* [`src/components/Table/components/TableCell/components/CodeCell/codeCell.styles.ts`](diffhunk://#diff-721379096aa3eddf7f97d985bf28d49440e2b8ec8b7aba78137f89612c25f4dcR1-R16): Added `StyledChip`, a styled version of the `Chip` component from Material-UI, with custom styles such as rounded corners, box shadow, and adjusted padding for the label.
* [`src/components/Table/components/TableCell/components/CodeCell/codeCell.tsx`](diffhunk://#diff-adb7eaa4510c27169591291eb300c45ed1a299fe6356f0f6387138f13421c7ccR1-R21): Implemented the `CodeCell` component, which uses `StyledChip` to display cell values as styled chips. The component gracefully handles empty values by returning `null`.