### PR TITLE
feat!: create filter drawer component (#597)

### DIFF
--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -24,6 +24,16 @@ export interface Attribute {
 export type CategoryKey = string;
 
 /**
+ * Clear all filters key.
+ */
+export const CLEAR_ALL = "CLEAR_ALL" as const;
+
+/**
+ * Clear all filters type.
+ */
+export type ClearAll = typeof CLEAR_ALL;
+
+/**
  * View model of category tag.
  */
 export interface CategoryTag {

--- a/src/components/DataDictionary/components/Filters/components/ColumnFilterTags/columnFilterTags.tsx
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilterTags/columnFilterTags.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import { Button, Theme, useMediaQuery } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import React from "react";
 import { Attribute } from "../../../../../../common/entities";
@@ -14,8 +14,11 @@ export const ColumnFilterTags = <T extends RowData = Attribute>({
 }: ColumnFilterTagsProps<T>): JSX.Element | null => {
   const { getAllColumns, resetColumnFilters } = table;
   const columns = getAllColumns().filter((column) => column.getIsFiltered());
+  const isDrawer = useMediaQuery((theme: Theme) => theme.breakpoints.down(820));
 
   if (columns.length === 0) return null;
+
+  if (isDrawer) return null;
 
   return (
     <StyledGrid className={className} {...GRID_PROPS}>

--- a/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.styles.ts
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.styles.ts
@@ -1,9 +1,0 @@
-import styled from "@emotion/styled";
-import { ButtonGroup } from "@mui/material";
-import { bpDown820 } from "../../../../../../styles/common/mixins/breakpoints";
-
-export const StyledButtonGroup = styled(ButtonGroup)`
-  ${bpDown820} {
-    display: none;
-  }
-`;

--- a/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
@@ -1,8 +1,10 @@
-import { ButtonGroup } from "@mui/material";
+import { ButtonGroup, Theme, useMediaQuery } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import React from "react";
 import { Attribute } from "../../../../../../common/entities";
 import { BUTTON_GROUP_PROPS } from "../../../../../common/ButtonGroup/constants";
+import { ColumnFiltersAdapter } from "../../../../../Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter";
+import { Drawer } from "../../../../../Filter/components/surfaces/drawer/Drawer/drawer";
 import { ColumnFilter } from "../../../../../Table/components/TableFeatures/ColumnFilter/columnFilter";
 import { ColumnFiltersProps } from "./types";
 
@@ -12,8 +14,17 @@ export const ColumnFilters = <T extends RowData = Attribute>({
   const columns = table.getAllColumns();
   const columnFilters = columns.filter((column) => column.getCanFilter());
   const enableColumnFilters = table.options.enableColumnFilters;
+  const isDrawer = useMediaQuery((theme: Theme) => theme.breakpoints.down(820));
 
   if (!enableColumnFilters) return null;
+
+  if (isDrawer)
+    return (
+      <ColumnFiltersAdapter
+        table={table}
+        renderSurface={(props) => <Drawer {...props} />}
+      />
+    );
 
   return (
     <ButtonGroup {...BUTTON_GROUP_PROPS.SECONDARY_OUTLINED}>

--- a/src/components/DataDictionary/components/Filters/stories/constants.ts
+++ b/src/components/DataDictionary/components/Filters/stories/constants.ts
@@ -47,3 +47,5 @@ export const REQUIRED: PartialColumn = {
     ]),
   id: "required",
 };
+
+export const COLUMNS = [DESCRIPTION, REQUIRED, BIONETWORK, EXAMPLE];

--- a/src/components/DataDictionary/components/Filters/stories/filters.stories.tsx
+++ b/src/components/DataDictionary/components/Filters/stories/filters.stories.tsx
@@ -4,9 +4,10 @@ import { Meta, StoryObj } from "@storybook/react";
 import { functionalUpdate, Table } from "@tanstack/react-table";
 import React from "react";
 import { Filters } from "../filters";
-import { BIONETWORK, DESCRIPTION, EXAMPLE, REQUIRED } from "./constants";
+import { COLUMNS } from "./constants";
 import { useFilterStore, useGlobalFilterStore } from "./hook";
 import { PartialColumn } from "./types";
+import { buildColumnFilters } from "./utils";
 
 const meta: Meta<typeof Filters> = {
   component: Filters,
@@ -27,6 +28,9 @@ const DefaultStory = (): JSX.Element => {
   const { filterStore, setFilterStore } = useFilterStore();
   const { globalFilter, setGlobalFilter } = useGlobalFilterStore();
 
+  // Builds column filters from filter store.
+  const columnFilters = buildColumnFilters(filterStore);
+
   const makeColumn = (column: PartialColumn): PartialColumn => ({
     ...column,
     getFilterValue: () => filterStore[column.id],
@@ -39,10 +43,13 @@ const DefaultStory = (): JSX.Element => {
     },
   });
 
+  // Make the columns.
+  const columns = COLUMNS.map(makeColumn);
+
   const table = {
-    getAllColumns: () =>
-      [DESCRIPTION, REQUIRED, BIONETWORK, EXAMPLE].map(makeColumn),
-    getState: () => ({ globalFilter }),
+    getAllColumns: () => columns,
+    getColumn: (columnId: string) => columns.find(({ id }) => id === columnId)!,
+    getState: () => ({ columnFilters, globalFilter }),
     options: { enableColumnFilters: true, enableGlobalFilter: true },
     setGlobalFilter,
   } as Table<unknown>;

--- a/src/components/DataDictionary/components/Filters/stories/utils.ts
+++ b/src/components/DataDictionary/components/Filters/stories/utils.ts
@@ -1,0 +1,15 @@
+import { ColumnFiltersState } from "@tanstack/react-table";
+
+/**
+ * Builds column filters from filter store.
+ * @param filterStore - The filter store.
+ * @returns The column filters.
+ */
+export function buildColumnFilters(
+  filterStore: Record<string, unknown>
+): ColumnFiltersState {
+  return Object.entries(filterStore).reduce((acc, [id, value]) => {
+    if (!value) return acc;
+    return [...acc, { id, value }];
+  }, [] as ColumnFiltersState);
+}

--- a/src/components/Filter/components/Filter/filter.styles.ts
+++ b/src/components/Filter/components/Filter/filter.styles.ts
@@ -1,28 +1,26 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Popover } from "@mui/material";
-import { mediaDesktopSmallDown } from "../../../../styles/common/mixins/breakpoints";
-import { smokeLight, white } from "../../../../styles/common/mixins/colors";
-import { IconButton as DXIconButton } from "../../../common/IconButton/iconButton";
+import { PALETTE } from "../../../../styles/common/constants/palette";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { FilterProps } from "./filter";
 
-export const FilterPopover = styled(Popover)`
+export const StyledPopover = styled(Popover, {
+  shouldForwardProp: (prop) => prop !== "surfaceType",
+})<Pick<FilterProps, "surfaceType">>`
   .MuiPaper-menu {
     margin: 4px 0;
   }
 
-  ${mediaDesktopSmallDown} {
-    .MuiPaper-root {
-      background-color: ${smokeLight};
-      height: 100%;
-      margin: 0;
-      max-height: 100%;
-      overflow: visible; // required; allows backdrop button to render outside of drawer container.
-    }
-  }
-`;
-
-export const IconButton = styled(DXIconButton)`
-  color: ${white};
-  left: calc(100% + 4px);
-  position: absolute;
-  top: 4px;
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.DRAWER &&
+    css`
+      .MuiPaper-root {
+        background-color: ${PALETTE.SMOKE_LIGHT};
+        height: 100%;
+        margin: 0;
+        max-height: 100%;
+        overflow: visible; // required; allows backdrop button to render outside of drawer container.
+      }
+    `}
 `;

--- a/src/components/Filter/components/Filter/filter.tsx
+++ b/src/components/Filter/components/Filter/filter.tsx
@@ -1,4 +1,3 @@
-import { CloseRounded } from "@mui/icons-material";
 import { Grow, PopoverPosition, PopoverProps } from "@mui/material";
 import React, { MouseEvent, ReactNode, useState } from "react";
 import { isRangeCategoryView } from "../../../../common/categories/views/range/typeGuards";
@@ -9,8 +8,10 @@ import { TEST_IDS } from "../../../../tests/testIds";
 import { FilterLabel } from "../FilterLabel/filterLabel";
 import { FilterMenu } from "../FilterMenu/filterMenu";
 import { FilterRange } from "../FilterRange/filterRange";
+import { IconButton } from "../surfaces/drawer/components/IconButton/iconButton";
+import { SURFACE_TYPE } from "../surfaces/types";
 import { DrawerTransition } from "./components/DrawerTransition/drawerTransition";
-import { FilterPopover, IconButton } from "./filter.styles";
+import { StyledPopover } from "./filter.styles";
 
 /**
  * Filter component.
@@ -30,8 +31,8 @@ export interface FilterProps {
   categorySection?: string;
   categoryView: CategoryView;
   closeAncestor?: () => void;
-  isFilterDrawer: boolean;
   onFilter: OnFilterFn;
+  surfaceType: SURFACE_TYPE;
   tags?: ReactNode; // e.g. filter tags
   trackFilterOpened?: TrackFilterOpenedFunction;
 }
@@ -40,18 +41,19 @@ export const Filter = ({
   categorySection,
   categoryView,
   closeAncestor,
-  isFilterDrawer,
   onFilter,
+  surfaceType,
   tags,
   trackFilterOpened,
 }: FilterProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [position, setPosition] = useState<PopoverPosition>(DEFAULT_POSITION);
-  const anchorPosition = isFilterDrawer ? DEFAULT_POSITION : position;
-  const slotProps = isFilterDrawer ? DRAWER_SLOT_PROPS : DEFAULT_SLOT_PROPS;
-  const TransitionComponent = isFilterDrawer ? DrawerTransition : Grow;
+  const isDrawer = surfaceType === SURFACE_TYPE.DRAWER;
+  const anchorPosition = isDrawer ? DEFAULT_POSITION : position;
+  const slotProps = isDrawer ? DRAWER_SLOT_PROPS : DEFAULT_SLOT_PROPS;
+  const TransitionComponent = isDrawer ? DrawerTransition : Grow;
   const transitionDuration = isOpen ? 250 : 300;
-  const TransitionDuration = isFilterDrawer ? transitionDuration : undefined;
+  const TransitionDuration = isDrawer ? transitionDuration : undefined;
   const isRangeView = isRangeCategoryView(categoryView);
 
   /**
@@ -93,8 +95,9 @@ export const Filter = ({
         isOpen={isOpen}
         label={categoryView.label}
         onClick={onOpenFilter}
+        surfaceType={surfaceType}
       />
-      <FilterPopover
+      <StyledPopover
         anchorPosition={anchorPosition}
         anchorReference="anchorPosition"
         data-testid={TEST_IDS.FILTER_POPOVER}
@@ -103,27 +106,22 @@ export const Filter = ({
         open={isOpen}
         slotProps={slotProps}
         slots={{ transition: TransitionComponent }}
+        surfaceType={surfaceType}
         transitionDuration={TransitionDuration}
       >
-        {isOpen && isFilterDrawer && (
-          <IconButton
-            Icon={CloseRounded}
-            onClick={onCloseFilters}
-            size="medium"
-          />
-        )}
+        {isDrawer && <IconButton onClick={onCloseFilters} />}
         {isRangeView ? (
           <FilterRange
             categoryKey={categoryView.key}
             categoryLabel={categoryView.label}
             categorySection={categorySection}
-            isFilterDrawer={isFilterDrawer}
             max={categoryView.max}
             min={categoryView.min}
             selectedMax={categoryView.selectedMax}
             selectedMin={categoryView.selectedMin}
             onCloseFilter={onCloseFilter}
             onFilter={onFilter}
+            surfaceType={surfaceType}
             unit={categoryView.unit}
           />
         ) : (
@@ -131,13 +129,13 @@ export const Filter = ({
             categoryKey={categoryView.key}
             categoryLabel={categoryView.label}
             categorySection={categorySection}
-            isFilterDrawer={isFilterDrawer}
             onCloseFilter={onCloseFilter}
             onFilter={onFilter}
+            surfaceType={surfaceType}
             values={categoryView.values}
           />
         )}
-      </FilterPopover>
+      </StyledPopover>
       {tags}
     </>
   );

--- a/src/components/Filter/components/Filter/stories/args.ts
+++ b/src/components/Filter/components/Filter/stories/args.ts
@@ -1,12 +1,13 @@
 import { fn } from "@storybook/test";
 import { ComponentProps } from "react";
 import { DONOR_COUNT, GENUS_SPECIES } from "../../Filters/stories/constants";
+import { SURFACE_TYPE } from "../../surfaces/types";
 import { Filter } from "../filter";
 
 export const SELECT_ARGS: ComponentProps<typeof Filter> = {
   categoryView: GENUS_SPECIES,
-  isFilterDrawer: false,
   onFilter: fn(),
+  surfaceType: SURFACE_TYPE.MENU,
 };
 
 export const DISABLED_SELECT_ARGS: ComponentProps<typeof Filter> = {
@@ -19,6 +20,6 @@ export const DISABLED_SELECT_ARGS: ComponentProps<typeof Filter> = {
 
 export const RANGE_ARGS: ComponentProps<typeof Filter> = {
   categoryView: DONOR_COUNT,
-  isFilterDrawer: false,
   onFilter: fn(),
+  surfaceType: SURFACE_TYPE.MENU,
 };

--- a/src/components/Filter/components/FilterLabel/filterLabel.stories.tsx
+++ b/src/components/Filter/components/FilterLabel/filterLabel.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { SURFACE_TYPE } from "../surfaces/types";
 import { FilterLabel } from "./filterLabel";
 
 const meta = {
@@ -31,5 +32,6 @@ export const FilterLabelStory: Story = {
     isOpen: false,
     label: "Label",
     onClick: () => {},
+    surfaceType: SURFACE_TYPE.MENU,
   },
 };

--- a/src/components/Filter/components/FilterLabel/filterLabel.styles.ts
+++ b/src/components/Filter/components/FilterLabel/filterLabel.styles.ts
@@ -1,16 +1,14 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
-import { mediaDesktopSmallUp } from "../../../../styles/common/mixins/breakpoints";
+import { PALETTE } from "../../../../styles/common/constants/palette";
 import { inkLight, smokeMain } from "../../../../styles/common/mixins/colors";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { FilterLabelProps } from "./filterLabel";
 
-interface Props {
-  isOpen: boolean;
-}
-
-export const FilterLabel = styled(Button, {
-  shouldForwardProp: (prop) => prop !== "isOpen",
-})<Props>`
+export const StyledButton = styled(Button, {
+  shouldForwardProp: (prop) => prop !== "isOpen" && prop !== "surfaceType",
+})<Pick<FilterLabelProps, "isOpen" | "surfaceType">>`
   font-weight: inherit;
   gap: 0;
   justify-content: space-between;
@@ -32,23 +30,26 @@ export const FilterLabel = styled(Button, {
     transform: rotate(-90deg);
   }
 
-  ${mediaDesktopSmallUp} {
-    padding: 6px 8px;
-
-    & .MuiButton-endIcon {
-      transform: unset;
-    }
-  }
-
-  ${(props) =>
-    props.isOpen &&
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.MENU &&
     css`
-      background-color: ${smokeMain(props)};
+      padding: 6px 8px;
 
-      ${mediaDesktopSmallUp(props)} {
+      & .MuiButton-endIcon {
+        transform: unset;
+      }
+    `}
+
+  ${({ isOpen, surfaceType }) =>
+    isOpen &&
+    css`
+      background-color: ${PALETTE.SMOKE_MAIN};
+
+      ${surfaceType === SURFACE_TYPE.MENU &&
+      css`
         & .MuiButton-endIcon {
           transform: rotate(180deg);
         }
-      }
+      `}
     `};
 `;

--- a/src/components/Filter/components/FilterLabel/filterLabel.tsx
+++ b/src/components/Filter/components/FilterLabel/filterLabel.tsx
@@ -2,7 +2,8 @@ import { ArrowDropDownRounded } from "@mui/icons-material";
 import React, { MouseEvent } from "react";
 import { DataDictionaryAnnotation } from "../../../../common/entities";
 import { Tooltip } from "../../../DataDictionary/components/Tooltip/tooltip";
-import { FilterLabel as Label } from "./filterLabel.styles";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { StyledButton } from "./filterLabel.styles";
 
 export interface FilterLabelProps {
   annotation?: DataDictionaryAnnotation;
@@ -11,6 +12,7 @@ export interface FilterLabelProps {
   isOpen: boolean;
   label: string;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  surfaceType: SURFACE_TYPE;
 }
 
 export const FilterLabel = ({
@@ -20,20 +22,22 @@ export const FilterLabel = ({
   isOpen,
   label,
   onClick,
+  surfaceType,
 }: FilterLabelProps): JSX.Element => {
   const filterLabel = count ? `${label}\xa0(${count})` : label; // When the count is present, a non-breaking space is used to prevent it from being on its own line
   return (
     <Tooltip description={annotation?.description} title={annotation?.label}>
-      <Label
+      <StyledButton
         color="inherit"
         disabled={disabled}
         endIcon={<ArrowDropDownRounded fontSize="small" />}
         fullWidth
         isOpen={isOpen}
         onClick={onClick}
+        surfaceType={surfaceType}
       >
         {filterLabel}
-      </Label>
+      </StyledButton>
     </Tooltip>
   );
 };

--- a/src/components/Filter/components/FilterList/filterList.styles.ts
+++ b/src/components/Filter/components/FilterList/filterList.styles.ts
@@ -33,7 +33,7 @@ export const MuiListItemTextRoot = css`
   }
 `;
 
-export const List = styled(MList)`
+export const StyledList = styled(MList)`
   && {
     overflow-wrap: break-word;
     margin: ${LIST_MARGIN}px 0;

--- a/src/components/Filter/components/FilterMenu/filterMenu.stories.tsx
+++ b/src/components/Filter/components/FilterMenu/filterMenu.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { SURFACE_TYPE } from "../surfaces/types";
 import { FilterMenu } from "./filterMenu";
 
 const meta = {
@@ -28,10 +29,10 @@ export const FilterMenuStory: Story = {
   args: {
     categoryKey: "donorDisease",
     categoryLabel: "Donor Disease",
-    isFilterDrawer: false,
     menuWidth: 312,
     onCloseFilter: () => {},
     onFilter: () => {},
+    surfaceType: SURFACE_TYPE.MENU,
     values: [
       {
         count: 312,

--- a/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
+++ b/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
@@ -1,7 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { ButtonBase } from "@mui/material";
-import { mediaDesktopSmallUp } from "../../../../styles/common/mixins/breakpoints";
-import { textBodyLarge500 } from "../../../../styles/common/mixins/fonts";
+import { FilterProps } from "../Filter/filter";
+import { SURFACE_TYPE } from "../surfaces/types";
 
 interface Props {
   menuWidth: number;
@@ -11,21 +11,12 @@ export const FilterView = styled.div<Props>`
   width: ${({ menuWidth }) => `${menuWidth}px`};
 `;
 
-export const FilterViewTools = styled.div`
+export const FilterViewTools = styled("div")<Pick<FilterProps, "surfaceType">>`
   margin: 24px 0 8px;
 
-  ${mediaDesktopSmallUp} {
-    margin: 0;
-  }
-}
-`;
-
-export const StyledButtonBase = styled(ButtonBase)`
-  ${textBodyLarge500};
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  justify-content: flex-start;
-  padding: 12px 16px;
-  width: 100%;
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.MENU &&
+    css`
+      margin: 0;
+    `}
 `;

--- a/src/components/Filter/components/FilterMenu/filterMenu.tsx
+++ b/src/components/Filter/components/FilterMenu/filterMenu.tsx
@@ -4,28 +4,25 @@ import {
   SelectCategoryValueView,
 } from "../../../../common/entities";
 import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
-import { SouthIcon } from "../../../common/CustomIcon/components/SouthIcon/southIcon";
 import { MAX_DISPLAYABLE_LIST_ITEMS } from "../../common/constants";
 import { FilterMenuSearchMatch } from "../../common/entities";
 import { getSortMatchesFn } from "../../common/utils";
-import { List } from "../FilterList/filterList.styles";
+import { StyledList } from "../FilterList/filterList.styles";
 import { FilterMenuSearch } from "../FilterMenuSearch/filterMenuSearch";
 import { FilterNoResultsFound } from "../FilterNoResultsFound/filterNoResultsFound";
+import { ButtonBase } from "../surfaces/drawer/components/ButtonBase/buttonBase";
+import { SURFACE_TYPE } from "../surfaces/types";
 import { VariableSizeList } from "../VariableSizeList/VariableSizeList";
-import {
-  FilterView,
-  FilterViewTools,
-  StyledButtonBase,
-} from "./filterMenu.styles";
+import { FilterView, FilterViewTools } from "./filterMenu.styles";
 
 export interface FilterMenuProps {
   categoryKey: CategoryKey;
   categoryLabel: string;
   categorySection?: string;
-  isFilterDrawer: boolean;
   menuWidth?: number;
   onCloseFilter: () => void;
   onFilter: OnFilterFn;
+  surfaceType: SURFACE_TYPE;
   values: SelectCategoryValueView[];
 }
 
@@ -33,29 +30,28 @@ export const FilterMenu = ({
   categoryKey,
   categoryLabel,
   categorySection,
-  isFilterDrawer,
   menuWidth = 312,
   onCloseFilter,
   onFilter,
+  surfaceType,
   values,
 }: FilterMenuProps): JSX.Element => {
   const [searchTerm, setSearchTerm] = useState<string>("");
   const isSearchable =
-    isFilterDrawer || values.length > MAX_DISPLAYABLE_LIST_ITEMS;
+    surfaceType === SURFACE_TYPE.DRAWER ||
+    values.length > MAX_DISPLAYABLE_LIST_ITEMS;
   const matchedItems = applyMenuFilter(values, isSearchable ? searchTerm : "");
   return (
     <FilterView menuWidth={menuWidth}>
-      <FilterViewTools>
-        {isFilterDrawer && (
-          <StyledButtonBase onClick={onCloseFilter}>
-            <SouthIcon fontSize="small" />
-            {categoryLabel}
-          </StyledButtonBase>
+      <FilterViewTools surfaceType={surfaceType}>
+        {surfaceType === SURFACE_TYPE.DRAWER && (
+          <ButtonBase onClick={onCloseFilter}>{categoryLabel}</ButtonBase>
         )}
         {isSearchable && (
           <FilterMenuSearch
             searchTerm={searchTerm}
             setSearchTerm={setSearchTerm}
+            surfaceType={surfaceType}
           />
         )}
       </FilterViewTools>
@@ -63,16 +59,16 @@ export const FilterMenu = ({
         <VariableSizeList
           categorySection={categorySection}
           categoryKey={categoryKey}
-          isFilterDrawer={isFilterDrawer}
           onFilter={onFilter}
           matchedItems={matchedItems}
+          surfaceType={surfaceType}
         />
       ) : (
-        <List>
+        <StyledList>
           <FilterNoResultsFound
             onClearSearchTerm={(): void => setSearchTerm("")}
           />
-        </List>
+        </StyledList>
       )}
     </FilterView>
   );

--- a/src/components/Filter/components/FilterMenuSearch/filterMenuSearch.styles.ts
+++ b/src/components/Filter/components/FilterMenuSearch/filterMenuSearch.styles.ts
@@ -1,16 +1,22 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { mediaDesktopSmallUp } from "../../../../styles/common/mixins/breakpoints";
 import { inkLight } from "../../../../styles/common/mixins/colors";
 import { Input } from "../../../common/Input/input";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { FilterMenuSearchProps } from "./filterMenuSearch";
 
-export const FilterMenuSearch = styled(Input)`
+export const StyledInput = styled(Input, {
+  shouldForwardProp: (prop) => prop !== "surfaceType",
+})<Pick<FilterMenuSearchProps, "surfaceType">>`
   padding: 0 16px;
 
   .MuiOutlinedInput-input {
     color: ${inkLight};
   }
 
-  ${mediaDesktopSmallUp} {
-    margin-top: 16px;
-  }
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.MENU &&
+    css`
+      margin-top: 16px;
+    `}
 `;

--- a/src/components/Filter/components/FilterMenuSearch/filterMenuSearch.tsx
+++ b/src/components/Filter/components/FilterMenuSearch/filterMenuSearch.tsx
@@ -1,16 +1,19 @@
 import React from "react";
 import { SearchIcon } from "../../../common/CustomIcon/components/SearchIcon/searchIcon";
 import { SetSearchTermFn } from "../../common/entities";
-import { FilterMenuSearch as Search } from "./filterMenuSearch.styles";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { StyledInput as Search } from "./filterMenuSearch.styles";
 
 export interface FilterMenuSearchProps {
   searchTerm: string;
   setSearchTerm: SetSearchTermFn;
+  surfaceType: SURFACE_TYPE;
 }
 
 export const FilterMenuSearch = ({
   searchTerm,
   setSearchTerm,
+  surfaceType,
 }: FilterMenuSearchProps): JSX.Element => {
   return (
     <Search
@@ -18,6 +21,7 @@ export const FilterMenuSearch = ({
       searchTerm={searchTerm}
       setSearchTerm={setSearchTerm}
       StartAdornment={SearchIcon}
+      surfaceType={surfaceType}
     />
   );
 };

--- a/src/components/Filter/components/FilterRange/filterRange.styles.ts
+++ b/src/components/Filter/components/FilterRange/filterRange.styles.ts
@@ -1,9 +1,11 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { mediaDesktopSmallDown } from "../../../../styles/common/mixins/breakpoints";
 import { textBody400 } from "../../../../styles/common/mixins/fonts";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { FilterRangeProps } from "./types";
 
-export const StyledForm = styled("form")`
+export const StyledForm = styled("form")<Pick<FilterRangeProps, "surfaceType">>`
   padding: 16px;
   width: 396px;
 
@@ -94,23 +96,27 @@ export const StyledForm = styled("form")`
     grid-column: 1 / -1;
   }
 
-  ${mediaDesktopSmallDown} {
-    padding: 0 16px;
-    width: 312px;
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.DRAWER &&
+    css`
+       {
+        padding: 0 16px;
+        width: 312px;
 
-    .MuiGrid-root {
-      gap: 16px 0;
-      grid-template-rows: auto auto;
-      margin: 16px 0;
+        .MuiGrid-root {
+          gap: 16px 0;
+          grid-template-rows: auto auto;
+          margin: 16px 0;
 
-      .MuiFormControl-root {
-        grid-row: unset;
-        grid-template-rows: unset;
+          .MuiFormControl-root {
+            grid-row: unset;
+            grid-template-rows: unset;
+          }
+
+          .MuiDivider-root {
+            display: none;
+          }
+        }
       }
-
-      .MuiDivider-root {
-        display: none;
-      }
-    }
-  }
+    `}
 `;

--- a/src/components/Filter/components/FilterRange/filterRange.tsx
+++ b/src/components/Filter/components/FilterRange/filterRange.tsx
@@ -11,11 +11,9 @@ import {
 } from "@mui/material";
 import React, { Fragment } from "react";
 import { TEST_IDS } from "../../../../tests/testIds";
-import { SouthIcon } from "../../../common/CustomIcon/components/SouthIcon/southIcon";
-import {
-  FilterViewTools,
-  StyledButtonBase,
-} from "../FilterMenu/filterMenu.styles";
+import { FilterViewTools } from "../FilterMenu/filterMenu.styles";
+import { ButtonBase } from "../surfaces/drawer/components/ButtonBase/buttonBase";
+import { SURFACE_TYPE } from "../surfaces/types";
 import {
   BUTTON_PROPS,
   DIVIDER_PROPS,
@@ -35,13 +33,13 @@ export const FilterRange = ({
   categoryLabel,
   categorySection,
   className,
-  isFilterDrawer,
   max,
   min,
   onCloseFilter,
   onFilter,
   selectedMax,
   selectedMin,
+  surfaceType,
   unit,
 }: FilterRangeProps): JSX.Element => {
   const rangeOperator = getRangeOperator({ selectedMax, selectedMin });
@@ -54,12 +52,9 @@ export const FilterRange = ({
   } = useFilterRange(rangeOperator);
   return (
     <Fragment>
-      {isFilterDrawer && (
-        <FilterViewTools>
-          <StyledButtonBase onClick={onCloseFilter}>
-            <SouthIcon fontSize="small" />
-            {categoryLabel}
-          </StyledButtonBase>
+      {surfaceType === SURFACE_TYPE.DRAWER && (
+        <FilterViewTools surfaceType={surfaceType}>
+          <ButtonBase onClick={onCloseFilter}>{categoryLabel}</ButtonBase>
         </FilterViewTools>
       )}
       <StyledForm
@@ -69,6 +64,7 @@ export const FilterRange = ({
           categoryKey,
           categorySection,
         })}
+        surfaceType={surfaceType}
       >
         <ToggleButtonGroup
           {...TOGGLE_BUTTON_GROUP_PROPS}

--- a/src/components/Filter/components/FilterRange/stories/args.ts
+++ b/src/components/Filter/components/FilterRange/stories/args.ts
@@ -1,16 +1,17 @@
 import { fn } from "@storybook/test";
 import { ComponentProps } from "react";
+import { SURFACE_TYPE } from "../../surfaces/types";
 import { FilterRange } from "../filterRange";
 
 export const DEFAULT_ARGS: ComponentProps<typeof FilterRange> = {
   categoryKey: "Weight",
   categoryLabel: "Weight",
-  isFilterDrawer: false,
   max: 2100,
   min: 100,
   onCloseFilter: fn(),
   onFilter: fn(),
   selectedMax: null,
   selectedMin: null,
+  surfaceType: SURFACE_TYPE.MENU,
   unit: "kg",
 };

--- a/src/components/Filter/components/FilterRange/types.ts
+++ b/src/components/Filter/components/FilterRange/types.ts
@@ -2,6 +2,7 @@ import { RangeCategoryView } from "../../../../common/categories/views/range/typ
 import { CategoryKey } from "../../../../common/entities";
 import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
 import { BaseComponentProps } from "../../../types";
+import { SURFACE_TYPE } from "../surfaces/types";
 
 export interface FilterRangeProps
   extends Omit<RangeCategoryView, "key" | "label">,
@@ -9,7 +10,7 @@ export interface FilterRangeProps
   categoryKey: CategoryKey;
   categoryLabel: string;
   categorySection?: string;
-  isFilterDrawer: boolean;
   onCloseFilter: () => void;
   onFilter: OnFilterFn;
+  surfaceType: SURFACE_TYPE;
 }

--- a/src/components/Filter/components/Filters/filters.styles.ts
+++ b/src/components/Filter/components/Filters/filters.styles.ts
@@ -1,18 +1,18 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { mediaDesktopSmallUp } from "../../../../styles/common/mixins/breakpoints";
-import { inkLight, inkMain } from "../../../../styles/common/mixins/colors";
-import {
-  textBody500,
-  textUppercase500,
-} from "../../../../styles/common/mixins/fonts";
+import { Typography } from "@mui/material";
+import { inkMain } from "../../../../styles/common/mixins/colors";
+import { textBody500 } from "../../../../styles/common/mixins/fonts";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { FiltersProps } from "./filters";
 
 interface Props {
-  disabled: boolean;
   height: number;
 }
 
-export const Filters = styled("div")<Props>`
+export const Filters = styled("div")<
+  Props & Pick<FiltersProps, "disabled" | "surfaceType">
+>`
   ${textBody500};
   color: ${inkMain};
   height: ${({ height }) => height}px;
@@ -31,15 +31,15 @@ export const Filters = styled("div")<Props>`
     margin: 8px;
   }
 
-  ${mediaDesktopSmallUp} {
-    height: unset;
-    overflow: unset;
-    padding: 0 8px;
-  }
+  ${({ surfaceType }) =>
+    surfaceType === SURFACE_TYPE.MENU &&
+    css`
+      height: unset;
+      overflow: unset;
+      padding: 0 8px;
+    `}
 `;
 
-export const CategoryViewsLabel = styled("div")`
-  ${textUppercase500};
-  color: ${inkLight};
+export const StyledTypography = styled(Typography)`
   padding: 8px;
 `;

--- a/src/components/Filter/components/Filters/filters.tsx
+++ b/src/components/Filter/components/Filters/filters.tsx
@@ -4,19 +4,16 @@ import { isRangeCategoryView } from "../../../../common/categories/views/range/t
 import { CategoryView } from "../../../../common/categories/views/types";
 import { CategoryTag } from "../../../../common/entities";
 import { TrackFilterOpenedFunction } from "../../../../config/entities";
-import {
-  BREAKPOINT_FN_NAME,
-  useBreakpointHelper,
-} from "../../../../hooks/useBreakpointHelper";
 import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
 import { useWindowResize } from "../../../../hooks/useWindowResize";
+import { TYPOGRAPHY_PROPS } from "../../../../styles/common/mui/typography";
 import { TEST_IDS } from "../../../../tests/testIds";
-import { DESKTOP_SM } from "../../../../theme/common/breakpoints";
 import { useDrawer } from "../../../common/Drawer/provider/hook";
 import { Filter } from "../Filter/filter";
 import { buildRangeTag } from "../FilterTag/utils";
 import { FilterTags } from "../FilterTags/filterTags";
-import { CategoryViewsLabel, Filters as FilterList } from "./filters.styles";
+import { SURFACE_TYPE } from "../surfaces/types";
+import { Filters as FilterList, StyledTypography } from "./filters.styles";
 
 export interface CategoryFilter {
   categoryViews: CategoryView[];
@@ -27,6 +24,7 @@ export interface FiltersProps {
   categoryFilters: CategoryFilter[];
   disabled?: boolean; // Global disabling of filters.
   onFilter: OnFilterFn;
+  surfaceType?: SURFACE_TYPE;
   trackFilterOpened?: TrackFilterOpenedFunction;
 }
 
@@ -76,13 +74,10 @@ export const Filters = ({
   categoryFilters,
   disabled = false,
   onFilter,
+  surfaceType = SURFACE_TYPE.MENU,
   trackFilterOpened,
 }: FiltersProps): JSX.Element => {
   const { onClose } = useDrawer();
-  const isFilterDrawer = useBreakpointHelper(
-    BREAKPOINT_FN_NAME.DOWN,
-    DESKTOP_SM
-  );
   const { height: windowHeight } = useWindowResize();
   const filterListRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number>(0);
@@ -97,19 +92,27 @@ export const Filters = ({
       disabled={disabled}
       height={height}
       ref={filterListRef}
+      surfaceType={surfaceType}
     >
       {categoryFilters.map(({ categoryViews, label }, i) => (
         <Fragment key={i}>
           {i !== 0 && <Divider />}
-          {label && <CategoryViewsLabel>{label}</CategoryViewsLabel>}
+          {label && (
+            <StyledTypography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_UPPERCASE_500}
+            >
+              {label}
+            </StyledTypography>
+          )}
           {categoryViews.map((categoryView) => (
             <Filter
               key={categoryView.key}
               categorySection={label}
               categoryView={categoryView}
               closeAncestor={onClose}
-              isFilterDrawer={isFilterDrawer}
               onFilter={onFilter}
+              surfaceType={surfaceType}
               trackFilterOpened={trackFilterOpened}
               tags={renderFilterTags(categoryView, onFilter)}
             />

--- a/src/components/Filter/components/Filters/filters.tsx
+++ b/src/components/Filter/components/Filters/filters.tsx
@@ -9,6 +9,7 @@ import { useWindowResize } from "../../../../hooks/useWindowResize";
 import { TYPOGRAPHY_PROPS } from "../../../../styles/common/mui/typography";
 import { TEST_IDS } from "../../../../tests/testIds";
 import { useDrawer } from "../../../common/Drawer/provider/hook";
+import { BaseComponentProps } from "../../../types";
 import { Filter } from "../Filter/filter";
 import { buildRangeTag } from "../FilterTag/utils";
 import { FilterTags } from "../FilterTags/filterTags";
@@ -20,7 +21,7 @@ export interface CategoryFilter {
   label?: string;
 }
 
-export interface FiltersProps {
+export interface FiltersProps extends BaseComponentProps {
   categoryFilters: CategoryFilter[];
   disabled?: boolean; // Global disabling of filters.
   onFilter: OnFilterFn;
@@ -72,6 +73,7 @@ function renderFilterTags(
 
 export const Filters = ({
   categoryFilters,
+  className,
   disabled = false,
   onFilter,
   surfaceType = SURFACE_TYPE.MENU,
@@ -88,6 +90,7 @@ export const Filters = ({
 
   return (
     <FilterList
+      className={className}
       data-testid={TEST_IDS.FILTERS}
       disabled={disabled}
       height={height}

--- a/src/components/Filter/components/SearchAllFilters/components/VariableSizeList/VariableSizeList.tsx
+++ b/src/components/Filter/components/SearchAllFilters/components/VariableSizeList/VariableSizeList.tsx
@@ -29,7 +29,7 @@ import {
   MAX_LIST_HEIGHT_PX,
 } from "../../../../common/constants";
 import { getSortMatchesFn } from "../../../../common/utils";
-import { List as FilterList } from "../../../FilterList/filterList.styles";
+import { StyledList } from "../../../FilterList/filterList.styles";
 import {
   DIVIDER_HEIGHT,
   DIVIDER_ITEM,
@@ -174,7 +174,7 @@ export const VariableSizeList = forwardRef<
     >
       <List
         height={height}
-        innerElementType={FilterList}
+        innerElementType={StyledList}
         innerRef={innerRef}
         itemCount={filteredItems.length}
         itemData={{

--- a/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
+++ b/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
@@ -14,8 +14,9 @@ import {
   MAX_LIST_HEIGHT_PX,
 } from "../../common/constants";
 import { FilterMenuSearchMatch } from "../../common/entities";
-import { List as FilterList } from "../FilterList/filterList.styles";
+import { StyledList } from "../FilterList/filterList.styles";
 import VariableSizeListItem from "../VariableSizeListItem/variableSizeListItem";
+import { SURFACE_TYPE } from "../surfaces/types";
 
 export type ItemSizeByItemKey = Map<unknown, number>;
 
@@ -23,11 +24,11 @@ export interface VariableSizeListProps {
   categoryKey: CategoryKey;
   categorySection?: string;
   height?: number; // Height of list; vertical list must be a number.
-  isFilterDrawer: boolean;
   itemSize?: number; // Default item size.
   matchedItems: FilterMenuSearchMatch[];
   onFilter: OnFilterFn;
   overscanCount?: ListProps["overscanCount"];
+  surfaceType: SURFACE_TYPE;
   width?: ListProps["width"]; // Width of list; default to 100% width of parent element.
 }
 
@@ -61,11 +62,11 @@ export const VariableSizeList = ({
   categoryKey,
   categorySection,
   height: initHeight = MAX_LIST_HEIGHT_PX,
-  isFilterDrawer,
   itemSize = LIST_ITEM_HEIGHT,
   matchedItems,
   onFilter,
   overscanCount = MAX_DISPLAYABLE_LIST_ITEMS * 2,
+  surfaceType,
   width = "100%",
 }: VariableSizeListProps): JSX.Element => {
   const { height: windowHeight } = useWindowResize();
@@ -87,12 +88,12 @@ export const VariableSizeList = ({
         initHeight,
         matchedItems,
         itemSizeByItemKeyRef.current,
-        isFilterDrawer,
+        surfaceType,
         windowHeight,
         outerRef.current
       )
     );
-  }, [initHeight, isFilterDrawer, matchedItems, windowHeight]);
+  }, [initHeight, matchedItems, surfaceType, windowHeight]);
 
   // Clears VariableSizeList cache (offsets and measurements) when values are updated (filtered).
   // Facilitates correct positioning of list items when list is updated.
@@ -104,7 +105,7 @@ export const VariableSizeList = ({
     <List
       height={height}
       outerRef={outerRef}
-      innerElementType={FilterList}
+      innerElementType={StyledList}
       itemCount={matchedItems.length}
       itemData={{
         categoryKey,
@@ -132,7 +133,7 @@ export const VariableSizeList = ({
  * @param height - Specified height of list.
  * @param matchedItems - Set of search results for category value view models in the given category.
  * @param itemSizeByItemKey - Map of item size by item key.
- * @param isFilterDrawer - True if filter is displayed in filter drawer.
+ * @param surfaceType - Surace type is "Drawer" or "Menu".
  * @param windowHeight - Window height.
  * @param outerListElem - Outer list element to reference list position from.
  * @returns calculated height.
@@ -141,11 +142,11 @@ function calculateListHeight(
   height: number,
   matchedItems: FilterMenuSearchMatch[],
   itemSizeByItemKey: ItemSizeByItemKey,
-  isFilterDrawer: boolean,
+  surfaceType: SURFACE_TYPE,
   windowHeight: number,
   outerListElem: HTMLDivElement | null
 ): number {
-  if (isFilterDrawer && outerListElem) {
+  if (surfaceType === SURFACE_TYPE.DRAWER && outerListElem) {
     return windowHeight - outerListElem.getBoundingClientRect().top;
   }
   if (matchedItems.length > MAX_DISPLAYABLE_LIST_ITEMS) {

--- a/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
+++ b/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
@@ -133,7 +133,7 @@ export const VariableSizeList = ({
  * @param height - Specified height of list.
  * @param matchedItems - Set of search results for category value view models in the given category.
  * @param itemSizeByItemKey - Map of item size by item key.
- * @param surfaceType - Surace type is "Drawer" or "Menu".
+ * @param surfaceType - Surface type is "Drawer" or "Menu".
  * @param windowHeight - Window height.
  * @param outerListElem - Outer list element to reference list position from.
  * @returns calculated height.

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
@@ -3,6 +3,8 @@ import { useCallback } from "react";
 import {
   CategoryKey,
   CategoryValueKey,
+  CLEAR_ALL,
+  ClearAll,
 } from "../../../../../../common/entities";
 import { updater } from "../../../../../Table/components/TableFeatures/ColumnFilter/utils";
 import { ColumnFiltersAdapterProps } from "./types";
@@ -17,11 +19,16 @@ export const ColumnFiltersAdapter = <T extends RowData>({
 
   const onFilter = useCallback(
     (
-      categoryKey: CategoryKey,
+      categoryKey: CategoryKey | ClearAll,
       selectedCategoryValue: CategoryValueKey,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `selected` is not required by TanStack adapter.
       _selected: boolean
     ) => {
+      if (categoryKey === CLEAR_ALL) {
+        table.resetColumnFilters();
+        return;
+      }
+
       table
         .getColumn(categoryKey)
         ?.setFilterValue(updater(selectedCategoryValue));

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
@@ -1,0 +1,37 @@
+import { RowData } from "@tanstack/react-table";
+import { useCallback } from "react";
+import {
+  CategoryKey,
+  CategoryValueKey,
+} from "../../../../../../common/entities";
+import { updater } from "../../../../../Table/components/TableFeatures/ColumnFilter/utils";
+import { ColumnFiltersAdapterProps } from "./types";
+import { buildColumnFilters, getColumnFiltersCount } from "./utils";
+
+export const ColumnFiltersAdapter = <T extends RowData>({
+  renderSurface,
+  table,
+}: ColumnFiltersAdapterProps<T>): JSX.Element | null => {
+  const categoryFilters = buildColumnFilters(table);
+  const count = getColumnFiltersCount(table);
+
+  const onFilter = useCallback(
+    (
+      categoryKey: CategoryKey,
+      selectedCategoryValue: CategoryValueKey,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `selected` is not required by TanStack adapter.
+      _selected: boolean
+    ) => {
+      table
+        .getColumn(categoryKey)
+        ?.setFilterValue(updater(selectedCategoryValue));
+    },
+    [table]
+  );
+
+  return renderSurface({
+    categoryFilters,
+    count,
+    onFilter,
+  });
+};

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types.ts
@@ -1,0 +1,7 @@
+import { RowData, Table } from "@tanstack/react-table";
+import { SurfaceProps } from "../../../surfaces/types";
+
+export interface ColumnFiltersAdapterProps<T extends RowData> {
+  renderSurface: (props: SurfaceProps) => JSX.Element | null;
+  table: Table<T>;
+}

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -1,0 +1,90 @@
+import { Column, RowData, Table } from "@tanstack/react-table";
+import { CategoryView } from "../../../../../../common/categories/views/types";
+import { SelectCategoryValueView } from "../../../../../../common/entities";
+import { getColumnHeader } from "../../../../../Table/common/utils";
+import { getSortedFacetedValues } from "../../../../../Table/featureOptions/facetedColumn/utils";
+import { SurfaceProps } from "../../../surfaces/types";
+
+/**
+ * Adapter for TanStack table column filters to category filters.
+ * @param table - Table.
+ * @returns Category filters.
+ */
+export function buildColumnFilters<T extends RowData>(
+  table: Table<T>
+): SurfaceProps["categoryFilters"] {
+  // Build the category views; single category filter.
+  const categoryViews = table
+    .getAllColumns()
+    .filter((column) => column.getCanFilter())
+    .map(mapColumnToCategoryView);
+
+  return [{ categoryViews }];
+}
+
+/**
+ * Adapter for TanStack table column filters to selected count.
+ * @param table - Table.
+ * @returns Selected count.
+ */
+export function getColumnFiltersCount<T extends RowData>(
+  table: Table<T>
+): number {
+  return table
+    .getState()
+    .columnFilters.reduce(
+      (acc, columnFilter) => acc + (columnFilter.value as unknown[]).length,
+      0
+    );
+}
+
+/**
+ * Adapter for TanStack column to category view.
+ * Currently supports only select category views.
+ * @param column - Column.
+ * @returns Category view.
+ */
+function mapColumnToCategoryView<T extends RowData>(
+  column: Column<T>
+): CategoryView {
+  const facetedUniqueValues = column.getFacetedUniqueValues();
+  const isDisabled = facetedUniqueValues.size === 0;
+  const values = mapColumnToSelectCategoryValueView(column);
+  return {
+    annotation: undefined,
+    enableChartView: false,
+    isDisabled,
+    key: column.id,
+    label: getColumnHeader(column),
+    values,
+  };
+}
+
+/**
+ * Adapter for TanStack column to select category value view.
+ * @param column - Column.
+ * @returns Select category value view.
+ */
+function mapColumnToSelectCategoryValueView<T extends RowData>(
+  column: Column<T>
+): SelectCategoryValueView[] {
+  // Get the faceted unique values and sort them.
+  const facetedUniqueValues = column.getFacetedUniqueValues();
+  const sortedFacetsValues = getSortedFacetedValues(facetedUniqueValues);
+
+  // Selected values for the column.
+  const filterValue = (column.getFilterValue() || []) as unknown[];
+
+  // Build the select category values.
+  const selectCategoryValues: SelectCategoryValueView[] = [];
+  for (const [label, count] of sortedFacetsValues) {
+    selectCategoryValues.push({
+      count,
+      key: String(label),
+      label: String(label),
+      selected: filterValue.includes(label),
+    });
+  }
+
+  return selectCategoryValues;
+}

--- a/src/components/Filter/components/controls/Controls/controls.styles.ts
+++ b/src/components/Filter/components/controls/Controls/controls.styles.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { Grid } from "@mui/material";
+
+export const StyledGrid = styled(Grid)`
+  display: grid;
+  gap: 8px 0;
+  grid-template-columns: 1fr auto;
+  margin: 8px 0;
+  padding: 0 16px;
+`;

--- a/src/components/Filter/components/controls/Controls/controls.tsx
+++ b/src/components/Filter/components/controls/Controls/controls.tsx
@@ -1,9 +1,9 @@
 import { Button as MButton, Typography } from "@mui/material";
-import { BaseComponentProps } from "components/types";
 import React from "react";
 import { CLEAR_ALL } from "../../../../../common/entities";
 import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 import { BUTTON_PROPS } from "../../../../common/Button/constants";
+import { BaseComponentProps } from "../../../../types";
 import { SurfaceProps } from "../../surfaces/types";
 import { StyledGrid } from "./controls.styles";
 

--- a/src/components/Filter/components/controls/Controls/controls.tsx
+++ b/src/components/Filter/components/controls/Controls/controls.tsx
@@ -1,0 +1,31 @@
+import { Button as MButton, Typography } from "@mui/material";
+import { BaseComponentProps } from "components/types";
+import React from "react";
+import { CLEAR_ALL } from "../../../../../common/entities";
+import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
+import { BUTTON_PROPS } from "../../../../common/Button/constants";
+import { SurfaceProps } from "../../surfaces/types";
+import { StyledGrid } from "./controls.styles";
+
+/**
+ * Renders filter title and "Clear All" button.
+ */
+
+export const Controls = ({
+  className,
+  onFilter,
+}: BaseComponentProps & Pick<SurfaceProps, "onFilter">): JSX.Element | null => {
+  return (
+    <StyledGrid className={className} container>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_LARGE_500}>
+        Filters
+      </Typography>
+      <MButton
+        {...BUTTON_PROPS.PRIMARY_TEXT}
+        onClick={() => onFilter(CLEAR_ALL, undefined, false)}
+      >
+        Clear All
+      </MButton>
+    </StyledGrid>
+  );
+};

--- a/src/components/Filter/components/surfaces/drawer/Drawer/constants.ts
+++ b/src/components/Filter/components/surfaces/drawer/Drawer/constants.ts
@@ -1,0 +1,7 @@
+import { DrawerProps } from "@mui/material";
+
+export const DRAWER_PROPS: DrawerProps = {
+  closeAfterTransition: true,
+  disableRestoreFocus: true,
+  elevation: 1,
+};

--- a/src/components/Filter/components/surfaces/drawer/Drawer/drawer.styles.ts
+++ b/src/components/Filter/components/surfaces/drawer/Drawer/drawer.styles.ts
@@ -1,0 +1,20 @@
+import styled from "@emotion/styled";
+import { Drawer } from "@mui/material";
+import { PALETTE } from "../../../../../../styles/common/constants/palette";
+
+export const StyledDrawer = styled(Drawer)`
+  &.MuiDrawer-root {
+    .MuiPaper-root {
+      background-color: ${PALETTE.SMOKE_LIGHT};
+      max-height: 100vh;
+      padding: 16px 0;
+      width: 312px;
+    }
+
+    + .MuiDrawer-root {
+      .MuiBackdrop-root {
+        background-color: transparent;
+      }
+    }
+  }
+`;

--- a/src/components/Filter/components/surfaces/drawer/Drawer/drawer.tsx
+++ b/src/components/Filter/components/surfaces/drawer/Drawer/drawer.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from "react";
 import { DrawerProvider } from "../../../../../common/Drawer/provider/provider";
+import { Controls } from "../../../controls/Controls/controls";
 import { Filters } from "../../../Filters/filters";
 import { SURFACE_TYPE } from "../../types";
 import { Button as BaseButton } from "../components/Button/button";
@@ -30,6 +31,8 @@ export const Drawer = ({
           >
             {/* Closes drawer */}
             <IconButton />
+            {/* Clear all button */}
+            <Controls onFilter={onFilter} />
             <Filters
               categoryFilters={categoryFilters}
               onFilter={onFilter}

--- a/src/components/Filter/components/surfaces/drawer/Drawer/drawer.tsx
+++ b/src/components/Filter/components/surfaces/drawer/Drawer/drawer.tsx
@@ -1,0 +1,43 @@
+import React, { Fragment } from "react";
+import { DrawerProvider } from "../../../../../common/Drawer/provider/provider";
+import { Filters } from "../../../Filters/filters";
+import { SURFACE_TYPE } from "../../types";
+import { Button as BaseButton } from "../components/Button/button";
+import { IconButton } from "../components/IconButton/iconButton";
+import { DRAWER_PROPS } from "./constants";
+import { StyledDrawer } from "./drawer.styles";
+import { DrawerProps } from "./types";
+
+export const Drawer = ({
+  Button = BaseButton,
+  categoryFilters,
+  className,
+  count,
+  onFilter,
+  ...props /* MuiDrawerProps */
+}: DrawerProps): JSX.Element | null => {
+  return (
+    <DrawerProvider>
+      {({ onClose, open }) => (
+        <Fragment>
+          <Button count={count} />
+          <StyledDrawer
+            {...DRAWER_PROPS}
+            className={className}
+            onClose={onClose}
+            open={open}
+            {...props}
+          >
+            {/* Closes drawer */}
+            <IconButton />
+            <Filters
+              categoryFilters={categoryFilters}
+              onFilter={onFilter}
+              surfaceType={SURFACE_TYPE.DRAWER}
+            />
+          </StyledDrawer>
+        </Fragment>
+      )}
+    </DrawerProvider>
+  );
+};

--- a/src/components/Filter/components/surfaces/drawer/Drawer/types.ts
+++ b/src/components/Filter/components/surfaces/drawer/Drawer/types.ts
@@ -1,0 +1,11 @@
+import { DrawerProps as MDrawerProps } from "@mui/material";
+import { BaseComponentProps } from "../../../../../types";
+import { SurfaceProps } from "../../types";
+import { Button } from "../components/Button/button";
+
+export interface DrawerProps
+  extends BaseComponentProps,
+    Omit<MDrawerProps, "children">,
+    SurfaceProps {
+  Button?: typeof Button;
+}

--- a/src/components/Filter/components/surfaces/drawer/components/Button/button.tsx
+++ b/src/components/Filter/components/surfaces/drawer/components/Button/button.tsx
@@ -1,14 +1,18 @@
 import { FilterListRounded } from "@mui/icons-material";
-import { Button, ButtonProps } from "@mui/material";
+import { ButtonProps, Button as MButton } from "@mui/material";
 import React from "react";
-import { SVG_ICON_PROPS } from "../../../../../../styles/common/mui/svgIcon";
-import { BUTTON_PROPS } from "../../../../../common/Button/constants";
-import { useDrawer } from "../../../../../common/Drawer/provider/hook";
-import { BaseComponentProps } from "../../../../../types";
-import { FilterCountChip } from "../../../FilterCountChip/filterCountChip";
-import { FilterCountChipProps } from "../../../FilterCountChip/types";
+import { SVG_ICON_PROPS } from "../../../../../../../styles/common/mui/svgIcon";
+import { BUTTON_PROPS } from "../../../../../../common/Button/constants";
+import { useDrawer } from "../../../../../../common/Drawer/provider/hook";
+import { BaseComponentProps } from "../../../../../../types";
+import { FilterCountChip } from "../../../../FilterCountChip/filterCountChip";
+import { FilterCountChipProps } from "../../../../FilterCountChip/types";
 
-export const FilterButton = ({
+/**
+ * Opens facet-filters drawer.
+ */
+
+export const Button = ({
   className,
   count = 0,
   ...props
@@ -17,7 +21,7 @@ export const FilterButton = ({
   Pick<FilterCountChipProps, "count">): JSX.Element => {
   const { onOpen } = useDrawer();
   return (
-    <Button
+    <MButton
       {...BUTTON_PROPS.SECONDARY_CONTAINED}
       className={className}
       onClick={onOpen}
@@ -31,6 +35,6 @@ export const FilterButton = ({
     >
       Filter
       <FilterCountChip count={count} />
-    </Button>
+    </MButton>
   );
 };

--- a/src/components/Filter/components/surfaces/drawer/components/ButtonBase/buttonBase.styles.ts
+++ b/src/components/Filter/components/surfaces/drawer/components/ButtonBase/buttonBase.styles.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { ButtonBase } from "@mui/material";
+import { textBodyLarge500 } from "../../../../../../../styles/common/mixins/fonts";
+
+export const StyledButtonBase = styled(ButtonBase)`
+  ${textBodyLarge500}
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-start;
+  padding: 12px 16px;
+  width: 100%;
+`;

--- a/src/components/Filter/components/surfaces/drawer/components/ButtonBase/buttonBase.tsx
+++ b/src/components/Filter/components/surfaces/drawer/components/ButtonBase/buttonBase.tsx
@@ -1,0 +1,25 @@
+import { ButtonProps } from "@mui/material";
+import React from "react";
+import { SVG_ICON_PROPS } from "../../../../../../../styles/common/mui/svgIcon";
+import { SouthIcon } from "../../../../../../common/CustomIcon/components/SouthIcon/southIcon";
+import { useDrawer } from "../../../../../../common/Drawer/provider/hook";
+import { BaseComponentProps } from "../../../../../../types";
+import { StyledButtonBase } from "./buttonBase.styles";
+
+/**
+ * Closes facet-filter drawer.
+ */
+
+export const ButtonBase = ({
+  children,
+  className,
+  ...props
+}: BaseComponentProps & ButtonProps): JSX.Element => {
+  const { onClose } = useDrawer();
+  return (
+    <StyledButtonBase className={className} onClick={onClose} {...props}>
+      <SouthIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
+      {children}
+    </StyledButtonBase>
+  );
+};

--- a/src/components/Filter/components/surfaces/drawer/components/IconButton/constants.ts
+++ b/src/components/Filter/components/surfaces/drawer/components/IconButton/constants.ts
@@ -1,0 +1,12 @@
+import { IconButtonProps, SvgIconProps } from "@mui/material";
+import { ICON_BUTTON_PROPS as MUI_ICON_BUTTON_PROPS } from "../../../../../../../styles/common/mui/iconButton";
+import { SVG_ICON_PROPS as MUI_SVG_ICON_PROPS } from "../../../../../../../styles/common/mui/svgIcon";
+
+export const ICON_BUTTON_PROPS: IconButtonProps = {
+  color: MUI_ICON_BUTTON_PROPS.COLOR.INHERIT,
+  size: MUI_ICON_BUTTON_PROPS.SIZE.MEDIUM,
+};
+
+export const SVG_ICON_PROPS: SvgIconProps = {
+  fontSize: MUI_SVG_ICON_PROPS.FONT_SIZE.SMALL,
+};

--- a/src/components/Filter/components/surfaces/drawer/components/IconButton/iconButton.styles.ts
+++ b/src/components/Filter/components/surfaces/drawer/components/IconButton/iconButton.styles.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { IconButton } from "@mui/material";
+import { PALETTE } from "../../../../../../../styles/common/constants/palette";
+
+export const StyledIconButton = styled(IconButton)`
+  color: ${PALETTE.COMMON_WHITE};
+  left: calc(100% + 4px);
+  position: absolute;
+  top: 4px;
+`;

--- a/src/components/Filter/components/surfaces/drawer/components/IconButton/iconButton.tsx
+++ b/src/components/Filter/components/surfaces/drawer/components/IconButton/iconButton.tsx
@@ -1,0 +1,28 @@
+import { CloseRounded } from "@mui/icons-material";
+import { IconButtonProps } from "@mui/material";
+import React from "react";
+import { useDrawer } from "../../../../../../common/Drawer/provider/hook";
+import { BaseComponentProps } from "../../../../../../types";
+import { ICON_BUTTON_PROPS, SVG_ICON_PROPS } from "./constants";
+import { StyledIconButton } from "./iconButton.styles";
+
+/**
+ * Closes facet-filters drawer.
+ */
+
+export const IconButton = ({
+  className,
+  ...props /* MuiIconButtonProps */
+}: BaseComponentProps & IconButtonProps): JSX.Element | null => {
+  const { onClose } = useDrawer();
+  return (
+    <StyledIconButton
+      {...ICON_BUTTON_PROPS}
+      className={className}
+      onClick={onClose}
+      {...props}
+    >
+      <CloseRounded {...SVG_ICON_PROPS} />
+    </StyledIconButton>
+  );
+};

--- a/src/components/Filter/components/surfaces/types.ts
+++ b/src/components/Filter/components/surfaces/types.ts
@@ -1,0 +1,13 @@
+import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
+import { CategoryFilter } from "../Filters/filters";
+
+export interface SurfaceProps {
+  categoryFilters: CategoryFilter[];
+  count?: number;
+  onFilter: OnFilterFn;
+}
+
+export enum SURFACE_TYPE {
+  DRAWER = "DRAWER",
+  MENU = "MENU",
+}

--- a/src/components/Table/components/TableFeatures/ColumnFilter/columnFilter.tsx
+++ b/src/components/Table/components/TableFeatures/ColumnFilter/columnFilter.tsx
@@ -47,7 +47,6 @@ export const ColumnFilter = <T extends RowData>({
   return (
     <Fragment>
       <Button
-        key={column.id}
         disabled={sortedValues.length === 0}
         endIcon={<DropDownIcon color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />}
         onClick={onOpen}

--- a/src/components/Table/components/TableFeatures/ColumnFilter/constants.ts
+++ b/src/components/Table/components/TableFeatures/ColumnFilter/constants.ts
@@ -12,6 +12,10 @@ export const MENU_PROPS: Omit<MenuProps, "anchorEl" | "onClose" | "open"> = {
     horizontal: "right",
     vertical: "bottom",
   },
+  /* Prevents the browser from auto‑focusing the menu on open, which can trigger a scrollIntoView jump when the viewport has `scroll-padding-top` (e.g., on <html>). */
+  disableAutoFocus: true,
+  /* Skips restoring focus to the trigger on close to avoid a similar scroll adjustment with `scroll-padding-top`. */
+  disableRestoreFocus: true,
   marginThreshold: 8,
   slotProps: {
     list: { component: "div" },

--- a/src/components/Table/components/TableFeatures/ColumnFilter/utils.ts
+++ b/src/components/Table/components/TableFeatures/ColumnFilter/utils.ts
@@ -7,6 +7,8 @@ export function updater(
   value: unknown
 ): (old: unknown[] | undefined) => unknown[] | undefined {
   return (old: unknown[] | undefined) => {
+    if (value === undefined) return undefined;
+
     // If no old value, return new value.
     if (!old) return [value];
 

--- a/src/components/Table/components/TableFeatures/ColumnFilter/utils.ts
+++ b/src/components/Table/components/TableFeatures/ColumnFilter/utils.ts
@@ -7,8 +7,6 @@ export function updater(
   value: unknown
 ): (old: unknown[] | undefined) => unknown[] | undefined {
   return (old: unknown[] | undefined) => {
-    if (value === undefined) return undefined;
-
     // If no old value, return new value.
     if (!old) return [value];
 

--- a/src/hooks/useCategoryFilter.ts
+++ b/src/hooks/useCategoryFilter.ts
@@ -10,6 +10,7 @@ import { COLLATOR_CASE_INSENSITIVE } from "../common/constants";
 import {
   CategoryKey,
   CategoryValueKey,
+  ClearAll,
   Filters,
   SelectCategory,
   SelectCategoryValue,
@@ -27,7 +28,7 @@ export type FilterState = Filters;
  * Function invoked when selected state of a category value is toggled or range is selected.
  */
 export type OnFilterFn = (
-  categoryKey: CategoryKey,
+  categoryKey: CategoryKey | ClearAll,
   selectedCategoryValue: CategoryValueKey,
   selected: boolean,
   categorySection?: string,

--- a/src/styles/common/mui/typography.ts
+++ b/src/styles/common/mui/typography.ts
@@ -23,6 +23,7 @@ const VARIANT: Record<string, TypographyOwnProps["variant"]> = {
   TEXT_HEADING_LARGE: "text-heading-large",
   TEXT_HEADING_SMALL: "text-heading-small",
   TEXT_HEADING_XSMALL: "text-heading-xsmall",
+  TEXT_UPPERCASE_500: "text-uppercase-500",
 };
 
 export const TYPOGRAPHY_PROPS: TypographyPropsOptions = {

--- a/src/styles/common/mui/typography.ts
+++ b/src/styles/common/mui/typography.ts
@@ -18,6 +18,7 @@ const VARIANT: Record<string, TypographyOwnProps["variant"]> = {
   TEXT_BODY_400: "text-body-400",
   TEXT_BODY_400_2_LINES: "text-body-400-2lines",
   TEXT_BODY_500: "text-body-500",
+  TEXT_BODY_LARGE_500: "text-body-large-500",
   TEXT_BODY_SMALL_400: "text-body-small-400",
   TEXT_BODY_SMALL_500: "text-body-small-500",
   TEXT_HEADING_LARGE: "text-heading-large",

--- a/src/views/ExploreView/exploreView.tsx
+++ b/src/views/ExploreView/exploreView.tsx
@@ -1,4 +1,3 @@
-import { useBreakpoint } from "hooks/useBreakpoint";
 import React, { useEffect, useMemo } from "react";
 import { AzulEntitiesStaticResponse } from "../../apis/azul/common/entities";
 import { track } from "../../common/analytics/analytics";
@@ -19,6 +18,7 @@ import { SidebarTools } from "../../components/Layout/components/Sidebar/compone
 import { Sidebar } from "../../components/Layout/components/Sidebar/sidebar";
 import { CategoryGroup } from "../../config/entities";
 import { useStateSyncManager } from "../../hooks/stateSyncManager/hook";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 import { useConfig } from "../../hooks/useConfig";
 import { useEntityList } from "../../hooks/useEntityList";
 import { useExploreState } from "../../hooks/useExploreState";

--- a/src/views/ExploreView/exploreView.tsx
+++ b/src/views/ExploreView/exploreView.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from "hooks/useBreakpoint";
 import React, { useEffect, useMemo } from "react";
 import { AzulEntitiesStaticResponse } from "../../apis/azul/common/entities";
 import { track } from "../../common/analytics/analytics";
@@ -11,6 +12,7 @@ import {
   Filters,
 } from "../../components/Filter/components/Filters/filters";
 import { SearchAllFilters } from "../../components/Filter/components/SearchAllFilters/searchAllFilters";
+import { SURFACE_TYPE } from "../../components/Filter/components/surfaces/types";
 import { Index as IndexView } from "../../components/Index/index";
 import { SidebarLabel } from "../../components/Layout/components/Sidebar/components/SidebarLabel/sidebarLabel";
 import { SidebarTools } from "../../components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles";
@@ -33,6 +35,7 @@ export interface ExploreViewProps extends AzulEntitiesStaticResponse {
 }
 
 export const ExploreView = (props: ExploreViewProps): JSX.Element => {
+  const { mdDown } = useBreakpoint();
   const { config, entityConfig } = useConfig(); // Get app level config.
   const { exploreDispatch, exploreState } = useExploreState(); // Get the useReducer state and dispatch for "Explore".
   const { trackingConfig } = config;
@@ -137,6 +140,7 @@ export const ExploreView = (props: ExploreViewProps): JSX.Element => {
           <Filters
             categoryFilters={categoryFilters}
             onFilter={onFilterChange.bind(null, false)}
+            surfaceType={mdDown ? SURFACE_TYPE.DRAWER : SURFACE_TYPE.MENU}
             trackFilterOpened={trackingConfig?.trackFilterOpened}
           />
         </Sidebar>


### PR DESCRIPTION
Closes #597.

This pull request introduces enhancements to the filtering functionality, including improved responsiveness, a unified surface type for filters, and code refactoring for better maintainability. Key changes include introducing a `surfaceType` property to replace the `isFilterDrawer` flag, adding responsive behavior for filters based on screen size, and refactoring styles and components to align with the new surface type structure.

### Enhancements to filtering functionality:

* Added a `surfaceType` property to the `Filter` component, replacing the `isFilterDrawer` flag, to determine whether the filter is displayed as a drawer or menu. Refactored components such as `Filter`, `FilterLabel`, and `FilterRange` to use this new property. (`[[1]](diffhunk://#diff-8b3b605dbfb49e08344fbd567fcabb2fcb385fb0a824caf6b9eef0002dbe9308L33-R35)`, `[[2]](diffhunk://#diff-8b3b605dbfb49e08344fbd567fcabb2fcb385fb0a824caf6b9eef0002dbe9308L43-R56)`, `[[3]](diffhunk://#diff-6c878dfde12c174e0ecb096f61cad37f4b7e62274ba4fea649ff5cd3bf5cfb7eR15)`, `[[4]](diffhunk://#diff-6c878dfde12c174e0ecb096f61cad37f4b7e62274ba4fea649ff5cd3bf5cfb7eR25-R40)`)
* Introduced responsive behavior for filters using `useMediaQuery` to render filters as drawers on smaller screens (below 820px) and as menus on larger screens. Updated components like `ColumnFilterTags` and `ColumnFilters` to include this behavior. (`[[1]](diffhunk://#diff-71b4afc5f0450278fd9eb3d6b5811961a2111c5d496f5a961b80b87036c6c1d4R17-R22)`, `[[2]](diffhunk://#diff-7943c2b249358bc0e5edadf255b893d21cfd0f83798359ec50fc17b2b83625faR17-R28)`)

### Refactoring for maintainability:

* Consolidated filter-related styles by replacing hardcoded colors with constants from the `PALETTE` module and improving the handling of surface-specific styles in `StyledPopover` and `StyledButton`. (`[[1]](diffhunk://#diff-48c8e625329155cd4f2e1cd110436832cb3ad003a197d5fdd141219c58e94b6fR1-R25)`, `[[2]](diffhunk://#diff-b550f2436be3e45d04d548c2aa43b40f00f8c13929538116cd4913b7a29a3a5eL35-R53)`)
* Renamed and updated styled components for consistency, such as `StyledPopover`, `StyledButton`, and `StyledList`, and removed unused styles like `StyledButtonGroup`. (`[[1]](diffhunk://#diff-bac17e62cc809a4487b1dce8b1c83b3904b9f43c0e291bb89db918e0df9fd1b5L1-L9)`, `[[2]](diffhunk://#diff-c60f1cc2d3bee0c3fa86570b8173ab6180d1eea3cb5d11b975753fedca2a23faL36-R36)`)

### Improvements to filter stories and utilities:

* Centralized column definitions into a `COLUMNS` constant for better reusability across stories and components. Updated the `DefaultStory` to use this constant and added a utility function `buildColumnFilters` for constructing column filters from the filter store. (`[[1]](diffhunk://#diff-dda9cef436cf90770be599f96fbf247a859568ef454daf7f0d5f84a551126ef1R50-R51)`, `[[2]](diffhunk://#diff-c70a1f54ad03c11bcf41457a6324a9f1a167f1bb433a95ce2ace3e54805fcae7R31-R33)`, `[[3]](diffhunk://#diff-e4217273f4f3aaae80599d42b42eb895bf3ab862ec44cd99dd8e0cc5bc366a52R1-R15)`)
* Updated storybook arguments and components to align with the new `surfaceType` property. (`[[1]](diffhunk://#diff-b6159b414ef95852d9225cbcf9c6a07d535315316021bc0c624a124d4c6d929dR4-R10)`, `[[2]](diffhunk://#diff-a927e5f0d7a9c682457b8b74c3221cce3d1cc08acd376bd5ef9cca1637dcf87eR35)`)

<img width="393" height="847" alt="image" src="https://github.com/user-attachments/assets/6a10b9fc-98da-4e9f-97c5-23b224a0e918" />

<img width="389" height="843" alt="image" src="https://github.com/user-attachments/assets/26492d28-96c3-4be2-9852-22264a515a16" />

<img width="388" height="844" alt="image" src="https://github.com/user-attachments/assets/0efdc632-4a1e-4180-9d02-3d5c924e9e7e" />

