### PR TITLE
feat: add data test id to summary (#557)

### DIFF
--- a/src/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary.tsx
+++ b/src/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { TEST_IDS } from "../../../../../../tests/testIds";
 import { SectionTitle } from "../../../../../common/Section/components/SectionTitle/sectionTitle";
 import { GridPaperSection } from "../../../../../common/Section/section.styles";
 import { Loading, LOADING_PANEL_STYLE } from "../../../../../Loading/loading";
@@ -17,7 +18,7 @@ export const ExportSelectedDataSummary = ({
   summaries,
 }: ExportSelectedDataSummaryProps): JSX.Element => {
   return (
-    <GridPaperSection>
+    <GridPaperSection data-testid={TEST_IDS.EXPORT_SUMMARY}>
       <Loading loading={isLoading} panelStyle={LOADING_PANEL_STYLE.INHERIT} />
       <SectionTitle title="Selected Data Summary" />
       {summaries.map(([label, value], i) => (

--- a/src/components/Index/components/EntityView/components/layout/Summary/summary.tsx
+++ b/src/components/Index/components/EntityView/components/layout/Summary/summary.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@mui/material";
 import React, { Fragment } from "react";
 import { useSummary } from "../../../../../../../hooks/useSummary";
 import { TYPOGRAPHY_PROPS } from "../../../../../../../styles/common/mui/typography";
+import { TEST_IDS } from "../../../../../../../tests/testIds";
 import { BaseComponentProps } from "../../../../../../types";
 import { GRID_PROPS } from "./constants";
 import { StyledDot, StyledGrid } from "./summary.styles";
@@ -14,7 +15,11 @@ export const Summary = ({
   if (!summaries) return null;
 
   return (
-    <StyledGrid {...GRID_PROPS} className={className}>
+    <StyledGrid
+      {...GRID_PROPS}
+      className={className}
+      data-testid={TEST_IDS.ENTITY_SUMMARY}
+    >
       {summaries.map(([count, label], i) => (
         <Fragment key={i}>
           {i !== 0 && <StyledDot />}

--- a/src/tests/testIds.ts
+++ b/src/tests/testIds.ts
@@ -1,6 +1,8 @@
 export const TEST_IDS = {
   CLEAR_ALL_FILTERS: "clear-all-filters",
+  ENTITY_SUMMARY: "entity-summary",
   EXPORT_BUTTON: "export-button",
+  EXPORT_SUMMARY: "export-summary",
   FILTERS: "filters",
   FILTER_CONTROLS: "filter-controls",
   FILTER_COUNT: "filter-count",


### PR DESCRIPTION
Closes #557.

This pull request introduces new test IDs to improve the ability to identify and interact with specific components during testing. The changes primarily involve adding `data-testid` attributes to key components and updating the `TEST_IDS` object to define these new IDs.

### Enhancements for testing:

* [`src/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary.tsx`](diffhunk://#diff-8bd4a43d8b3b8104301743440d6fa6f5360a95f70585a85ff59f5cf223ba2484L20-R21): Added a `data-testid` attribute (`TEST_IDS.EXPORT_SUMMARY`) to the `GridPaperSection` component to facilitate testing of the export summary section.
* [`src/components/Index/components/EntityView/components/layout/Summary/summary.tsx`](diffhunk://#diff-45488f7ea6441ab76b1b82f8a7226c9ca6e47c8db509514e950c3f8b4e0580eeL17-R22): Added a `data-testid` attribute (`TEST_IDS.ENTITY_SUMMARY`) to the `StyledGrid` component to enable testing of the entity summary layout.
* [`src/tests/testIds.ts`](diffhunk://#diff-4553cdbb10c2e630d8802942e2423fd5d070baf35bd041ce18fc140704a33d93R3-R5): Updated the `TEST_IDS` object to include `ENTITY_SUMMARY` and `EXPORT_SUMMARY` test IDs for use in the respective components.