### PR TITLE
refactor!: refactor components.ts - limit exposure of each component to the theme (#427)

### DIFF
--- a/src/styles/common/mixins/breakpoints.ts
+++ b/src/styles/common/mixins/breakpoints.ts
@@ -7,8 +7,14 @@ export const bpDown820 = ({ theme }: ThemeProps): string =>
 export const bpDown1024 = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down(1024);
 
+export const bpUpLg = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.up("lg");
+
 export const bpUpSm = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("sm");
+
+export const bpUpXs = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.up("xs");
 
 export const mediaDesktopSmallDown = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down(DESKTOP_SM);

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -1,23 +1,22 @@
-import { Components } from "@mui/material";
+import { Components, Theme, ThemeOptions } from "@mui/material";
 import { DropDownIcon } from "../../components/common/Form/components/Select/components/DropDownIcon/dropDownIcon";
 import { APP } from "../../styles/common/constants/app";
 import { COLOR_MIXES } from "../../styles/common/constants/colorMixes";
 import { FONT } from "../../styles/common/constants/font";
 import { PALETTE } from "../../styles/common/constants/palette";
 import { SHADOWS } from "../../styles/common/constants/shadows";
+import { bpUpLg, bpUpSm, bpUpXs } from "../../styles/common/mixins/breakpoints";
 import { BUTTON_PROPS } from "../../styles/common/mui/button";
 import { CHIP_PROPS } from "../../styles/common/mui/chip";
 import { OUTLINED_INPUT_PROPS } from "../../styles/common/mui/outlinedInput";
 import { TOGGLE_BUTTON_PROPS } from "../../styles/common/mui/toggleButton";
-import { desktopUp, mobileUp, tabletUp } from "./breakpoints";
+import { TYPOGRAPHY_PROPS } from "../../styles/common/mui/typography";
+import * as C from "../components";
 
 // Constants
 const FLEX_START = "flex-start";
 
-/**
- * MuiAccordion Component
- */
-export const MuiAccordion: Components["MuiAccordion"] = {
+const MuiAccordion: Components["MuiAccordion"] = {
   defaultProps: {
     disableGutters: true,
     elevation: 0,
@@ -38,10 +37,7 @@ export const MuiAccordion: Components["MuiAccordion"] = {
   },
 };
 
-/**
- * MuiAccordionDetails Component
- */
-export const MuiAccordionDetails: Components["MuiAccordionDetails"] = {
+const MuiAccordionDetails: Components["MuiAccordionDetails"] = {
   styleOverrides: {
     root: {
       marginBottom: 16,
@@ -50,10 +46,7 @@ export const MuiAccordionDetails: Components["MuiAccordionDetails"] = {
   },
 };
 
-/**
- * MuiAccordionSummary Component
- */
-export const MuiAccordionSummary: Components["MuiAccordionSummary"] = {
+const MuiAccordionSummary: Components["MuiAccordionSummary"] = {
   styleOverrides: {
     content: {
       margin: "16px 0",
@@ -66,10 +59,7 @@ export const MuiAccordionSummary: Components["MuiAccordionSummary"] = {
   },
 };
 
-/**
- * MuiAppBar Component
- */
-export const MuiAppBar: Components["MuiAppBar"] = {
+const MuiAppBar: Components["MuiAppBar"] = {
   defaultProps: {
     color: "default",
     elevation: 0,
@@ -82,11 +72,7 @@ export const MuiAppBar: Components["MuiAppBar"] = {
   },
 };
 
-/**
- * MuiBackdrop Component
- * @returns MuiBackdrop component theme styles.
- */
-export const MuiBackdrop: Components["MuiBackdrop"] = {
+const MuiBackdrop: Components["MuiBackdrop"] = {
   styleOverrides: {
     invisible: {
       backgroundColor: "transparent",
@@ -97,10 +83,7 @@ export const MuiBackdrop: Components["MuiBackdrop"] = {
   },
 };
 
-/**
- * MuiBreadcrumbs Component
- */
-export const MuiBreadcrumbs: Components["MuiBreadcrumbs"] = {
+const MuiBreadcrumbs: Components["MuiBreadcrumbs"] = {
   styleOverrides: {
     li: {
       font: FONT.BODY_SMALL_400,
@@ -126,10 +109,7 @@ export const MuiBreadcrumbs: Components["MuiBreadcrumbs"] = {
   },
 };
 
-/**
- * MuiButton Component
- */
-export const MuiButton: Components["MuiButton"] = {
+const MuiButton: Components["MuiButton"] = {
   defaultProps: {
     disableRipple: true,
     disableTouchRipple: true,
@@ -327,10 +307,7 @@ export const MuiButton: Components["MuiButton"] = {
   ],
 };
 
-/**
- * MuiButtonBase Component
- */
-export const MuiButtonBase: Components["MuiButtonBase"] = {
+const MuiButtonBase: Components["MuiButtonBase"] = {
   defaultProps: {
     disableRipple: true,
     disableTouchRipple: true,
@@ -343,10 +320,7 @@ export const MuiButtonBase: Components["MuiButtonBase"] = {
   },
 };
 
-/**
- * MuiCard Component
- */
-export const MuiCard: Components["MuiCard"] = {
+const MuiCard: Components["MuiCard"] = {
   styleOverrides: {
     root: {
       borderRadius: 8,
@@ -354,10 +328,7 @@ export const MuiCard: Components["MuiCard"] = {
   },
 };
 
-/**
- * MuiCheckbox Component
- */
-export const MuiCheckbox: Components["MuiCheckbox"] = {
+const MuiCheckbox: Components["MuiCheckbox"] = {
   defaultProps: {
     size: "xsmall",
   },
@@ -383,10 +354,7 @@ export const MuiCheckbox: Components["MuiCheckbox"] = {
   ],
 };
 
-/**
- * MuiChip Component
- */
-export const MuiChip: Components["MuiChip"] = {
+const MuiChip: Components["MuiChip"] = {
   defaultProps: {
     size: "small",
   },
@@ -509,10 +477,7 @@ export const MuiChip: Components["MuiChip"] = {
   ],
 };
 
-/**
- * MuiCircularProgress Component
- */
-export const MuiCircularProgress: Components["MuiCircularProgress"] = {
+const MuiCircularProgress: Components["MuiCircularProgress"] = {
   styleOverrides: {
     circle: {
       strokeLinecap: "round",
@@ -530,10 +495,7 @@ export const MuiCircularProgress: Components["MuiCircularProgress"] = {
   ],
 };
 
-/**
- * MuiCssBaseline Component
- */
-export const MuiCssBaseline: Components["MuiCssBaseline"] = {
+const MuiCssBaseline: Components["MuiCssBaseline"] = {
   styleOverrides: {
     a: {
       color: PALETTE.PRIMARY_MAIN,
@@ -572,10 +534,7 @@ export const MuiCssBaseline: Components["MuiCssBaseline"] = {
   },
 };
 
-/**
- * MuiDialog Component
- */
-export const MuiDialog: Components["MuiDialog"] = {
+const MuiDialog: Components["MuiDialog"] = {
   styleOverrides: {
     paper: {
       boxShadow: SHADOWS["02"],
@@ -589,10 +548,7 @@ export const MuiDialog: Components["MuiDialog"] = {
   },
 };
 
-/**
- * MuiDialogActions Component
- */
-export const MuiDialogActions: Components["MuiDialogActions"] = {
+const MuiDialogActions: Components["MuiDialogActions"] = {
   styleOverrides: {
     root: {
       padding: 20,
@@ -600,10 +556,7 @@ export const MuiDialogActions: Components["MuiDialogActions"] = {
   },
 };
 
-/**
- * MuiDialogContent Component
- */
-export const MuiDialogContent: Components["MuiDialogContent"] = {
+const MuiDialogContent: Components["MuiDialogContent"] = {
   styleOverrides: {
     root: {
       borderColor: PALETTE.SMOKE_MAIN,
@@ -612,31 +565,25 @@ export const MuiDialogContent: Components["MuiDialogContent"] = {
   },
 };
 
-/**
- * MuiDialogTitle Component
- */
-export const MuiDialogTitle: Components["MuiDialogTitle"] = {
+const MuiDialogTitle: Components<Theme>["MuiDialogTitle"] = {
   styleOverrides: {
-    root: {
+    root: ({ theme }) => ({
       alignItems: "center",
       display: "grid",
       font: FONT.HEADING,
       gridAutoFlow: "column",
       padding: 20,
-      [tabletUp]: {},
+      [bpUpSm({ theme })]: {},
       // eslint-disable-next-line sort-keys -- disabling key order for readability
       "& .MuiIconButton-edgeEnd": {
         alignSelf: FLEX_START,
         justifySelf: "flex-end",
       },
-    },
+    }),
   },
 };
 
-/**
- * MuiDivider Component
- */
-export const MuiDivider: Components["MuiDivider"] = {
+const MuiDivider: Components["MuiDivider"] = {
   styleOverrides: {
     root: {
       borderColor: PALETTE.SMOKE_MAIN,
@@ -644,10 +591,7 @@ export const MuiDivider: Components["MuiDivider"] = {
   },
 };
 
-/**
- * MuiDrawer Component
- */
-export const MuiDrawer: Components["MuiDrawer"] = {
+const MuiDrawer: Components["MuiDrawer"] = {
   styleOverrides: {
     paper: {
       overflowY: "visible", // required; allows backdrop button to render outside of drawer container
@@ -655,10 +599,7 @@ export const MuiDrawer: Components["MuiDrawer"] = {
   },
 };
 
-/**
- * MuiFormControlLabel Component
- */
-export const MuiFormControlLabel: Components["MuiFormControlLabel"] = {
+const MuiFormControlLabel: Components["MuiFormControlLabel"] = {
   styleOverrides: {
     label: {
       font: FONT.BODY_400,
@@ -670,10 +611,7 @@ export const MuiFormControlLabel: Components["MuiFormControlLabel"] = {
   },
 };
 
-/**
- * MuiFormGroup Component
- */
-export const MuiFormGroup: Components["MuiFormGroup"] = {
+const MuiFormGroup: Components["MuiFormGroup"] = {
   styleOverrides: {
     root: {
       alignItems: FLEX_START,
@@ -682,10 +620,7 @@ export const MuiFormGroup: Components["MuiFormGroup"] = {
   },
 };
 
-/**
- * MuiFormHelperText Component
- */
-export const MuiFormHelperText: Components["MuiFormHelperText"] = {
+const MuiFormHelperText: Components["MuiFormHelperText"] = {
   styleOverrides: {
     root: {
       font: FONT.BODY_SMALL_400,
@@ -697,10 +632,7 @@ export const MuiFormHelperText: Components["MuiFormHelperText"] = {
   },
 };
 
-/**
- * MuiIconButton Component
- */
-export const MuiIconButton: Components["MuiIconButton"] = {
+const MuiIconButton: Components["MuiIconButton"] = {
   defaultProps: {
     disableRipple: true,
   },
@@ -828,21 +760,18 @@ export const MuiIconButton: Components["MuiIconButton"] = {
   ],
 };
 
-/**
- * MuiInputBase Component
- */
-export const MuiInputBase: Components["MuiInputBase"] = {
+const MuiInputBase: Components<Theme>["MuiInputBase"] = {
   styleOverrides: {
     multiline: {
       height: "unset",
     },
-    root: {
+    root: ({ theme }) => ({
       font: FONT.BODY_400,
       fontSize: 16, // overrides default 14px to prevent IOS zoom on focus.
       height: 40,
       letterSpacing: "normal",
       // eslint-disable-next-line sort-keys -- disabling key order for readability
-      [tabletUp]: {
+      [bpUpSm({ theme })]: {
         fontSize: "14px",
       },
       variants: [
@@ -856,14 +785,11 @@ export const MuiInputBase: Components["MuiInputBase"] = {
           },
         },
       ],
-    },
+    }),
   },
 };
 
-/**
- * MuiLink Component
- */
-export const MuiLink: Components["MuiLink"] = {
+const MuiLink: Components["MuiLink"] = {
   defaultProps: {
     underline: "always",
   },
@@ -882,10 +808,7 @@ export const MuiLink: Components["MuiLink"] = {
   },
 };
 
-/**
- * MuiListItemButton Component
- */
-export const MuiListItemButton: Components["MuiListItemButton"] = {
+const MuiListItemButton: Components["MuiListItemButton"] = {
   styleOverrides: {
     root: {
       font: FONT.BODY_400,
@@ -907,10 +830,7 @@ export const MuiListItemButton: Components["MuiListItemButton"] = {
   },
 };
 
-/**
- * MuiListItemText Component
- */
-export const MuiListItemText: Components["MuiListItemText"] = {
+const MuiListItemText: Components["MuiListItemText"] = {
   styleOverrides: {
     root: {
       margin: 0,
@@ -918,10 +838,7 @@ export const MuiListItemText: Components["MuiListItemText"] = {
   },
 };
 
-/**
- * MuiListSubheader Component
- */
-export const MuiListSubheader: Components["MuiListSubheader"] = {
+const MuiListSubheader: Components["MuiListSubheader"] = {
   defaultProps: { disableSticky: true },
   styleOverrides: {
     root: {
@@ -931,10 +848,7 @@ export const MuiListSubheader: Components["MuiListSubheader"] = {
   },
 };
 
-/**
- * MuiMenuItem Component
- */
-export const MuiMenuItem: Components["MuiMenuItem"] = {
+const MuiMenuItem: Components["MuiMenuItem"] = {
   defaultProps: { disableRipple: true },
   styleOverrides: {
     root: {
@@ -945,10 +859,7 @@ export const MuiMenuItem: Components["MuiMenuItem"] = {
   },
 };
 
-/**
- * MuiOutlinedInput Component
- */
-export const MuiOutlinedInput: Components["MuiOutlinedInput"] = {
+const MuiOutlinedInput: Components["MuiOutlinedInput"] = {
   styleOverrides: {
     input: {
       color: PALETTE.INK_LIGHT,
@@ -1080,10 +991,7 @@ export const MuiOutlinedInput: Components["MuiOutlinedInput"] = {
   },
 };
 
-/**
- * MuiPaper Component
- */
-export const MuiPaper: Components["MuiPaper"] = {
+const MuiPaper: Components["MuiPaper"] = {
   variants: [
     {
       props: { elevation: 1 },
@@ -1144,10 +1052,7 @@ export const MuiPaper: Components["MuiPaper"] = {
   ],
 };
 
-/**
- * MuiRadio Component
- */
-export const MuiRadio: Components["MuiRadio"] = {
+const MuiRadio: Components["MuiRadio"] = {
   defaultProps: {
     disableRipple: true,
   },
@@ -1175,10 +1080,7 @@ export const MuiRadio: Components["MuiRadio"] = {
   },
 };
 
-/**
- * MuiSelect Component
- */
-export const MuiSelect: Components["MuiSelect"] = {
+const MuiSelect: Components["MuiSelect"] = {
   defaultProps: {
     IconComponent: DropDownIcon,
   },
@@ -1190,10 +1092,7 @@ export const MuiSelect: Components["MuiSelect"] = {
   },
 };
 
-/**
- * MuiSvgIcon Component
- */
-export const MuiSvgIcon: Components["MuiSvgIcon"] = {
+const MuiSvgIcon: Components["MuiSvgIcon"] = {
   styleOverrides: {
     fontSizeLarge: {
       fontSize: "32px",
@@ -1260,10 +1159,7 @@ export const MuiSvgIcon: Components["MuiSvgIcon"] = {
   ],
 };
 
-/**
- * MuiTab Component
- */
-export const MuiTab: Components["MuiTab"] = {
+const MuiTab: Components["MuiTab"] = {
   styleOverrides: {
     labelIcon: {
       gap: 8,
@@ -1293,10 +1189,7 @@ export const MuiTab: Components["MuiTab"] = {
   },
 };
 
-/**
- * MuiTableSortLabel Component
- */
-export const MuiTableSortLabel: Components["MuiTableSortLabel"] = {
+const MuiTableSortLabel: Components["MuiTableSortLabel"] = {
   styleOverrides: {
     icon: {
       fontSize: 20,
@@ -1321,10 +1214,7 @@ export const MuiTableSortLabel: Components["MuiTableSortLabel"] = {
   },
 };
 
-/**
- * MuiTabs Component
- */
-export const MuiTabs: Components["MuiTabs"] = {
+const MuiTabs: Components<Theme>["MuiTabs"] = {
   defaultProps: {
     textColor: "inherit",
     variant: "scrollable",
@@ -1376,21 +1266,18 @@ export const MuiTabs: Components["MuiTabs"] = {
       minHeight: "unset",
       position: "relative", // Positions scroll fuzz.
     },
-    scroller: {
+    scroller: ({ theme }) => ({
       margin: 0,
       padding: "0 8px",
       // eslint-disable-next-line sort-keys -- disabling key order for readability
-      [tabletUp]: {
+      [bpUpSm({ theme })]: {
         padding: 0,
       },
-    },
+    }),
   },
 };
 
-/**
- * MuiToggleButton Component
- */
-export const MuiToggleButton: Components["MuiToggleButton"] = {
+const MuiToggleButton: Components<Theme>["MuiToggleButton"] = {
   styleOverrides: {
     root: {
       backgroundColor: PALETTE.SMOKE_MAIN,
@@ -1421,10 +1308,7 @@ export const MuiToggleButton: Components["MuiToggleButton"] = {
   },
 };
 
-/**
- * MuiToggleButtonGroup Component
- */
-export const MuiToggleButtonGroup: Components["MuiToggleButtonGroup"] = {
+const MuiToggleButtonGroup: Components["MuiToggleButtonGroup"] = {
   styleOverrides: {
     grouped: {
       border: "none !important", // Overrides "grouped" css selector specificity.
@@ -1443,29 +1327,23 @@ export const MuiToggleButtonGroup: Components["MuiToggleButtonGroup"] = {
   },
 };
 
-/**
- * MuiToolbar Component
- */
-export const MuiToolbar: Components["MuiToolbar"] = {
+const MuiToolbar: Components<Theme>["MuiToolbar"] = {
   styleOverrides: {
-    root: {
-      [mobileUp]: {
+    root: ({ theme }) => ({
+      [bpUpXs({ theme })]: {
         paddingLeft: 12,
         paddingRight: 12,
       },
       // eslint-disable-next-line sort-keys -- disabling key order for readability
-      [desktopUp]: {
+      [bpUpLg({ theme })]: {
         paddingLeft: 16,
         paddingRight: 16,
       },
-    },
+    }),
   },
 };
 
-/**
- * MuiTooltip Component
- */
-export const MuiTooltip: Components["MuiTooltip"] = {
+const MuiTooltip: Components["MuiTooltip"] = {
   defaultProps: {
     enterTouchDelay: 0,
     leaveTouchDelay: 4000,
@@ -1489,10 +1367,7 @@ export const MuiTooltip: Components["MuiTooltip"] = {
   },
 };
 
-/**
- * MuiTypography Component
- */
-export const MuiTypography: Components["MuiTypography"] = {
+const MuiTypography: Components["MuiTypography"] = {
   defaultProps: {
     variant: "inherit",
   },
@@ -1500,5 +1375,62 @@ export const MuiTypography: Components["MuiTypography"] = {
     gutterBottom: {
       marginBottom: 8,
     },
+    root: {
+      variants: [
+        {
+          props: { variant: TYPOGRAPHY_PROPS.VARIANT.UPPERCASE_500 },
+          style: { textTransform: "uppercase" },
+        },
+      ],
+    },
   },
+};
+
+export const components: ThemeOptions["components"] = {
+  MuiAccordion,
+  MuiAccordionDetails,
+  MuiAccordionSummary,
+  MuiAlert: C.MuiAlert,
+  MuiAlertTitle: C.MuiAlertTitle,
+  MuiAppBar,
+  MuiBackdrop,
+  MuiBreadcrumbs,
+  MuiButton,
+  MuiButtonBase,
+  MuiButtonGroup: C.MuiButtonGroup,
+  MuiCard,
+  MuiCheckbox,
+  MuiChip,
+  MuiCircularProgress,
+  MuiCssBaseline,
+  MuiDialog,
+  MuiDialogActions,
+  MuiDialogContent,
+  MuiDialogTitle,
+  MuiDivider,
+  MuiDrawer,
+  MuiFormControlLabel,
+  MuiFormGroup,
+  MuiFormHelperText,
+  MuiIconButton,
+  MuiInputBase,
+  MuiLink,
+  MuiListItemButton,
+  MuiListItemText,
+  MuiListSubheader,
+  MuiMenuItem,
+  MuiOutlinedInput,
+  MuiPaper,
+  MuiRadio,
+  MuiSelect,
+  MuiSvgIcon,
+  MuiTab,
+  MuiTableCell: C.MuiTableCell,
+  MuiTableSortLabel,
+  MuiTabs,
+  MuiToggleButton,
+  MuiToggleButtonGroup,
+  MuiToolbar,
+  MuiTooltip,
+  MuiTypography,
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,12 +1,11 @@
 import { createTheme, Theme, ThemeOptions } from "@mui/material";
 import { deepmerge } from "@mui/utils";
 import { breakpoints } from "./common/breakpoints";
-import * as C from "./common/components";
+import { components } from "./common/components";
 import { fontStyles } from "./common/fontStyles";
 import { palette } from "./common/palette";
 import { shadows } from "./common/shadows";
 import { typography } from "./common/typography";
-import * as M from "./components";
 
 /**
  * Returns a generated theme with customization.
@@ -27,11 +26,12 @@ export function createAppTheme(customOptions: ThemeOptions = {}): Theme {
   delete options.breakpoints;
 
   // Generate default theme with custom overrides.
-  const theme = createTheme(
+  return createTheme(
     deepmerge(
       {
         app: { fontFamily: baseTheme.typography.fontFamily },
         breakpoints: baseTheme.breakpoints,
+        components,
         cssVarPrefix: "",
         cssVariables: true,
         palette,
@@ -42,56 +42,4 @@ export function createAppTheme(customOptions: ThemeOptions = {}): Theme {
       options
     )
   );
-
-  // Theme components.
-  theme.components = {
-    MuiAccordion: C.MuiAccordion,
-    MuiAccordionDetails: C.MuiAccordionDetails,
-    MuiAccordionSummary: C.MuiAccordionSummary,
-    MuiAlert: M.MuiAlert,
-    MuiAlertTitle: M.MuiAlertTitle,
-    MuiAppBar: C.MuiAppBar,
-    MuiBackdrop: C.MuiBackdrop,
-    MuiBreadcrumbs: C.MuiBreadcrumbs,
-    MuiButton: C.MuiButton,
-    MuiButtonBase: C.MuiButtonBase,
-    MuiButtonGroup: M.MuiButtonGroup,
-    MuiCard: C.MuiCard,
-    MuiCheckbox: C.MuiCheckbox,
-    MuiChip: C.MuiChip,
-    MuiCircularProgress: C.MuiCircularProgress,
-    MuiCssBaseline: C.MuiCssBaseline,
-    MuiDialog: C.MuiDialog,
-    MuiDialogActions: C.MuiDialogActions,
-    MuiDialogContent: C.MuiDialogContent,
-    MuiDialogTitle: C.MuiDialogTitle,
-    MuiDivider: C.MuiDivider,
-    MuiDrawer: C.MuiDrawer,
-    MuiFormControlLabel: C.MuiFormControlLabel,
-    MuiFormGroup: C.MuiFormGroup,
-    MuiFormHelperText: C.MuiFormHelperText,
-    MuiIconButton: C.MuiIconButton,
-    MuiInputBase: C.MuiInputBase,
-    MuiLink: C.MuiLink,
-    MuiListItemButton: C.MuiListItemButton,
-    MuiListItemText: C.MuiListItemText,
-    MuiListSubheader: C.MuiListSubheader,
-    MuiMenuItem: C.MuiMenuItem,
-    MuiOutlinedInput: C.MuiOutlinedInput,
-    MuiPaper: C.MuiPaper,
-    MuiRadio: C.MuiRadio,
-    MuiSelect: C.MuiSelect,
-    MuiSvgIcon: C.MuiSvgIcon,
-    MuiTab: C.MuiTab,
-    MuiTableCell: M.MuiTableCell,
-    MuiTableSortLabel: C.MuiTableSortLabel,
-    MuiTabs: C.MuiTabs,
-    MuiToggleButton: C.MuiToggleButton,
-    MuiToggleButtonGroup: C.MuiToggleButtonGroup,
-    MuiToolbar: C.MuiToolbar,
-    MuiTooltip: C.MuiTooltip,
-    MuiTypography: C.MuiTypography,
-  };
-
-  return theme;
 }


### PR DESCRIPTION
Closes #427.

This pull request refactors the MUI component theme overrides in `src/theme/common/components.ts` to use local constants instead of exported ones, streamlining the code and improving maintainability. It also introduces new breakpoint mixins in `src/styles/common/mixins/breakpoints.ts` and updates how breakpoints are referenced within component overrides for better consistency.

**Refactoring and Code Organization:**

* Converted all exported MUI component theme overrides from `export const` to local `const` assignments, removing JSDoc comments and reducing export clutter in `src/theme/common/components.ts`. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1-R19) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L41-R40) [[3]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L53-R49) [[4]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L69-R62) [[5]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L85-R75) [[6]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L100-R86) [[7]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L129-R112) [[8]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L330-R310) [[9]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L346-R331) [[10]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L386-R357) [[11]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L512-R480) [[12]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L533-R498) [[13]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L575-R537) [[14]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L592-R559) [[15]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L615-R602) [[16]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L673-R614) [[17]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L685-R623) [[18]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L700-R635) [[19]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L831-R774) [[20]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L859-R792) [[21]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L885-R811) [[22]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L910-R841) [[23]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L934-R851) [[24]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L948-R862) [[25]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1083-R994) [[26]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1147-R1055) [[27]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1178-R1083) [[28]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1193-R1095) [[29]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1263-R1162) [[30]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1296-R1192) [[31]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1324-R1217)

**Breakpoint and Responsive Design Improvements:**

* Added new breakpoint mixins: `bpUpLg`, `bpUpSm`, and `bpUpXs` in `src/styles/common/mixins/breakpoints.ts`, and replaced usage of older breakpoint constants (e.g., `tabletUp`) with these new mixins in component overrides for improved clarity and consistency. [[1]](diffhunk://#diff-e6335f24e1ea71e29585444daf18b0bb2b7cb9eacddacbae7e39636a5fcd8856R10-R18) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1-R19) [[3]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L615-R602) [[4]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L831-R774)

**Type and Interface Updates:**

* Updated the type annotations for certain MUI components to use `Components<Theme>` or `Components<ThemeOptions>` where appropriate, ensuring correct typing for theme-dependent overrides. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1-R19) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L615-R602) [[3]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L831-R774) [[4]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L1324-R1217)

These changes collectively make the theme configuration easier to maintain, more consistent, and better typed for future development.