### PR TITLE
feat: update data dictionary column filter button size to large (#603)

### DIFF
--- a/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
+++ b/src/components/DataDictionary/components/Filters/components/ColumnFilters/columnFilters.tsx
@@ -1,9 +1,11 @@
 import { ButtonGroup, Theme, useMediaQuery } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
-import React from "react";
+import React, { ComponentProps } from "react";
 import { Attribute } from "../../../../../../common/entities";
+import { BUTTON_PROPS } from "../../../../../../styles/common/mui/button";
 import { BUTTON_GROUP_PROPS } from "../../../../../common/ButtonGroup/constants";
 import { ColumnFiltersAdapter } from "../../../../../Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter";
+import { Button } from "../../../../../Filter/components/surfaces/drawer/components/Button/button";
 import { Drawer } from "../../../../../Filter/components/surfaces/drawer/Drawer/drawer";
 import { ColumnFilter } from "../../../../../Table/components/TableFeatures/ColumnFilter/columnFilter";
 import { ColumnFiltersProps } from "./types";
@@ -22,7 +24,7 @@ export const ColumnFilters = <T extends RowData = Attribute>({
     return (
       <ColumnFiltersAdapter
         table={table}
-        renderSurface={(props) => <Drawer {...props} />}
+        renderSurface={(props) => <Drawer Button={renderButton} {...props} />}
       />
     );
 
@@ -34,3 +36,12 @@ export const ColumnFilters = <T extends RowData = Attribute>({
     </ButtonGroup>
   );
 };
+
+/**
+ * Renders the drawer's open button with the specified size.
+ * @param props - Button props.
+ * @returns Button.
+ */
+function renderButton(props: ComponentProps<typeof Button>): JSX.Element {
+  return <Button size={BUTTON_PROPS.SIZE.LARGE} {...props} />;
+}

--- a/src/components/Table/components/TableFeatures/ColumnFilter/columnFilter.tsx
+++ b/src/components/Table/components/TableFeatures/ColumnFilter/columnFilter.tsx
@@ -1,6 +1,7 @@
 import { Grid, Typography } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
 import React, { Fragment, useCallback } from "react";
+import { BUTTON_PROPS } from "../../../../../styles/common/mui/button";
 import { SVG_ICON_PROPS } from "../../../../../styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
 import { DropDownIcon } from "../../../../common/Form/components/Select/components/DropDownIcon/dropDownIcon";
@@ -51,6 +52,7 @@ export const ColumnFilter = <T extends RowData>({
         endIcon={<DropDownIcon color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />}
         onClick={onOpen}
         open={open}
+        size={BUTTON_PROPS.SIZE.LARGE}
       >
         <Grid {...GRID_PROPS}>
           {getColumnHeader(column)}

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -258,7 +258,16 @@ export const MuiButton = (theme: Theme): Components["MuiButton"] => {
     variants: [
       {
         props: { size: BUTTON_PROPS.SIZE.LARGE },
-        style: { padding: "10px 16px" },
+        style: {
+          padding: "10px 16px",
+          // eslint-disable-next-line sort-keys -- disabling key order for readability
+          ".MuiButton-iconSizeLarge": {
+            // eslint-disable-next-line sort-keys -- disabling key order for readability
+            ".MuiSvgIcon-root": {
+              fontSize: "20px",
+            },
+          },
+        },
       },
       {
         props: { size: BUTTON_PROPS.SIZE.MEDIUM },


### PR DESCRIPTION
Closes #603.

This pull request introduces enhancements to the `ColumnFilters` and `ColumnFilter` components by standardizing button sizes and improving reusability through shared constants. It also updates the theme to support the new button size styling. Below are the most significant changes grouped by theme:

### Component Enhancements
* Updated the `ColumnFilters` component to use a custom `renderButton` function for rendering the drawer's open button, ensuring consistent button size (`BUTTON_PROPS.SIZE.LARGE`). [[1]](diffhunk://#diff-7943c2b249358bc0e5edadf255b893d21cfd0f83798359ec50fc17b2b83625faL25-R27) [[2]](diffhunk://#diff-7943c2b249358bc0e5edadf255b893d21cfd0f83798359ec50fc17b2b83625faR39-R47)
* Added support for the `size` property in the `ColumnFilter` component's button, aligning it with the shared `BUTTON_PROPS.SIZE.LARGE` constant.

### Code Reusability
* Imported `BUTTON_PROPS` into `columnFilters.tsx` and `columnFilter.tsx` to standardize button properties across components. [[1]](diffhunk://#diff-7943c2b249358bc0e5edadf255b893d21cfd0f83798359ec50fc17b2b83625faL3-R8) [[2]](diffhunk://#diff-d55790682b4df7a03b004786596dbaab4b4386b29f03f40a34ba62f5b836763aR4)

### Theme Updates
* Enhanced the `MuiButton` theme configuration to include specific styles for the `BUTTON_PROPS.SIZE.LARGE` variant, such as padding adjustments and icon size customization.