### PR TITLE
feat: add 'introduction' section to data dictionary (#566)

### DIFF
--- a/src/components/DataDictionary/components/Description/description.styles.ts
+++ b/src/components/DataDictionary/components/Description/description.styles.ts
@@ -1,0 +1,56 @@
+import styled from "@emotion/styled";
+import { PALETTE } from "../../../../styles/common/constants/palette";
+import {
+  mediaTabletDown,
+  mediaTabletUp,
+} from "../../../../styles/common/mixins/breakpoints";
+import { textHeadingSmall } from "../../../../styles/common/mixins/fonts";
+import { RoundedPaper } from "../../../common/Paper/components/RoundedPaper/roundedPaper";
+import { MarkdownRenderer } from "../../../MarkdownRenderer/markdownRenderer";
+
+export const StyledRoundedPaper = styled(RoundedPaper)`
+  padding: 20px;
+
+  ${mediaTabletDown} {
+    padding: 20px 16px;
+  }
+`;
+
+export const StyledMarkdownRenderer = styled(MarkdownRenderer)`
+  align-self: flex-start;
+
+  code {
+    all: unset;
+    font: inherit;
+    font-family: Roboto Mono, monospace;
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 8px 0;
+  }
+
+  h2 {
+    ${textHeadingSmall};
+    font-size: 18px;
+    line-height: 26px;
+
+    ${mediaTabletUp} {
+      font-size: 18px;
+      line-height: 26px;
+    }
+  }
+
+  hr {
+    border: none;
+    border-bottom: 1px solid ${PALETTE.SMOKE_MAIN};
+    margin: 16px 0;
+  }
+
+  p {
+    font: inherit;
+  }
+`;

--- a/src/components/DataDictionary/components/Description/description.tsx
+++ b/src/components/DataDictionary/components/Description/description.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import {
+  StyledMarkdownRenderer,
+  StyledRoundedPaper,
+} from "./description.styles";
+import { DescriptionProps } from "./types";
+
+export const Description = ({
+  description,
+}: DescriptionProps): JSX.Element | null => {
+  if (!description) return null;
+  return (
+    <StyledRoundedPaper elevation={0}>
+      <StyledMarkdownRenderer value={description} />
+    </StyledRoundedPaper>
+  );
+};

--- a/src/components/DataDictionary/components/Description/types.ts
+++ b/src/components/DataDictionary/components/Description/types.ts
@@ -1,0 +1,3 @@
+export interface DescriptionProps {
+  description?: string;
+}

--- a/src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts
@@ -7,6 +7,8 @@ const PB = LAYOUT_SPACING.CONTENT_PADDING_BOTTOM; /* bottom padding */
 const PT = LAYOUT_SPACING.CONTENT_PADDING_TOP; /* top padding */
 
 export const Layout = styled("div")<LayoutSpacing>`
+  display: grid;
+  gap: 16px;
   grid-column: 2;
   grid-row: 1;
   padding-bottom: ${PB}px;

--- a/src/components/DataDictionary/dataDictionary.tsx
+++ b/src/components/DataDictionary/dataDictionary.tsx
@@ -3,6 +3,7 @@ import { RowData } from "@tanstack/react-table";
 import React from "react";
 import { Attribute } from "../../common/entities";
 import { useLayoutSpacing } from "../../hooks/UseLayoutSpacing/hook";
+import { Description } from "./components/Description/description";
 import { Entities } from "./components/Entities/entities";
 import { ColumnFilterTags } from "./components/Filters/components/ColumnFilterTags/columnFilterTags";
 import { Filters } from "./components/Filters/filters";
@@ -30,7 +31,7 @@ export const DataDictionary = <T extends RowData = Attribute>({
   TitleLayout = DefaultTitleLayout,
 }: DataDictionaryProps): JSX.Element => {
   // Get dictionary configuration.
-  const { classes, tableOptions, title } =
+  const { classes, description, tableOptions, title } =
     useDataDictionaryConfig<T>(dictionary);
 
   // Layout measurements.
@@ -64,6 +65,7 @@ export const DataDictionary = <T extends RowData = Attribute>({
         <Fade in={dimensions.height > 0}>
           {/* Fade in entities when filters are measured. */}
           <EntitiesLayout spacing={entitiesSpacing}>
+            <Description description={description} />
             <Entities spacing={entitiesSpacing} table={table} />
           </EntitiesLayout>
         </Fade>

--- a/src/components/DataDictionary/hooks/UseDataDictionaryConfig/hook.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionaryConfig/hook.ts
@@ -31,6 +31,7 @@ export const useDataDictionaryConfig = <T extends RowData = Attribute>(
     // exists above and would have thrown an error if undefined.
     return {
       classes: dataDictionaryConfig!.dataDictionary.classes,
+      description: dataDictionaryConfig!.dataDictionary.description,
       tableOptions: dataDictionaryConfig!.tableOptions,
       title: dataDictionaryConfig!.dataDictionary.title,
     };

--- a/src/components/DataDictionary/hooks/UseDataDictionaryConfig/types.ts
+++ b/src/components/DataDictionary/hooks/UseDataDictionaryConfig/types.ts
@@ -3,6 +3,7 @@ import { Attribute, Class } from "../../../../common/entities";
 
 export interface UseDataDictionaryConfig<T extends RowData = Attribute> {
   classes: Class<T>[];
+  description?: string;
   tableOptions: Omit<TableOptions<T>, "data" | "getCoreRowModel">;
   title: string;
 }


### PR DESCRIPTION
Closes #566.

This pull request introduces a new `Description` component to the `DataDictionary` module, enhances the layout styling, and updates the configuration hook to support descriptions. The changes improve the module's usability by allowing descriptions to be displayed alongside entities and ensuring consistent styling.

### New `Description` Component:

* [`src/components/DataDictionary/components/Description/description.styles.ts`](diffhunk://#diff-a61d82df2129617b1a4046c9f7073ad0e07024de4e8900efc72931e6a7a2aebeR1-R56): Added styled components for `Description`, including `StyledRoundedPaper` and `StyledMarkdownRenderer`, with support for responsive design and markdown rendering.
* [`src/components/DataDictionary/components/Description/description.tsx`](diffhunk://#diff-a9505d30e1a9ffea36dc62258bd8018130614d4565d13a93619f594aac8e2785R1-R17): Implemented the `Description` component to render markdown content inside a styled container.
* [`src/components/DataDictionary/components/Description/types.ts`](diffhunk://#diff-7d5e253f4c57a60b325f01503a8b77abc7ee98753ad2dc1f66b49db73e614560R1-R3): Defined the `DescriptionProps` interface to specify the optional `description` property.

### Integration of `Description` Component into `DataDictionary`:

* [`src/components/DataDictionary/dataDictionary.tsx`](diffhunk://#diff-b7171f2e8195fd9d15fa09d40aa102ece57386601f9fc46fecac60534af27723R6): Integrated the `Description` component into the `DataDictionary` layout, displaying it above the entities section. Updated the configuration to include the `description` property. [[1]](diffhunk://#diff-b7171f2e8195fd9d15fa09d40aa102ece57386601f9fc46fecac60534af27723R6) [[2]](diffhunk://#diff-b7171f2e8195fd9d15fa09d40aa102ece57386601f9fc46fecac60534af27723L33-R34) [[3]](diffhunk://#diff-b7171f2e8195fd9d15fa09d40aa102ece57386601f9fc46fecac60534af27723R68)

### Updates to Configuration Hook:

* [`src/components/DataDictionary/hooks/UseDataDictionaryConfig/hook.ts`](diffhunk://#diff-cc5f914cbc130fc7320ec33c680a3e6be61d406c688d4116ec6440956e939239R34): Extended the hook to retrieve the `description` property from the data dictionary configuration.
* [`src/components/DataDictionary/hooks/UseDataDictionaryConfig/types.ts`](diffhunk://#diff-38ee1856bd39aa372eccc232306d31c029621f48be55e8788c7e3547bd26afd4R6): Updated the `UseDataDictionaryConfig` interface to include the optional `description` property.

### Layout Enhancements:

* [`src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts`](diffhunk://#diff-f3e827a591f228340594a3b2c5cfc8b44384fe6007ad09b30d9e805c06c0fa09R10-R11): Added a `gap` property to the layout for improved spacing between elements.

<img width="1651" height="1002" alt="image" src="https://github.com/user-attachments/assets/9933ad4a-0b86-4499-a93a-45cc00525f8a" />
