### PR TITLE
fix: fix markdown rendering overflow (#551)

### DIFF
--- a/src/components/MarkdownRenderer/markdownRenderer.styles.ts
+++ b/src/components/MarkdownRenderer/markdownRenderer.styles.ts
@@ -6,6 +6,9 @@ const ignoreSsrWarning =
   "/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */";
 
 export const StyledContainer = styled("div")`
+  min-width: 0;
+  width: 100%;
+
   > *:first-child:not(style)${ignoreSsrWarning} {
     margin-top: 0;
   }


### PR DESCRIPTION
Closes #551.

This pull request includes a small change to the `src/components/MarkdownRenderer/markdownRenderer.styles.ts` file. The change ensures that the `StyledContainer` has a `min-width` of `0` and a `width` of `100%`, likely to improve layout consistency.

<img width="860" height="1111" alt="image" src="https://github.com/user-attachments/assets/d5d2dcca-aad4-4249-bd1c-df4d413d08b4" />
