### PR TITLE
feat: chart view - show more link for long tail charts (#446)

### DIFF
--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/barX/plot.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/barX/plot.ts
@@ -5,7 +5,6 @@ import { PALETTE } from "../../../../../../../../../../styles/common/constants/p
 import { formatCountSize } from "../../../../../../../../../../utils/formatCountSize";
 import { DATA_FIELD, MARGIN_LEFT, TEXT_PADDING } from "./constants";
 import {
-  getCategoryTotalCount,
   getCategoryValueText,
   getCategoryValueTextFill,
   getColorRangeValue,
@@ -22,10 +21,10 @@ import {
 
 export function getPlotOptions(
   selectCategoryValueViews: SelectCategoryValueView[],
+  totalCount: number,
   width: number
 ): PlotOptions {
   const isCategorySelected = isAnyValueSelected(selectCategoryValueViews);
-  const totalCount = getCategoryTotalCount(selectCategoryValueViews);
   return {
     color: {
       domain: [false, true], // false = unselected, true = selected.
@@ -54,7 +53,6 @@ export function getPlotOptions(
         fill: DATA_FIELD.SELECTED,
         rx1: 0,
         rx2: 4,
-        sort: { order: "descending", y: "x" }, // Sort by count (x-axis), descending.
         x: DATA_FIELD.COUNT,
         y: DATA_FIELD.LABEL,
       }),
@@ -99,6 +97,7 @@ export function getPlotOptions(
       line: false,
     },
     y: {
+      domain: selectCategoryValueViews.map((d) => d.label), // Preserve the order of the pre-sorted data.
       label: null,
       line: false,
       paddingInner: getYPaddingInner(),

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.styles.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.styles.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { Button } from "@mui/material";
 import { mediaTabletDown } from "../../../../../../../../../styles/common/mixins/breakpoints";
 import { textBodySmall400 } from "../../../../../../../../../styles/common/mixins/fonts";
 import { BarX } from "../../../../../../../../Plot/components/BarX/barX";
@@ -27,4 +28,9 @@ export const StyledBarX = styled(BarX)`
       }
     }
   }
+`;
+
+export const StyledButton = styled(Button)`
+  align-self: flex-start;
+  text-transform: none;
 `;

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.tsx
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.tsx
@@ -18,7 +18,19 @@ export const Chart = ({
     <Fragment>
       <StyledBarX options={options} testId={testId} />
       {isChartExpandable(selectCategoryValueViews) && (
-        <StyledButton {...BUTTON_PROPS.PRIMARY_TEXT} onClick={onToggleBarCount}>
+        <StyledButton
+          {...BUTTON_PROPS.PRIMARY_TEXT}
+          onClick={(e) => {
+            // Scroll, only if we are closing the chart (i.e. barCount is undefined).
+            const shouldScroll = barCount === undefined;
+            onToggleBarCount();
+            if (!shouldScroll) return;
+            // Scroll the chart into view.
+            e.currentTarget
+              ?.closest("div")
+              ?.scrollIntoView({ behavior: "smooth" });
+          }}
+        >
           {renderButtonText(barCount, selectCategoryValueViews)}
         </StyledButton>
       )}

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.tsx
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.tsx
@@ -1,16 +1,27 @@
-import React, { useMemo } from "react";
-import { getPlotOptions } from "./barX/plot";
-import { StyledBarX } from "./chart.styles";
+import React, { Fragment } from "react";
+import { BUTTON_PROPS } from "../../../../../../../../common/Button/constants";
+import { StyledBarX, StyledButton } from "./chart.styles";
+import { useBarCount } from "./hooks/UseBarCount/hook";
+import { isChartExpandable } from "./hooks/UseBarCount/utils";
+import { usePlotOptions } from "./hooks/UsePlotOptions/hook";
 import { ChartProps } from "./types";
+import { renderButtonText } from "./utils";
 
 export const Chart = ({
   selectCategoryValueViews,
   testId,
   width,
 }: ChartProps): JSX.Element => {
-  const options = useMemo(
-    () => getPlotOptions(selectCategoryValueViews, width),
-    [selectCategoryValueViews, width]
+  const { barCount, onToggleBarCount } = useBarCount(selectCategoryValueViews);
+  const { options } = usePlotOptions(selectCategoryValueViews, width, barCount);
+  return (
+    <Fragment>
+      <StyledBarX options={options} testId={testId} />
+      {isChartExpandable(selectCategoryValueViews) && (
+        <StyledButton {...BUTTON_PROPS.PRIMARY_TEXT} onClick={onToggleBarCount}>
+          {renderButtonText(barCount, selectCategoryValueViews)}
+        </StyledButton>
+      )}
+    </Fragment>
   );
-  return <StyledBarX options={options} testId={testId} />;
 };

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/constants.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/constants.ts
@@ -1,1 +1,1 @@
-export const MAX_BAR_COUNT = 25;
+export const MAX_BAR_COUNT = 20;

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/constants.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_BAR_COUNT = 25;

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/hook.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/hook.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+import { SelectCategoryValueView } from "../../../../../../../../../../../common/entities";
+import { UseBarCount } from "./types";
+import { initBarCount, updateBarCount } from "./utils";
+
+export const useBarCount = (
+  selectCategoryValueViews: SelectCategoryValueView[]
+): UseBarCount => {
+  const [barCount, setBarCount] = useState<number | undefined>(
+    initBarCount(selectCategoryValueViews)
+  );
+
+  const onToggleBarCount = useCallback(() => {
+    setBarCount(updateBarCount);
+  }, []);
+
+  return { barCount, onToggleBarCount };
+};

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/types.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/types.ts
@@ -1,0 +1,4 @@
+export type UseBarCount = {
+  barCount: number | undefined;
+  onToggleBarCount: () => void;
+};

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/utils.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UseBarCount/utils.ts
@@ -1,0 +1,38 @@
+import { SelectCategoryValueView } from "../../../../../../../../../../../common/entities";
+import { MAX_BAR_COUNT } from "./constants";
+
+/**
+ * Returns the initial bar count for the chart.
+ * @param selectCategoryValueViews - Category value views.
+ * @returns Initial bar count.
+ */
+export function initBarCount(
+  selectCategoryValueViews: SelectCategoryValueView[]
+): number | undefined {
+  return isChartExpandable(selectCategoryValueViews)
+    ? MAX_BAR_COUNT
+    : undefined;
+}
+
+/**
+ * Returns true if the chart is expandable.
+ * The chart is expandable if the number of category values is greater than the maximum bar count.
+ * @param selectCategoryValueViews - Category value views.
+ * @returns True if the chart is expandable.
+ */
+export function isChartExpandable(
+  selectCategoryValueViews: SelectCategoryValueView[]
+): boolean {
+  return selectCategoryValueViews.length > MAX_BAR_COUNT;
+}
+
+/**
+ * Updates the bar count for the chart.
+ * @param barCount - Current bar count.
+ * @returns Updated bar count.
+ */
+export function updateBarCount(
+  barCount: number | undefined
+): number | undefined {
+  return barCount === undefined ? MAX_BAR_COUNT : undefined;
+}

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UsePlotOptions/hook.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UsePlotOptions/hook.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { SelectCategoryValueView } from "../../../../../../../../../../../common/entities";
+import { getPlotOptions } from "../../barX/plot";
+import { getCategoryTotalCount } from "../../barX/utils";
+import { sortByCountThenLabel } from "../../utils";
+import { UsePlotOptions } from "./types";
+
+export const usePlotOptions = (
+  selectCategoryValueViews: SelectCategoryValueView[],
+  width: number,
+  barCount: number | undefined
+): UsePlotOptions => {
+  // Organise the select category value views (sort and slice) for chart display.
+  const data = selectCategoryValueViews
+    // Sort the category values by count and label.
+    .sort(sortByCountThenLabel)
+    // Slice the category values to the number of bars to display.
+    .slice(0, barCount);
+
+  // Build the plot options.
+  const options = useMemo(
+    () =>
+      getPlotOptions(
+        data,
+        getCategoryTotalCount(selectCategoryValueViews),
+        width
+      ),
+    [data, selectCategoryValueViews, width]
+  );
+
+  return { options };
+};

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UsePlotOptions/types.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/hooks/UsePlotOptions/types.ts
@@ -1,0 +1,5 @@
+import { PlotOptions } from "@observablehq/plot";
+
+export interface UsePlotOptions {
+  options: PlotOptions;
+}

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/utils.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/utils.ts
@@ -1,0 +1,35 @@
+import { SelectCategoryValueView } from "../../../../../../../../../common/entities";
+import { sortCategoryValueViews } from "../../../../../../../../../hooks/useCategoryFilter";
+
+/**
+ * Renders the button text for the chart.
+ * @param maxBarCount - Maximum number of bars to display.
+ * @param selectCategoryValueViews - Category value views.
+ * @returns Button text.
+ */
+export function renderButtonText(
+  maxBarCount: number | undefined,
+  selectCategoryValueViews: SelectCategoryValueView[]
+): string {
+  if (!maxBarCount) return "Show less";
+
+  // Calculate the number of additional bars to show.
+  const totalBars = selectCategoryValueViews.length;
+  const count = totalBars - maxBarCount;
+
+  return `Show ${count} additional results`;
+}
+
+/**
+ * Sorts category value views by count in descending order, then label in ascending order.
+ * @param a - First category value view.
+ * @param b - Second category value view.
+ * @returns Sorted category value views.
+ */
+export function sortByCountThenLabel(
+  a: SelectCategoryValueView,
+  b: SelectCategoryValueView
+): number {
+  const compare = b.count - a.count;
+  return compare === 0 ? sortCategoryValueViews(a, b) : compare;
+}

--- a/src/hooks/useCategoryFilter.ts
+++ b/src/hooks/useCategoryFilter.ts
@@ -278,7 +278,7 @@ function isCategoryAcceptListed(
  * @param cvv1 - Second category value view to compare.
  * @returns Number indicating sort precedence of cv0 vs cv1.
  */
-function sortCategoryValueViews(
+export function sortCategoryValueViews(
   cvv0: SelectCategoryValueView,
   cvv1: SelectCategoryValueView
 ): number {


### PR DESCRIPTION
Closes #446.

This pull request introduces a new feature to make bar charts expandable, allowing users to toggle between a limited and full view of chart data. The implementation includes changes to the chart's rendering logic, supporting hooks, and utility functions. Additionally, the code has been refactored to improve modularity and maintainability.

### New Feature: Expandable Bar Charts
* Added a `StyledButton` component to enable toggling between expanded and collapsed chart views. (`[src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.styles.tsR32-R36](diffhunk://#diff-e1c498068c8e59d019aee839a3c1823f392e9c8cb81e009994159af81f074941R32-R36)`)
* Introduced the `useBarCount` hook to manage the state of the number of bars displayed, with utility functions for initialization and toggling. (`[[1]](diffhunk://#diff-e083486f1ee17f98a48a2424c657f33dcdc3b6970cfbc2a30cd854004611c621R1-R18)`, `[[2]](diffhunk://#diff-6f427b162f7bc6785dbdcf503f8b13f596acdd3bc920bd1928dfbdd621a8719dR1-R38)`, `[[3]](diffhunk://#diff-5dab0d1945c5d43fbf36847c38bbe36ee5a7b51d03ae96ffaa2903e54c7c7501R1)`, `[[4]](diffhunk://#diff-ec578b1b2d5d6c37c80bd3db9e00bd380698cf647b73adc2a1c1cbadbca98c6aR1-R4)`)
* Updated the `Chart` component to include the toggle button and integrate the `useBarCount` and `usePlotOptions` hooks for dynamic chart rendering. (`[src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.tsxL1-L15](diffhunk://#diff-a99658d08841523589d34afa18a76d70fc865c30de7968f0f7ce82d60c539ff5L1-L15)`)
* Added a `renderButtonText` utility to dynamically generate button labels based on the chart's state. (`[src/components/Index/components/EntityView/components/views/ChartView/components/Chart/utils.tsR1-R35](diffhunk://#diff-9777fd3057b3d9b024c80aa45c8b23e8520737d38b75b19a82666ee31a982375R1-R35)`)

### Refactoring and Code Improvements
* Replaced the `getPlotOptions` function with the `usePlotOptions` hook to encapsulate logic for sorting, slicing, and generating plot options. (`[[1]](diffhunk://#diff-ba51626f2a14c86611d54756d39f41dd08064ff7a95c376e4ae46e70379edb47R1-R32)`, `[[2]](diffhunk://#diff-ed9f8edb98858dd13c3da14c97b34be90c86d4540763fd91eceb977f4fb45960R1-R5)`)
* Refactored the `sortCategoryValueViews` function to be reusable across modules by exporting it. (`[src/hooks/useCategoryFilter.tsL281-R281](diffhunk://#diff-be429ae58d9b8cb952135d90b68491299b2604e948ddfb50527d4d23d27ea270L281-R281)`)
* Removed unused `getCategoryTotalCount` import and refactored the `totalCount` parameter to be passed explicitly to `getPlotOptions`. (`[[1]](diffhunk://#diff-2b83279d40573e6b6a3379495893e63b34110f3373a580e22d070fa48f7d6407L8)`, `[[2]](diffhunk://#diff-2b83279d40573e6b6a3379495893e63b34110f3373a580e22d070fa48f7d6407R24-L28)`)

These changes improve the user experience by adding interactivity to the chart and enhance the maintainability of the codebase by clearly separating concerns.