### PR TITLE
fix: align range filter toggle button styles with design (#563)

### DIFF
--- a/src/components/Filter/components/FilterRange/filterRange.styles.ts
+++ b/src/components/Filter/components/FilterRange/filterRange.styles.ts
@@ -13,6 +13,7 @@ export const StyledForm = styled("form")`
 
     .MuiToggleButton-root {
       color: ${PALETTE.INK_LIGHT};
+      padding: 8px 12px;
       text-transform: capitalize;
 
       &.Mui-selected {


### PR DESCRIPTION
Closes #563.

This pull request introduces a small adjustment to the styling of toggle buttons within the `StyledForm` component. The change adds padding (`8px 12px`) to the `.MuiToggleButton-root` class in `filterRange.styles.ts`.

<img width="1297" height="1102" alt="image" src="https://github.com/user-attachments/assets/509762d5-ab87-47c5-819b-111b8e985b6f" />
