### PR TITLE
feat: hide global filtering search bar when global filters are disabled (#547)

### DIFF
--- a/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
@@ -8,9 +8,13 @@ import { ColumnFiltersProps } from "./types";
 
 export const ColumnFilters = <T extends RowData = Attribute>({
   table,
-}: ColumnFiltersProps<T>): JSX.Element => {
+}: ColumnFiltersProps<T>): JSX.Element | null => {
   const columns = table.getAllColumns();
   const columnFilters = columns.filter((column) => column.getCanFilter());
+  const enableColumnFilters = table.options.enableColumnFilters;
+
+  if (!enableColumnFilters) return null;
+
   return (
     <ButtonGroup {...BUTTON_GROUP_PROPS.SECONDARY_OUTLINED}>
       {columnFilters.map((column) => (

--- a/src/components/DataDictionary/components/Filters/stories/filters.stories.tsx
+++ b/src/components/DataDictionary/components/Filters/stories/filters.stories.tsx
@@ -43,6 +43,7 @@ const DefaultStory = (): JSX.Element => {
     getAllColumns: () =>
       [DESCRIPTION, REQUIRED, BIONETWORK, EXAMPLE].map(makeColumn),
     getState: () => ({ globalFilter }),
+    options: { enableColumnFilters: true, enableGlobalFilter: true },
     setGlobalFilter,
   } as Table<unknown>;
 

--- a/src/components/Table/components/TableFeatures/GlobalFilter/globalFilter.tsx
+++ b/src/components/Table/components/TableFeatures/GlobalFilter/globalFilter.tsx
@@ -10,9 +10,13 @@ export const GlobalFilter = <T extends RowData>({
   className,
   table,
   ...props /* MuiOutlinedInputProps */
-}: GlobalFilterProps<T>): JSX.Element => {
-  const { getState, setGlobalFilter } = table;
+}: GlobalFilterProps<T>): JSX.Element | null => {
+  const { getState, options, setGlobalFilter } = table;
   const { globalFilter } = getState();
+  const { enableGlobalFilter } = options;
+
+  if (!enableGlobalFilter) return null;
+
   return (
     <StyledOutlinedInput
       {...OUTLINED_INPUT_PROPS}


### PR DESCRIPTION
Closes #547.

This pull request introduces conditional rendering for column and global filters in the data dictionary and table components. The changes ensure that filters are only displayed when explicitly enabled via table options, improving flexibility and configurability.

### Conditional Rendering for Filters:

* [`src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx`](diffhunk://#diff-7943c2b249358bc0e5edadf255b893d21cfd0f83798359ec50fc17b2b83625faL11-R17): Updated the `ColumnFilters` component to return `null` if `enableColumnFilters` is not enabled in the table options, preventing unnecessary rendering.
* [`src/components/Table/components/TableFeatures/GlobalFilter/globalFilter.tsx`](diffhunk://#diff-6c6680038054ca9efe9c6bd2a8c5c85bb4d1663957b87eee90198229c4eee348L13-R19): Modified the `GlobalFilter` component to return `null` if `enableGlobalFilter` is not enabled in the table options, aligning its behavior with the new conditional rendering approach.

### Table Options Configuration:

* [`src/components/DataDictionary/components/Filters/stories/filters.stories.tsx`](diffhunk://#diff-c70a1f54ad03c11bcf41457a6324a9f1a167f1bb433a95ce2ace3e54805fcae7R46): Added `enableColumnFilters` and `enableGlobalFilter` properties to the table options in the `DefaultStory` to demonstrate the new conditional rendering behavior in the storybook.