### PR TITLE
feat: make data dictionary table row-collapse for smaller viewports (#600)

### DIFF
--- a/src/components/DataDictionary/components/Description/description.styles.ts
+++ b/src/components/DataDictionary/components/Description/description.styles.ts
@@ -5,10 +5,10 @@ import {
   mediaTabletUp,
 } from "../../../../styles/common/mixins/breakpoints";
 import { textHeadingSmall } from "../../../../styles/common/mixins/fonts";
-import { RoundedPaper } from "../../../common/Paper/components/RoundedPaper/roundedPaper";
+import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 import { MarkdownRenderer } from "../../../MarkdownRenderer/markdownRenderer";
 
-export const StyledRoundedPaper = styled(RoundedPaper)`
+export const StyledFluidPaper = styled(FluidPaper)`
   padding: 20px;
 
   ${mediaTabletDown} {

--- a/src/components/DataDictionary/components/Description/description.tsx
+++ b/src/components/DataDictionary/components/Description/description.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  StyledMarkdownRenderer,
-  StyledRoundedPaper,
-} from "./description.styles";
+import { StyledFluidPaper, StyledMarkdownRenderer } from "./description.styles";
 import { DescriptionProps } from "./types";
 
 export const Description = ({
@@ -10,8 +7,8 @@ export const Description = ({
 }: DescriptionProps): JSX.Element | null => {
   if (!description) return null;
   return (
-    <StyledRoundedPaper elevation={0}>
+    <StyledFluidPaper elevation={0}>
       <StyledMarkdownRenderer value={description} />
-    </StyledRoundedPaper>
+    </StyledFluidPaper>
   );
 };

--- a/src/components/DataDictionary/components/Entity/entity.styles.ts
+++ b/src/components/DataDictionary/components/Entity/entity.styles.ts
@@ -1,8 +1,13 @@
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
+import { mediaTabletDown } from "../../../../styles/common/mixins/breakpoints";
 
 export const StyledTypography = styled(Typography)`
   &:hover a {
     opacity: 1;
+  }
+
+  ${mediaTabletDown} {
+    margin: 0 16px;
   }
 ` as typeof Typography;

--- a/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
-import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
+import {
+  bpDown1024,
+  mediaTabletDown,
+} from "../../../../../../styles/common/mixins/breakpoints";
 import { LAYOUT_SPACING } from "../../constants";
 
 const PB = LAYOUT_SPACING.FILTERS_PADDING_BOTTOM; /* bottom padding */
@@ -26,5 +29,9 @@ export const Layout = styled("div")<LayoutSpacing>`
     grid-row: auto;
     padding-top: ${PT}px;
     position: relative;
+  }
+
+  ${mediaTabletDown} {
+    margin: 0 16px;
   }
 `;

--- a/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
-import { bpDown1024 } from "../../../../../../styles/common/mixins/breakpoints";
+import {
+  bpDown1024,
+  mediaTabletDown,
+} from "../../../../../../styles/common/mixins/breakpoints";
 
 export const Layout = styled("div")<LayoutSpacing>`
   grid-column: 1 / -1;
@@ -15,5 +18,9 @@ export const Layout = styled("div")<LayoutSpacing>`
     grid-column: 1;
     grid-row: auto;
     position: relative;
+  }
+
+  ${mediaTabletDown} {
+    margin: 0 16px;
   }
 `;

--- a/src/components/DataDictionary/components/Table/table.styles.ts
+++ b/src/components/DataDictionary/components/Table/table.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { RoundedPaper } from "../../../common/Paper/components/RoundedPaper/roundedPaper";
+import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 
-export const StyledRoundedPaper = styled(RoundedPaper)`
+export const StyledFluidPaper = styled(FluidPaper)`
   background-color: ${PALETTE.SMOKE_MAIN};
   display: grid;
   gap: 1px;

--- a/src/components/DataDictionary/components/Table/table.tsx
+++ b/src/components/DataDictionary/components/Table/table.tsx
@@ -6,7 +6,7 @@ import { ROW_DIRECTION } from "../../../Table/common/entities";
 import { TableHead } from "../../../Table/components/TableHead/tableHead";
 import { GridTable } from "../../../Table/table.styles";
 import { getColumnTrackSizing } from "../../../TableCreator/options/columnTrackSizing/utils";
-import { StyledRoundedPaper } from "./table.styles";
+import { StyledFluidPaper } from "./table.styles";
 import { TableProps } from "./types";
 
 export const Table = <T extends RowData>({
@@ -14,7 +14,7 @@ export const Table = <T extends RowData>({
   table,
 }: TableProps<T>): JSX.Element => {
   return (
-    <StyledRoundedPaper elevation={0}>
+    <StyledFluidPaper elevation={0}>
       <TableContainer>
         <GridTable
           gridTemplateColumns={getColumnTrackSizing(
@@ -29,6 +29,6 @@ export const Table = <T extends RowData>({
           />
         </GridTable>
       </TableContainer>
-    </StyledRoundedPaper>
+    </StyledFluidPaper>
   );
 };

--- a/src/components/DataDictionary/components/Table/table.tsx
+++ b/src/components/DataDictionary/components/Table/table.tsx
@@ -1,6 +1,7 @@
 import { TableContainer } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import React from "react";
+import { useBreakpoint } from "../../../../hooks/useBreakpoint";
 import { TableBody } from "../../../Detail/components/Table/components/TableBody/tableBody";
 import { ROW_DIRECTION } from "../../../Table/common/entities";
 import { TableHead } from "../../../Table/components/TableHead/tableHead";
@@ -13,17 +14,20 @@ export const Table = <T extends RowData>({
   row,
   table,
 }: TableProps<T>): JSX.Element => {
+  const { smDown } = useBreakpoint();
+  const rowDirection = smDown ? ROW_DIRECTION.VERTICAL : ROW_DIRECTION.DEFAULT;
   return (
     <StyledFluidPaper elevation={0}>
       <TableContainer>
         <GridTable
+          collapsable
           gridTemplateColumns={getColumnTrackSizing(
             table.getVisibleFlatColumns()
           )}
         >
           <TableHead tableInstance={table} />
           <TableBody
-            rowDirection={ROW_DIRECTION.DEFAULT}
+            rowDirection={rowDirection}
             rows={row.getLeafRows()}
             tableInstance={table}
           />

--- a/src/components/DataDictionary/dataDictionary.styles.ts
+++ b/src/components/DataDictionary/dataDictionary.styles.ts
@@ -1,5 +1,8 @@
 import styled from "@emotion/styled";
-import { bpDown1024 } from "../../styles/common/mixins/breakpoints";
+import {
+  bpDown1024,
+  mediaTabletDown,
+} from "../../styles/common/mixins/breakpoints";
 
 export const View = styled("div")`
   column-gap: 24px;
@@ -12,5 +15,9 @@ export const View = styled("div")`
   ${bpDown1024} {
     grid-template-columns: 1fr;
     margin: 0 16px;
+  }
+
+  ${mediaTabletDown} {
+    margin: 0;
   }
 `;

--- a/src/components/Detail/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Detail/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -25,7 +25,7 @@ export const CollapsableRows = <T extends RowData>({
   return (
     <Fragment>
       {(leafOrSubRows || rows).map((row) => {
-        if (row.depth > 0) return null; // Hide sub rows.
+        if (row.depth > 0 && !leafOrSubRows) return null; // Hide sub rows that are not already leaf or sub rows.
         return (
           <StyledTableRow
             key={row.id}


### PR DESCRIPTION
Closes #600.

This pull request introduces several updates to the `DataDictionary` components, focusing on replacing the `RoundedPaper` component with `FluidPaper`, improving responsiveness with new breakpoints, and refining table behavior. Below is a summary of the most important changes grouped by theme:

### Component Updates:
* Replaced `RoundedPaper` with `FluidPaper` across multiple components (`Description`, `Table`) to align with updated design standards. (`[[1]](diffhunk://#diff-a61d82df2129617b1a4046c9f7073ad0e07024de4e8900efc72931e6a7a2aebeL8-R11)`, `[[2]](diffhunk://#diff-a9505d30e1a9ffea36dc62258bd8018130614d4565d13a93619f594aac8e2785L2-R12)`, `[[3]](diffhunk://#diff-9730880f6a7cfb16530f6ce6e5817b00b016d55700395c0d7a0eb23434f32cf7L3-R5)`, `[[4]](diffhunk://#diff-4764775786fddeeb789131b5732379710f66adba31e74344f777edd1d6c79b26R4-R36)`)

### Responsiveness Enhancements:
* Added `mediaTabletDown` breakpoint to improve layout responsiveness in `Entity`, `FiltersLayout`, `TitleLayout`, and `DataDictionary` components. (`[[1]](diffhunk://#diff-061a643c0bbef3560c0e8c8048fd0c2f1bb8972c0acb4e0d0f031bd6b5028970R3-R12)`, `[[2]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL4-R7)`, `[[3]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bR33-R36)`, `[[4]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L3-R6)`, `[[5]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48R22-R25)`, `[[6]](diffhunk://#diff-08a9dee42e7fb0acba8a1754b8db71281ccbbcc6b06c1e5891b455e67648e906L2-R5)`, `[[7]](diffhunk://#diff-08a9dee42e7fb0acba8a1754b8db71281ccbbcc6b06c1e5891b455e67648e906R19-R22)`)

### Table Improvements:
* Updated `Table` component to dynamically adjust row direction based on screen size (`ROW_DIRECTION.VERTICAL` for smaller screens). (`[src/components/DataDictionary/components/Table/table.tsxR4-R36](diffhunk://#diff-4764775786fddeeb789131b5732379710f66adba31e74344f777edd1d6c79b26R4-R36)`)
* Refined logic in `CollapsableRows` to better handle sub-row visibility by ensuring only non-leaf sub-rows are hidden. (`[src/components/Detail/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsxL28-R28](diffhunk://#diff-30b29396fee719337c3df48fe9b030e8cb01adc9772e3aeaa02f091b04d74352L28-R28)`)

<img width="559" height="997" alt="image" src="https://github.com/user-attachments/assets/be1f8a5f-ce8a-4273-bbfc-7115ea4560f0" />
