### PR TITLE
refactor: drawerprovider to expose onClose via render prop (#585)

### DIFF
--- a/src/components/common/Drawer/provider/provider.tsx
+++ b/src/components/common/Drawer/provider/provider.tsx
@@ -1,12 +1,9 @@
-import React, { ReactNode, useCallback, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { DrawerContext } from "./context";
+import { DrawerProviderProps } from "./types";
 
-export function DrawerProvider({
-  children,
-}: {
-  children: ReactNode | ReactNode[];
-}): JSX.Element {
-  const [open, setOpen] = useState(false);
+export function DrawerProvider({ children }: DrawerProviderProps): JSX.Element {
+  const [open, setOpen] = useState<boolean>(false);
 
   const onClose = useCallback(() => setOpen(false), []);
 
@@ -14,7 +11,9 @@ export function DrawerProvider({
 
   return (
     <DrawerContext.Provider value={{ onClose, onOpen, open }}>
-      {children}
+      {typeof children === "function"
+        ? children({ onClose, onOpen, open })
+        : children}
     </DrawerContext.Provider>
   );
 }

--- a/src/components/common/Drawer/provider/types.ts
+++ b/src/components/common/Drawer/provider/types.ts
@@ -1,10 +1,12 @@
 import { DrawerProps } from "@mui/material";
+import { ReactNode } from "react";
 
-export type DrawerContextProps = Omit<
-  DrawerProps,
-  "onClose" | "onOpen" | "open"
-> & {
+export type DrawerContextProps = Omit<DrawerProps, "onClose"> & {
   onClose: () => void;
   onOpen: () => void;
   open: boolean;
+};
+
+export type DrawerProviderProps = {
+  children: ReactNode | ((props: DrawerContextProps) => ReactNode);
 };


### PR DESCRIPTION
Closes #585.

This pull request refactors the `DrawerProvider` component to improve type safety and enhance flexibility in how children are rendered. The key changes include introducing a new `DrawerProviderProps` type and updating the `DrawerProvider` implementation to support function-based children.

### Type improvements:
* [`src/components/common/Drawer/provider/types.ts`](diffhunk://#diff-6ffce666dcb687e6bb3ba63ec2c3ff675eb4e89c9f4ad7ddc07edf1c742e9c1cR2-R12): Added a new `DrawerProviderProps` type, which allows `children` to be either a `ReactNode` or a function that receives `DrawerContextProps` as an argument and returns a `ReactNode`.

### Component refactor:
* [`src/components/common/Drawer/provider/provider.tsx`](diffhunk://#diff-7cfc88fd9753f71b26690f991ac965e62c193d52076e76e47948220ecef0f257L1-R16): Updated the `DrawerProvider` component to use the new `DrawerProviderProps` type. The `children` prop now supports function-based rendering, enabling dynamic child rendering based on the `DrawerContext` state. Also added an explicit type for the `useState` hook to improve type safety.