### PR TITLE
fix: refactor CodeCell to use node prop instead of value string (#540)

### DIFF
--- a/src/components/Table/components/TableCell/components/CodeCell/codeCell.tsx
+++ b/src/components/Table/components/TableCell/components/CodeCell/codeCell.tsx
@@ -1,10 +1,13 @@
 import { CellContext, RowData } from "@tanstack/react-table";
-import React from "react";
+import React, { ReactNode } from "react";
 import { CHIP_PROPS } from "../../../../../../styles/common/mui/chip";
 import { BaseComponentProps } from "../../../../../types";
 import { StyledChip } from "./codeCell.styles";
 
-export const CodeCell = <T extends RowData, TValue extends string = string>({
+export const CodeCell = <
+  T extends RowData,
+  TValue extends ReactNode = ReactNode
+>({
   className,
   getValue,
 }: BaseComponentProps & CellContext<T, TValue>): JSX.Element | null => {


### PR DESCRIPTION
Closes #540.

This pull request includes a small change to the `CodeCell` component in `codeCell.tsx`. The change updates the `TValue` type from `string` to `ReactNode`, allowing the component to handle more flexible content types.