### PR TITLE
feat: add table row expansion to table components (#569)

### DIFF
--- a/src/components/DataDictionary/components/Table/options/expanded/constants.ts
+++ b/src/components/DataDictionary/components/Table/options/expanded/constants.ts
@@ -6,8 +6,9 @@ import {
 
 export const EXPANDED_OPTIONS: Pick<
   ExpandedOptions<RowData>,
-  "enableExpanding" | "getExpandedRowModel"
+  "enableExpanding" | "getExpandedRowModel" | "getRowCanExpand"
 > = {
   enableExpanding: true,
   getExpandedRowModel: getExpandedRowModel(),
+  getRowCanExpand: () => true,
 };

--- a/src/components/Detail/components/Table/components/TableRows/tableRows.tsx
+++ b/src/components/Detail/components/Table/components/TableRows/tableRows.tsx
@@ -5,6 +5,7 @@ import {
   getTableCellAlign,
   getTableCellPadding,
 } from "../../../../../Table/components/TableCell/common/utils";
+import { handleToggleExpanded } from "../../../../../Table/components/TableFeatures/RowExpanding/utils";
 import { StyledTableRow } from "../../../../../Table/components/TableRow/tableRow.styles";
 import { TableView } from "../../table";
 
@@ -34,8 +35,11 @@ export const TableRows = <T extends RowData>({
         return (
           <StyledTableRow
             key={row.id}
+            canExpand={row.getCanExpand()}
+            isExpanded={row.getIsExpanded()}
             isGrouped={row.getIsGrouped()}
             isPreview={row.getIsPreview()}
+            onClick={() => handleToggleExpanded(row)}
           >
             {row.getVisibleCells().map((cell) => {
               if (cell.getIsAggregated()) return null; // Display of aggregated cells is currently not supported.

--- a/src/components/Links/components/Link/components/ExploreViewLink/exploreViewLink.tsx
+++ b/src/components/Links/components/Link/components/ExploreViewLink/exploreViewLink.tsx
@@ -46,12 +46,12 @@ export const ExploreViewLink = ({
     <Link
       className={className}
       href={url.href}
-      onClick={(): void => {
+      onClick={(e): void => {
         exploreDispatch({
           payload: { entityListType, filters, grouping, sorting },
           type: ExploreActionKind.UpdateEntityFilters,
         });
-        onClick?.();
+        onClick?.(e);
       }}
       rel={REL_ATTRIBUTE.NO_OPENER}
       target={target}

--- a/src/components/Links/components/Link/link.tsx
+++ b/src/components/Links/components/Link/link.tsx
@@ -22,7 +22,6 @@ export interface LinkProps
     Omit<MLinkProps, "children" | "component"> {
   copyable?: boolean;
   label: ReactNode /* link label may be an element */;
-  onClick?: () => void;
   target?: ANCHOR_TARGET;
   TypographyProps?: TypographyProps;
   url: Url /* url specified as UrlObject with href and query defined, and is currently only used for internal links */;

--- a/src/components/MarkdownRenderer/components/Anchor/anchor.tsx
+++ b/src/components/MarkdownRenderer/components/Anchor/anchor.tsx
@@ -28,6 +28,11 @@ export const Anchor = (
     <Link
       className={props.className}
       label={props.children}
+      /*
+       * Prevents click events from bubbling up to parent components
+       * (such as CardActionArea or Accordion) when the link is activated.
+       */
+      onClick={(e) => e.stopPropagation()}
       url={props.href || ""}
     />
   );

--- a/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
+++ b/src/components/Table/components/TableCell/components/LinkCell/linkCell.tsx
@@ -53,6 +53,11 @@ export const LinkCell = <
       color={color}
       component={getComponent(href, isClientSide)}
       href={href}
+      /*
+       * Prevents click events from bubbling up to parent components
+       * (such as CardActionArea or Accordion) when the link is activated.
+       */
+      onClick={(e) => e.stopPropagation()}
       rel={getRelAttribute(rel, isClientSide)}
       target={getTargetAttribute(target, isClientSide)}
       underline={underline}

--- a/src/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
+++ b/src/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
@@ -13,6 +13,11 @@ export const RowSelectionCell = <T extends RowData, TValue = unknown>({
       checked={getIsSelected()}
       checkedIcon={<CheckedIcon />}
       icon={<UncheckedIcon />}
+      /*
+       * Prevents click events from bubbling up to parent components
+       * (such as CardActionArea or Accordion) when the checkbox is activated.
+       */
+      onClick={(e) => e.stopPropagation()}
       onChange={getToggleSelectedHandler()}
     />
   );

--- a/src/components/Table/components/TableFeatures/RowExpanding/utils.ts
+++ b/src/components/Table/components/TableFeatures/RowExpanding/utils.ts
@@ -1,0 +1,25 @@
+import { Row, RowData } from "@tanstack/react-table";
+
+/**
+ * Handles toggling the expanded state of a row.
+ * Rows can not be expanded if:
+ * - the row can not be expanded.
+ * - the row is grouped (expanded rows are not supported on grouped rows).
+ * - the user is selecting text.
+ * @param row - Row.
+ */
+export function handleToggleExpanded<T extends RowData>(row: Row<T>): void {
+  const { getCanExpand, getIsGrouped, toggleExpanded } = row;
+
+  // Row can not be expanded.
+  if (!getCanExpand()) return;
+
+  // Row is grouped - row expansion not supported on a grouped row.
+  if (getIsGrouped()) return;
+
+  // User is selecting text - do not toggle row expanded state.
+  if (window.getSelection()?.toString()) return;
+
+  // Toggle row expanded state.
+  toggleExpanded();
+}

--- a/src/components/Table/components/TableRow/tableRow.styles.ts
+++ b/src/components/Table/components/TableRow/tableRow.styles.ts
@@ -1,19 +1,22 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { TableRow as MTableRow } from "@mui/material";
-import {
-  primaryLightest,
-  smokeLightest,
-} from "../../../../styles/common/mixins/colors";
+import { PALETTE } from "../../../../styles/common/constants/palette";
 import { textBodySmall500 } from "../../../../styles/common/mixins/fonts";
 
 export interface StyledTableRowProps {
+  canExpand?: boolean;
+  isExpanded?: boolean;
   isGrouped?: boolean;
   isPreview?: boolean;
 }
 
 export const StyledTableRow = styled(MTableRow, {
-  shouldForwardProp: (prop) => prop !== "isPreview" && prop !== "isGrouped",
+  shouldForwardProp: (prop) =>
+    prop !== "canExpand" &&
+    prop !== "isExpanded" &&
+    prop !== "isPreview" &&
+    prop !== "isGrouped",
 })<StyledTableRowProps>`
   && {
     transition: background-color 300ms ease-in;
@@ -21,7 +24,7 @@ export const StyledTableRow = styled(MTableRow, {
     ${(props) =>
       props.isGrouped &&
       css`
-        background-color: ${smokeLightest(props)};
+        background-color: ${PALETTE.SMOKE_LIGHTEST};
 
         td {
           ${textBodySmall500(props)};
@@ -30,10 +33,26 @@ export const StyledTableRow = styled(MTableRow, {
         }
       `}
 
-    ${(props) =>
-      props.isPreview &&
+    ${({ canExpand, isExpanded, isGrouped }) =>
+      !isGrouped &&
+      canExpand &&
       css`
-        background-color: ${primaryLightest(props)};
+        cursor: pointer;
+
+        &:hover {
+          background-color: #f8fbfd;
+        }
+
+        ${isExpanded &&
+        css`
+          background-color: #f8fbfd;
+        `}
+      `}
+
+    ${({ isPreview }) =>
+      isPreview &&
+      css`
+        background-color: ${PALETTE.PRIMARY_LIGHTEST};
       `}
   }
 `;

--- a/src/components/Table/components/TableRows/tableRows.tsx
+++ b/src/components/Table/components/TableRows/tableRows.tsx
@@ -7,6 +7,7 @@ import {
   getTableCellAlign,
   getTableCellPadding,
 } from "../TableCell/common/utils";
+import { handleToggleExpanded } from "../TableFeatures/RowExpanding/utils";
 import { StyledTableRow } from "../TableRow/tableRow.styles";
 
 export interface TableRowsProps<T extends RowData> {
@@ -24,13 +25,16 @@ export const TableRows = <T extends RowData>({
       {virtualItems.map((virtualRow) => {
         const rowIndex = virtualRow.index;
         const row = rows[rowIndex] as Row<T>;
-        const { getIsGrouped, getIsPreview } = row;
+        const { getCanExpand, getIsExpanded, getIsGrouped, getIsPreview } = row;
         return (
           <StyledTableRow
             key={row.id}
+            canExpand={getCanExpand()}
             data-index={rowIndex}
+            isExpanded={getIsExpanded()}
             isGrouped={getIsGrouped()}
             isPreview={getIsPreview()}
+            onClick={() => handleToggleExpanded(row)}
             ref={virtualizer.measureElement}
           >
             {row.getVisibleCells().map((cell, i) => {


### PR DESCRIPTION
Closes #569.

This pull request introduces functionality to support expandable table rows in the application. Key changes include adding the ability to toggle row expansion, updating styles for expandable rows, and ensuring proper integration with existing table components.

### New functionality for row expansion:
* Added a utility function `handleToggleExpanded` in `src/components/Table/components/TableFeatures/RowExpanding/utils.ts` to manage the logic for toggling the expanded state of rows, including checks for grouping and text selection.
* Updated the `EXPANDED_OPTIONS` object in `src/components/DataDictionary/components/Table/options/expanded/constants.ts` to include `getRowCanExpand`, enabling the expansion feature.

### Integration with table components:
* Modified `TableRows` components in `src/components/Detail/components/Table/components/TableRows/tableRows.tsx` and `src/components/Table/components/TableRows/tableRows.tsx` to pass `canExpand`, `isExpanded`, and `onClick` properties to rows, enabling interaction with the new expansion functionality. [[1]](diffhunk://#diff-43c05edeeab2dab26b92dd84cd70a8b04703577421956d9d0021fa3440d43b05R38-R42) [[2]](diffhunk://#diff-61e2f760fabb8e70dd8c671efa51ff2406da14214df8e8084c7b4ad6573715fcL27-R37)

### Styling updates for expandable rows:
* Enhanced the `StyledTableRow` component in `src/components/Table/components/TableRow/tableRow.styles.ts` to include visual indicators for expandable rows, such as pointer cursors and hover effects. Additionally, updated the color palette references for consistency. [[1]](diffhunk://#diff-857569b13da2fc3d48bc294caab6c301affada6d453a6418a0c58d163c033209L4-R27) [[2]](diffhunk://#diff-857569b13da2fc3d48bc294caab6c301affada6d453a6418a0c58d163c033209L33-R55)


https://github.com/user-attachments/assets/d555e0e0-21cb-4f65-99f5-2f628ce8cb47

