### PR TITLE
feat: update data dictionary smaller viewport navigation and search bar layouts (#583)

### DIFF
--- a/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.styles.ts
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.styles.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+import { ButtonGroup } from "@mui/material";
+import { bpDown820 } from "../../../../../../styles/common/mixins/breakpoints";
+
+export const StyledButtonGroup = styled(ButtonGroup)`
+  ${bpDown820} {
+    display: none;
+  }
+`;

--- a/src/components/DataDictionary/components/Filters/filters.styles.ts
+++ b/src/components/DataDictionary/components/Filters/filters.styles.ts
@@ -1,14 +1,9 @@
 import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
-import { mediaTabletDown } from "../../../../styles/common/mixins/breakpoints";
 
 export const StyledGrid = styled(Grid)`
   align-items: center;
   display: grid;
   gap: 16px;
   grid-template-columns: 1fr auto;
-
-  ${mediaTabletDown} {
-    grid-template-columns: 1fr;
-  }
 `;

--- a/src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
-import { mediaTabletDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
 import { LAYOUT_SPACING } from "../../constants";
 
 const PB = LAYOUT_SPACING.CONTENT_PADDING_BOTTOM; /* bottom padding */
@@ -15,7 +15,7 @@ export const Layout = styled("div")<LayoutSpacing>`
   padding-top: ${({ top }) => top}px;
   z-index: 1; /* not required, but helpful in that the entities are always on top */
 
-  ${mediaTabletDown} {
+  ${bpDown1024} {
     grid-column: 1;
     grid-row: auto;
     padding-top: ${PT}px;

--- a/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
-import { mediaTabletDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
 import { LAYOUT_SPACING } from "../../constants";
 
 const PB = LAYOUT_SPACING.FILTERS_PADDING_BOTTOM; /* bottom padding */
@@ -21,7 +21,7 @@ export const Layout = styled("div")<LayoutSpacing>`
   top: 0;
   z-index: 2; /* required, filters should be on top of entities */
 
-  ${mediaTabletDown} {
+  ${bpDown1024} {
     grid-column: 1;
     grid-row: auto;
     padding-top: ${PT}px;

--- a/src/components/DataDictionary/components/Layout/components/OutlineLayout/outlineLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/OutlineLayout/outlineLayout.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
-import { mediaTabletDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
 import { LAYOUT_SPACING } from "../../constants";
 
 const PB = LAYOUT_SPACING.CONTENT_PADDING_BOTTOM; /* bottom padding */
@@ -19,7 +19,7 @@ export const Layout = styled("div")<LayoutSpacing>`
   position: sticky;
   top: 0;
 
-  ${mediaTabletDown} {
+  ${bpDown1024} {
     display: none;
   }
 `;

--- a/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
-import { mediaTabletDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
 
 export const Layout = styled("div")<LayoutSpacing>`
   grid-column: 1 / -1;
@@ -11,7 +11,7 @@ export const Layout = styled("div")<LayoutSpacing>`
   top: 0;
   z-index: 4;
 
-  ${mediaTabletDown} {
+  ${bpDown1024} {
     grid-column: 1;
     grid-row: auto;
     position: relative;

--- a/src/components/DataDictionary/components/Title/title.styles.ts
+++ b/src/components/DataDictionary/components/Title/title.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { mediaTabletDown } from "../../../../styles/common/mixins/breakpoints";
+import { bpDown820 } from "../../../../styles/common/mixins/breakpoints";
 import { Title } from "../../../common/Title/title";
 
 export const StyledTitle = styled(Title)`
@@ -10,7 +10,7 @@ export const StyledTitle = styled(Title)`
     line-height: 42px;
     margin: 24px 0 8px;
 
-    ${mediaTabletDown} {
+    ${bpDown820} {
       font-size: 26px;
       line-height: 34px;
     }

--- a/src/components/DataDictionary/dataDictionary.styles.ts
+++ b/src/components/DataDictionary/dataDictionary.styles.ts
@@ -1,20 +1,15 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { mediaTabletDown } from "../../styles/common/mixins/breakpoints";
-
-export const grid = css`
-  column-gap: 24px;
-  display: grid;
-  grid-template-columns: 242px 1fr;
-`;
+import { bpDown1024 } from "../../styles/common/mixins/breakpoints";
 
 export const View = styled("div")`
-  ${grid};
+  column-gap: 24px;
+  display: grid;
   flex: 1;
+  grid-template-columns: 242px 1fr;
   margin: 0 24px;
   position: relative;
 
-  ${mediaTabletDown} {
+  ${bpDown1024} {
     grid-template-columns: 1fr;
     margin: 0 16px;
   }

--- a/src/styles/common/mixins/breakpoints.ts
+++ b/src/styles/common/mixins/breakpoints.ts
@@ -1,6 +1,12 @@
 import { DESKTOP, DESKTOP_SM, TABLET } from "../../../theme/common/breakpoints";
 import { ThemeProps } from "../../../theme/theme";
 
+export const bpDown820 = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.down(820);
+
+export const bpDown1024 = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.down(1024);
+
 export const mediaDesktopSmallDown = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down(DESKTOP_SM);
 


### PR DESCRIPTION
Closes #583.

This pull request focuses on updating the breakpoint mixins used across various styled components to improve responsiveness and maintain consistency. The most important changes include replacing the `mediaTabletDown` mixin with newly introduced `bpDown820` and `bpDown1024` mixins, as well as introducing new breakpoints in the `breakpoints.ts` file.

### Introduction of new breakpoints:
* [`src/styles/common/mixins/breakpoints.ts`](diffhunk://#diff-e6335f24e1ea71e29585444daf18b0bb2b7cb9eacddacbae7e39636a5fcd8856R4-R9): Added `bpDown820` and `bpDown1024` mixins for more precise control over responsive design.

### Updates to styled components:
* **Switch to `bpDown820`:**
  - [`src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.styles.ts`](diffhunk://#diff-bac17e62cc809a4487b1dce8b1c83b3904b9f43c0e291bb89db918e0df9fd1b5R1-R9): Added `StyledButtonGroup` styled component with `bpDown820` to hide button groups on smaller screens.
  - [`src/components/DataDictionary/components/Title/title.styles.ts`](diffhunk://#diff-e83eaa257d9274fb2d31bc951bf3bc5ccb0416c2df34d03919863bf4bc77a5e4L2-R2): Updated `StyledTitle` to use `bpDown820` for font size and line-height adjustments on smaller screens. [[1]](diffhunk://#diff-e83eaa257d9274fb2d31bc951bf3bc5ccb0416c2df34d03919863bf4bc77a5e4L2-R2) [[2]](diffhunk://#diff-e83eaa257d9274fb2d31bc951bf3bc5ccb0416c2df34d03919863bf4bc77a5e4L13-R13)

* **Switch to `bpDown1024`:**
  - [`src/components/DataDictionary/components/Layout/components/EntitiesLayout/entitiesLayout.styles.ts`](diffhunk://#diff-f3e827a591f228340594a3b2c5cfc8b44384fe6007ad09b30d9e805c06c0fa09L3-R3): Replaced `mediaTabletDown` with `bpDown1024` for layout adjustments. [[1]](diffhunk://#diff-f3e827a591f228340594a3b2c5cfc8b44384fe6007ad09b30d9e805c06c0fa09L3-R3) [[2]](diffhunk://#diff-f3e827a591f228340594a3b2c5cfc8b44384fe6007ad09b30d9e805c06c0fa09L18-R18)
  - [`src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts`](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL4-R4): Replaced `mediaTabletDown` with `bpDown1024` for filter layout adjustments. [[1]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL4-R4) [[2]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL24-R24)
  - [`src/components/DataDictionary/components/Layout/components/OutlineLayout/outlineLayout.styles.ts`](diffhunk://#diff-aa105531d57f3f744025ec6e98c80dd227ff655fd3f71f9f432671fb75f23d3aL3-R3): Updated `Layout` to use `bpDown1024` for hiding the outline layout on smaller screens. [[1]](diffhunk://#diff-aa105531d57f3f744025ec6e98c80dd227ff655fd3f71f9f432671fb75f23d3aL3-R3) [[2]](diffhunk://#diff-aa105531d57f3f744025ec6e98c80dd227ff655fd3f71f9f432671fb75f23d3aL22-R22)
  - [`src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts`](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L3-R3): Replaced `mediaTabletDown` with `bpDown1024` for title layout adjustments. [[1]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L3-R3) [[2]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L14-R14)
  - [`src/components/DataDictionary/dataDictionary.styles.ts`](diffhunk://#diff-08a9dee42e7fb0acba8a1754b8db71281ccbbcc6b06c1e5891b455e67648e906L1-R12): Updated the `View` styled component to use `bpDown1024` for grid column adjustments on smaller screens.

These changes ensure more granular control over responsive behavior and align the codebase with the new breakpoint strategy.

<img width="1013" height="1080" alt="image" src="https://github.com/user-attachments/assets/ade55c29-df24-4ad4-9bb2-24c35f522398" />
