### PR TITLE
fix!: file format filter dropped from curl manifest request (#543)

### DIFF
--- a/src/components/Export/components/DownloadCurlCommand/downloadCurlCommand.tsx
+++ b/src/components/Export/components/DownloadCurlCommand/downloadCurlCommand.tsx
@@ -30,6 +30,7 @@ interface DownloadCurlCommandProps {
   filters: Filters; // Initializes bulk download filters.
   formFacet: FormFacet;
   manifestDownloadFormat?: ManifestDownloadFormat;
+  speciesFacetName: string;
 }
 
 export const DownloadCurlCommand = ({
@@ -41,8 +42,9 @@ export const DownloadCurlCommand = ({
   filters,
   formFacet,
   manifestDownloadFormat = MANIFEST_DOWNLOAD_FORMAT.CURL,
+  speciesFacetName,
 }: DownloadCurlCommandProps): JSX.Element => {
-  useFileManifest(filters, fileSummaryFacetName);
+  useFileManifest(filters, fileSummaryFacetName, speciesFacetName);
   const [executionEnvironment, setExecutionEnvironment] =
     useState<ExecutionEnvironment>(BULK_DOWNLOAD_EXECUTION_ENVIRONMENT.BASH);
   const {

--- a/src/components/Export/components/ExportToTerra/exportToTerra.tsx
+++ b/src/components/Export/components/ExportToTerra/exportToTerra.tsx
@@ -24,6 +24,7 @@ export interface ExportToTerraProps {
   formFacet: FormFacet;
   manifestDownloadFormat?: ManifestDownloadFormat;
   manifestDownloadFormats: ManifestDownloadFormat[];
+  speciesFacetName: string;
 }
 
 export const ExportToTerra = ({
@@ -36,11 +37,12 @@ export const ExportToTerra = ({
   formFacet,
   manifestDownloadFormat,
   manifestDownloadFormats,
+  speciesFacetName,
 }: ExportToTerraProps): JSX.Element => {
   const {
     exploreState: { tabValue: entityList },
   } = useExploreState();
-  useFileManifest(filters, fileSummaryFacetName);
+  useFileManifest(filters, fileSummaryFacetName, speciesFacetName);
   const fileManifestFormatState = useFileManifestFormat(manifestDownloadFormat);
   const { requestMethod, requestParams, requestUrl } = useRequestManifest(
     fileManifestFormatState.fileManifestFormat,

--- a/src/components/Export/components/ManifestDownload/manifestDownload.tsx
+++ b/src/components/Export/components/ManifestDownload/manifestDownload.tsx
@@ -25,6 +25,7 @@ export interface ManifestDownloadProps {
   manifestDownloadFormat?: ManifestDownloadFormat;
   ManifestDownloadStart: ElementType;
   ManifestDownloadSuccess: ElementType;
+  speciesFacetName: string;
 }
 
 export const ManifestDownload = ({
@@ -36,8 +37,9 @@ export const ManifestDownload = ({
   manifestDownloadFormat = MANIFEST_DOWNLOAD_FORMAT.COMPACT,
   ManifestDownloadStart,
   ManifestDownloadSuccess,
+  speciesFacetName,
 }: ManifestDownloadProps): JSX.Element => {
-  useFileManifest(filters, fileSummaryFacetName);
+  useFileManifest(filters, fileSummaryFacetName, speciesFacetName);
   const {
     exploreState: { tabValue: entityList },
   } = useExploreState();

--- a/src/hooks/useFileManifest/useFileManifest.ts
+++ b/src/hooks/useFileManifest/useFileManifest.ts
@@ -2,21 +2,32 @@ import { useEffect, useState } from "react";
 import { Filters } from "../../common/entities";
 import { FileManifestActionKind } from "../../providers/fileManifestState";
 import { useFileManifestState } from "../useFileManifestState";
+import { useFileManifestFileCount } from "./useFileManifestFileCount";
 
 /**
  * Initializes the file manifest with specified filters and a file summary facet name.
  * This hook sets up the file manifest state by dispatching an action to fetch the manifest
  * based on the provided initial filters and file summary facet name. It also ensures that
  * the manifest state is cleared when the component is unmounted.
+ * Dispatches file summary count, from the summary endpoint with filters, excluding
+ * the given facet names.
  * @param initialFilters - The initial filters used to fetch the file manifest.
  * @param fileSummaryFacetName - The name of the file summary facet to be used in the file manifest request.
+ * @param speciesFacetName - The name of the species facet to be used in the file manifest request.
  */
 export const useFileManifest = (
   initialFilters: Filters | undefined = [],
-  fileSummaryFacetName?: string
+  fileSummaryFacetName?: string,
+  speciesFacetName?: string
 ): void => {
   // Initial file manifest filter.
   const [initFilters] = useState(() => initialFilters);
+
+  // Dispatch file summary count.
+  useFileManifestFileCount(initFilters, [
+    fileSummaryFacetName,
+    speciesFacetName,
+  ]);
 
   // File manifest state.
   const { fileManifestDispatch } = useFileManifestState();

--- a/src/hooks/useFileManifest/useFileManifestFileCount.ts
+++ b/src/hooks/useFileManifest/useFileManifestFileCount.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { Filters } from "../../common/entities";
+import { FileManifestActionKind } from "../../providers/fileManifestState";
+import { useCatalog } from "../useCatalog";
+import { useFileManifestState } from "../useFileManifestState";
+import { useFetchSummary } from "./useFetchSummary";
+
+/**
+ * Fetches the file summary count from the summary endpoint; the request excludes any filters with
+ * the given facet names.
+ * Dispatches the file count to the file manifest state.
+ * @param initialFilters - Initial Filters.
+ * @param facetNames - Facets.
+ */
+export const useFileManifestFileCount = (
+  initialFilters: Filters | undefined = [],
+  facetNames: (string | undefined)[] // Facet names to exclude from filters.
+): void => {
+  // File manifest dispatch.
+  const { fileManifestDispatch } = useFileManifestState();
+
+  // Determine catalog.
+  const catalog = useCatalog() as string; // catalog should be defined.
+
+  // Get filters required for fetching the summary.
+  const fileCountFilters = getFileCountFilters(initialFilters, facetNames);
+
+  // Fetch file count from summary.
+  const { summary: { fileCount } = {} } = useFetchSummary(
+    fileCountFilters || [],
+    catalog,
+    !!fileCountFilters
+  );
+
+  useEffect(() => {
+    if (!fileCount) return;
+    fileManifestDispatch({
+      payload: { fileCount },
+      type: FileManifestActionKind.UpdateFileCount,
+    });
+  }, [fileCount, fileManifestDispatch]);
+};
+
+/**
+ * Returns the filters with the given facets excluded.
+ * @param filters - Filters.
+ * @param facetNames - A list of facet names to exclude from the filters.
+ * @returns Filters with facets excluded.
+ */
+function getFileCountFilters(
+  filters: Filters,
+  facetNames: (string | undefined)[]
+): Filters | undefined {
+  // Filter out undefined facets.
+  const filteredFacets = facetNames.filter(Boolean);
+
+  // Return undefined if no facets to exclude; we don't want to fetch the summary until we have facet names to exclude
+  // from the filters.
+  if (filteredFacets.length === 0) return;
+
+  // Return filters with facets excluded.
+  return filters.filter(
+    ({ categoryKey }) => !filteredFacets.includes(categoryKey)
+  );
+}

--- a/src/hooks/useFileManifest/useFileManifestFileCount.ts
+++ b/src/hooks/useFileManifest/useFileManifestFileCount.ts
@@ -54,9 +54,9 @@ function getFileCountFilters(
   // Filter out undefined facets.
   const filteredFacets = facetNames.filter(Boolean);
 
-  // Return undefined if no facets to exclude; we don't want to fetch the summary until we have facet names to exclude
-  // from the filters.
-  if (filteredFacets.length === 0) return;
+  // Do not fetch the summary until both required facet names (species and file type) are available.
+  // If fewer than two facets are provided, return undefined.
+  if (filteredFacets.length < 2) return;
 
   // Return filters with facets excluded.
   return filters.filter(

--- a/src/mocks/useRequestFileManifest.mocks.ts
+++ b/src/mocks/useRequestFileManifest.mocks.ts
@@ -79,9 +79,11 @@ export const FILTERS: Record<string, Filters> = {
 };
 
 export const FILE_MANIFEST_STATE = {
+  fileCount: 10,
   filters: FILTERS.FORM_INITIAL_SET,
   isEnabled: true,
   isLoading: false,
+  summary: { fileCount: 10 },
 } as FileManifestState;
 
 export const FORM_FACET: Record<string, FormFacet> = {

--- a/src/providers/fileManifestState.tsx
+++ b/src/providers/fileManifestState.tsx
@@ -24,6 +24,7 @@ import { FILE_MANIFEST_STATE } from "./fileManifestState/constants";
  * File manifest state.
  */
 export type FileManifestState = {
+  fileCount: number | undefined;
   filesFacets: FileFacet[];
   fileSummary?: AzulSummaryResponse;
   fileSummaryFacetName?: string;
@@ -133,6 +134,7 @@ export function FileManifestStateProvider({
 export enum FileManifestActionKind {
   ClearFileManifest = "CLEAR_FILE_MANIFEST",
   FetchFileManifest = "FETCH_FILE_MANIFEST",
+  UpdateFileCount = "UPDATE_FILE_COUNT",
   UpdateFileManifest = "UPDATE_FILE_MANIFEST",
   UpdateFilter = "UPDATE_FILTER",
   UpdateFiltersCategory = "UPDATE_FILTERS_CATEGORY",
@@ -144,6 +146,7 @@ export enum FileManifestActionKind {
 export type FileManifestAction =
   | ClearFileManifestAction
   | FetchFileManifestAction
+  | UpdateFileCountAction
   | UpdateFileManifestAction
   | UpdateFilterAction
   | UpdateFiltersCategoryAction;
@@ -173,6 +176,14 @@ type UpdateFileManifestAction = {
 };
 
 /**
+ * Update file count action.
+ */
+type UpdateFileCountAction = {
+  payload: UpdateFileCountPayload;
+  type: FileManifestActionKind.UpdateFileCount;
+};
+
+/**
  * Update filter action.
  */
 type UpdateFilterAction = {
@@ -194,6 +205,13 @@ type UpdateFiltersCategoryAction = {
 type FetchFileManifestPayload = {
   fileSummaryFacetName?: string;
   filters: Filters;
+};
+
+/**
+ * Update file count payload.
+ */
+export type UpdateFileCountPayload = {
+  fileCount: number | undefined;
 };
 
 /**
@@ -235,6 +253,7 @@ function fileManifestReducer(
     case FileManifestActionKind.ClearFileManifest: {
       return {
         ...state,
+        fileCount: undefined,
         isEnabled: false,
       };
     }
@@ -251,6 +270,10 @@ function fileManifestReducer(
         fileSummaryFilters,
         isEnabled: true,
       };
+    }
+    // Updates file count.
+    case FileManifestActionKind.UpdateFileCount: {
+      return { ...state, ...payload };
     }
     // Updates file manifest.
     case FileManifestActionKind.UpdateFileManifest: {

--- a/src/providers/fileManifestState/constants.ts
+++ b/src/providers/fileManifestState/constants.ts
@@ -1,6 +1,7 @@
 import { FileManifestState } from "../fileManifestState";
 
 export const FILE_MANIFEST_STATE: FileManifestState = {
+  fileCount: undefined,
   fileSummary: undefined,
   fileSummaryFacetName: undefined,
   fileSummaryFilters: [],

--- a/tests/buildRequestFilters.test.ts
+++ b/tests/buildRequestFilters.test.ts
@@ -24,26 +24,18 @@ describe("buildRequestFilters", () => {
       expect(result).toEqual(fileManifestState.filters);
     });
 
-    test("when at least one form facet has no terms selected", () => {
-      const fileManifestState = getFileManifestState(
-        FILTERS.FORM_INCOMPLETE_SET
-      );
+    test("when summary file count is not equal to initial file count", () => {
+      const fileManifestState = getFileManifestState(FILTERS.FORM_COMPLETE_SET);
       const result = buildRequestFilters(
-        fileManifestState,
-        FORM_FACET.INCOMPLETE_SET
+        { ...fileManifestState, summary: { fileCount: 9 } },
+        FORM_FACET.COMPLETE_SET
       );
-      expect(result).toEqual(fileManifestState.filters);
-    });
-
-    test("when at least one form facet has an unselected term", () => {
-      const fileManifestState = getFileManifestState(FILTERS.FORM_SUBSET);
-      const result = buildRequestFilters(fileManifestState, FORM_FACET.SUBSET);
       expect(result).toEqual(fileManifestState.filters);
     });
   });
 
   describe("should return filters excluding form related filters", () => {
-    test("when all form facets have all their terms selected", () => {
+    test("when summary file count is equal to initial file count", () => {
       const fileManifestState = getFileManifestState(FILTERS.FORM_COMPLETE_SET);
       const result = buildRequestFilters(
         fileManifestState,

--- a/tests/useRequestManifest.test.ts
+++ b/tests/useRequestManifest.test.ts
@@ -109,6 +109,16 @@ describe("useRequestManifest", () => {
       });
     });
 
+    test("when fileManifestState fileCount is undefined", () => {
+      MOCK_USE_FILE_MANIFEST_STATE.mockReturnValue({
+        fileManifestDispatch: jest.fn(),
+        fileManifestState: { ...FILE_MANIFEST_STATE, fileCount: undefined },
+      });
+      testRequestManifest({
+        fileManifestFormat: MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB,
+      });
+    });
+
     describe("form selection is not ready", () => {
       test("when a form facet is undefined", () => {
         testRequestManifest({


### PR DESCRIPTION
Closes #543.

This pull request introduces enhancements to the file manifest functionality, focusing on improving file count management and refining filter behavior for requests. The changes include adding support for a new `speciesFacetName` parameter across multiple components, implementing a new hook (`useFileManifestFileCount`) to manage file counts, and updating the file manifest state and its associated utilities to handle file count logic more effectively.

### Enhancements to File Manifest Functionality

#### Support for `speciesFacetName` Parameter:
* Added `speciesFacetName` to the `DownloadCurlCommandProps`, `ExportToTerraProps`, and `ManifestDownloadProps` interfaces, along with corresponding updates to the `useFileManifest` calls in `downloadCurlCommand.tsx`, `exportToTerra.tsx`, and `manifestDownload.tsx` to include this parameter. [[1]](diffhunk://#diff-0ad214f82269efaf5022cec1e1571d52bd0dd0704e1b21a0b309cadf78ea655dR33) [[2]](diffhunk://#diff-0ad214f82269efaf5022cec1e1571d52bd0dd0704e1b21a0b309cadf78ea655dR45-R47) [[3]](diffhunk://#diff-de99b1ea3e8da3f938c7ec1f063f66e7c33e7da3dc8d4302b10fc638e7c09af3R27) [[4]](diffhunk://#diff-de99b1ea3e8da3f938c7ec1f063f66e7c33e7da3dc8d4302b10fc638e7c09af3R40-R45) [[5]](diffhunk://#diff-76cf772855960112b001eb5aa2297b4001b457b04b1ed98963af89d5e30f3552R28) [[6]](diffhunk://#diff-76cf772855960112b001eb5aa2297b4001b457b04b1ed98963af89d5e30f3552R40-R42)

#### File Count Management:
* Introduced the `useFileManifestFileCount` hook to fetch and dispatch file count data based on filters and excluded facet names. This hook ensures that file count is updated dynamically and is integrated into the `useFileManifest` hook. [[1]](diffhunk://#diff-97215699f391d29c8bc8d4deabd91d65b34c811bfb47845dc42dcf55675fa130R5-R31) [[2]](diffhunk://#diff-48b6822c64b2d213229f752d7d9fbb3a5fe2d2ba9d4f5df22822a66f6f2e1032R1-R65)
* Updated the `FileManifestState` type to include a `fileCount` property and added a new action (`UpdateFileCount`) in the file manifest reducer to handle file count updates. [[1]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR27) [[2]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR137) [[3]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR149) [[4]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR178-R185) [[5]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR210-R216) [[6]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR256) [[7]](diffhunk://#diff-190513f4250df7fbfe77a16fed6dbdb2b2c714bc53426edf3bb4cafbdd977afbR274-R277) [[8]](diffhunk://#diff-2970a3ebe97250db2d2544735ad49ccfd621df6a701d3fad9c6d746c697a4683R4)

#### Refinements to Filter Behavior:
* Replaced the `areAllFormFilterTermsSelected` utility with `areAllFilesSelected`, which compares the file count to the summary file count to determine whether all files are selected. Updated the `buildRequestFilters` function to use this logic for generating request filters. [[1]](diffhunk://#diff-ed0a728add8f76d0c8892974ccf9ea50bfc4799dfaac07167cc1a4895a16d5c7L15-R49) [[2]](diffhunk://#diff-ed0a728add8f76d0c8892974ccf9ea50bfc4799dfaac07167cc1a4895a16d5c7L118-R140)
* Adjusted related tests to reflect the new file count-based logic for filter behavior. [[1]](diffhunk://#diff-d7907e372c7b949b8f3dd0e545adf2fdfffe5fd5eebde411a537f7df467410f4L27-R38) [[2]](diffhunk://#diff-b3fc21c911abaace54d480dee06589b8d6423258b6a7242b2d93189422054861R112-R121)

These changes collectively improve the handling of file manifest data, particularly in scenarios involving large datasets and complex filtering requirements.