### PR TITLE
refactor!: refactor breakpoints.ts - limit public surface area (#428)

### DIFF
--- a/src/components/DataDictionary/components/Description/description.styles.ts
+++ b/src/components/DataDictionary/components/Description/description.styles.ts
@@ -1,17 +1,14 @@
 import styled from "@emotion/styled";
 import { FONT } from "../../../../styles/common/constants/font";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import {
-  mediaTabletDown,
-  mediaTabletUp,
-} from "../../../../styles/common/mixins/breakpoints";
+import { bpDownSm, bpUpSm } from "../../../../styles/common/mixins/breakpoints";
 import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 import { MarkdownRenderer } from "../../../MarkdownRenderer/markdownRenderer";
 
 export const StyledFluidPaper = styled(FluidPaper)`
   padding: 20px;
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     padding: 20px 16px;
   }
 `;
@@ -38,7 +35,7 @@ export const StyledMarkdownRenderer = styled(MarkdownRenderer)`
     font-size: 18px;
     line-height: 26px;
 
-    ${mediaTabletUp} {
+    ${bpUpSm} {
       font-size: 18px;
       line-height: 26px;
     }

--- a/src/components/DataDictionary/components/Entity/entity.styles.ts
+++ b/src/components/DataDictionary/components/Entity/entity.styles.ts
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
-import { mediaTabletDown } from "../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../styles/common/mixins/breakpoints";
 
 export const StyledTypography = styled(Typography)`
   &:hover a {
     opacity: 1;
   }
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 0 16px;
   }
 ` as typeof Typography;

--- a/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/FiltersLayout/filtersLayout.styles.ts
@@ -3,7 +3,7 @@ import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
 import {
   bpDown1024,
-  mediaTabletDown,
+  bpDownSm,
 } from "../../../../../../styles/common/mixins/breakpoints";
 import { LAYOUT_SPACING } from "../../constants";
 
@@ -31,7 +31,7 @@ export const Layout = styled("div")<LayoutSpacing>`
     position: relative;
   }
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 0 16px;
   }
 `;

--- a/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
+++ b/src/components/DataDictionary/components/Layout/components/TitleLayout/titleLayout.styles.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { LayoutSpacing } from "../../../../../../hooks/UseLayoutSpacing/types";
 import {
   bpDown1024,
-  mediaTabletDown,
+  bpDownSm,
 } from "../../../../../../styles/common/mixins/breakpoints";
 
 export const Layout = styled("div")<LayoutSpacing>`
@@ -20,7 +20,7 @@ export const Layout = styled("div")<LayoutSpacing>`
     position: relative;
   }
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 0 16px;
   }
 `;

--- a/src/components/DataDictionary/dataDictionary.styles.ts
+++ b/src/components/DataDictionary/dataDictionary.styles.ts
@@ -1,8 +1,5 @@
 import styled from "@emotion/styled";
-import {
-  bpDown1024,
-  mediaTabletDown,
-} from "../../styles/common/mixins/breakpoints";
+import { bpDown1024, bpDownSm } from "../../styles/common/mixins/breakpoints";
 
 export const View = styled("div")`
   column-gap: 24px;
@@ -17,7 +14,7 @@ export const View = styled("div")`
     margin: 0 16px;
   }
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 0;
   }
 `;

--- a/src/components/Detail/components/Table/table.tsx
+++ b/src/components/Detail/components/Table/table.tsx
@@ -16,7 +16,6 @@ import {
   BREAKPOINT_FN_NAME,
   useBreakpointHelper,
 } from "../../../../hooks/useBreakpointHelper";
-import { TABLET } from "../../../../theme/common/breakpoints";
 import { arrIncludesSome } from "../../../Table/columnDef/columnFilters/filterFn";
 import { COLUMN_DEF } from "../../../Table/common/columnDef";
 import { ROW_DIRECTION } from "../../../Table/common/entities";
@@ -52,9 +51,9 @@ export const Table = <T extends RowData>({
   tableOptions,
   tableView,
 }: TableProps<T>): JSX.Element => {
-  const tabletDown = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, TABLET);
+  const bpDownSm = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "sm");
   const rowDirection =
-    collapsable && tabletDown ? ROW_DIRECTION.VERTICAL : ROW_DIRECTION.DEFAULT;
+    collapsable && bpDownSm ? ROW_DIRECTION.VERTICAL : ROW_DIRECTION.DEFAULT;
   const { table, tableContainer } = tableView || {};
   const { stickyHeader = false } = table || {};
   const { sx: tableContainerSx } = tableContainer || {};

--- a/src/components/Error/error.styles.ts
+++ b/src/components/Error/error.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { FONT } from "../../styles/common/constants/font";
-import { TABLET } from "../../theme/common/breakpoints";
+import { bpUpSm } from "../../styles/common/mixins/breakpoints";
 import { Section, sectionMarginXsm } from "../common/Section/section.styles";
 
 interface Props {
@@ -29,7 +29,7 @@ export const ErrorSection = styled(Section)`
   align-items: center;
   padding: 0;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     padding: 0;
   }
 `;

--- a/src/components/Export/components/ExportForm/exportForm.styles.ts
+++ b/src/components/Export/components/ExportForm/exportForm.styles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { FormControl as MFormControl } from "@mui/material";
 import { FONT } from "../../../../styles/common/constants/font";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../styles/common/mixins/breakpoints";
 import { ThemeProps } from "../../../../theme/types";
 import {
   sectionMargin,
@@ -12,7 +12,7 @@ import {
 
 export const margin = ({ theme }: ThemeProps) => css`
   ${sectionMargin}
-  ${mediaTabletUp({ theme })} {
+  ${bpUpSm({ theme })} {
     ${sectionMarginSm}
   }
 `;
@@ -52,7 +52,7 @@ export const TableFormControl = styled(FormControl)`
     .MuiFormLabel-root {
       margin: 16px;
 
-      ${mediaTabletUp} {
+      ${bpUpSm} {
         margin: 16px 20px;
       }
     }
@@ -64,7 +64,7 @@ export const TableFormControl = styled(FormControl)`
     .MuiFormHelperText-root {
       margin: 16px;
 
-      ${mediaTabletUp} {
+      ${bpUpSm} {
         margin: 16px 20px;
       }
     }
@@ -81,7 +81,7 @@ export const TableFormControl = styled(FormControl)`
         min-height: 48px;
         padding: 14px 16px;
 
-        ${mediaTabletUp} {
+        ${bpUpSm} {
           padding: 14px 20px;
         }
       }

--- a/src/components/Export/components/ManifestDownload/components/ManifestDownloadEntity/manifestDownloadEntity.styles.ts
+++ b/src/components/Export/components/ManifestDownload/components/ManifestDownloadEntity/manifestDownloadEntity.styles.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { TableContainer as MTableContainer } from "@mui/material";
 import { FONT } from "../../../../../../styles/common/constants/font";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../../../styles/common/mixins/breakpoints";
 
 export const SectionTitle = styled("h4")`
   background-color: ${PALETTE.COMMON_WHITE};
@@ -10,7 +10,7 @@ export const SectionTitle = styled("h4")`
   margin: 0;
   padding: 20px 16px;
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     padding: 20px;
   }
 `;
@@ -25,7 +25,7 @@ export const TableContainer = styled(MTableContainer)`
     min-height: 56px;
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     td,
     th {
       padding: 12px 20px;

--- a/src/components/Export/export.styles.ts
+++ b/src/components/Export/export.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { FONT } from "../../styles/common/constants/font";
 import { PALETTE } from "../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../styles/common/mixins/breakpoints";
 import { ThemeProps } from "../../theme/types";
 import { SectionContent as MDXSectionContent } from "../common/MDXMarkdown/components/Section/mdxSection.styles";
 import {
@@ -12,7 +12,7 @@ import {
 
 export const sectionMargin = ({ theme }: ThemeProps) => css`
   ${sectionMarginXsm}
-  ${mediaTabletUp({ theme })} {
+  ${bpUpSm({ theme })} {
     margin: 16px 20px;
   }
 `;

--- a/src/components/Filter/components/SearchAllFilters/components/AutocompletePopper/autocompletePopper.styles.ts
+++ b/src/components/Filter/components/SearchAllFilters/components/AutocompletePopper/autocompletePopper.styles.ts
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 import { Popper as MPopper } from "@mui/material";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
-import { mediaDesktopSmallDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDownMd } from "../../../../../../styles/common/mixins/breakpoints";
 
 export const AutocompletePopper = styled(MPopper)`
-  ${mediaDesktopSmallDown} {
+  ${bpDownMd} {
     .MuiPaper-root {
       background-color: ${PALETTE.SMOKE_LIGHT};
 

--- a/src/components/Filter/components/SearchAllFilters/components/VariableSizeList/VariableSizeList.tsx
+++ b/src/components/Filter/components/SearchAllFilters/components/VariableSizeList/VariableSizeList.tsx
@@ -21,7 +21,6 @@ import {
 } from "../../../../../../hooks/useBreakpointHelper";
 import { OnFilterFn } from "../../../../../../hooks/useCategoryFilter";
 import { useWindowResize } from "../../../../../../hooks/useWindowResize";
-import { DESKTOP_SM } from "../../../../../../theme/common/breakpoints";
 import {
   LIST_ITEM_HEIGHT,
   LIST_MARGIN,
@@ -132,10 +131,7 @@ export const VariableSizeList = forwardRef<
 ): JSX.Element {
   const filteredItems = applyMenuFilter(selectCategoryViews, searchTerm);
   let resizeRequired = true;
-  const desktopSmDown = useBreakpointHelper(
-    BREAKPOINT_FN_NAME.DOWN,
-    DESKTOP_SM
-  );
+  const bpDownMd = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "md");
   const { height: windowHeight } = useWindowResize();
   const [height, setHeight] = useState<number>(initHeight);
   const itemSizeByItemKeyRef = useRef<ItemSizeByItemKey>(new Map());
@@ -157,10 +153,10 @@ export const VariableSizeList = forwardRef<
           outerRef.current,
           innerRef.current,
           windowHeight,
-          desktopSmDown
+          bpDownMd
         )
       );
-  }, [desktopSmDown, windowHeight]);
+  }, [bpDownMd, windowHeight]);
 
   // Clears VariableSizeList cache (offsets and measurements) when values are updated (filtered).
   // Facilitates correct positioning of list items when list is updated.
@@ -202,7 +198,7 @@ export const VariableSizeList = forwardRef<
                   outerRef.current,
                   innerRef.current,
                   windowHeight,
-                  desktopSmDown
+                  bpDownMd
                 )
               );
             }
@@ -270,18 +266,18 @@ function applyMenuFilter(
  * @param outerListElem - Outer list element to reference list position from.
  * @param innerListElem - Element containing list items.
  * @param windowHeight - Window height.
- * @param desktopSmDown - True if viewport is small desktop or smaller.
+ * @param bpDownMd - True if viewport is "md" or smaller.
  * @returns calculated height.
  */
 function calculateListHeight(
   outerListElem: HTMLDivElement,
   innerListElem: HTMLUListElement,
   windowHeight: number,
-  desktopSmDown: boolean
+  bpDownMd: boolean
 ): number {
   // Calculate max possible list height, based on window height and top position of the list element.
   const maxHeight = windowHeight - outerListElem.getBoundingClientRect().top;
-  if (desktopSmDown) {
+  if (bpDownMd) {
     return maxHeight;
   }
   // Grab the first and last element in the list.

--- a/src/components/Filter/components/SearchAllFilters/searchAllFilters.tsx
+++ b/src/components/Filter/components/SearchAllFilters/searchAllFilters.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../../../hooks/useBreakpointHelper";
 import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
 import { TEST_IDS } from "../../../../tests/testIds";
-import { DESKTOP_SM } from "../../../../theme/common/breakpoints";
 import { useDrawer } from "../../../common/Drawer/provider/hook";
 import { SearchCloseButton } from "../SearchAllFiltersSearch/components/SearchCloseButton/searchCloseButton";
 import { SearchAllFiltersSearch } from "../SearchAllFiltersSearch/searchAllFiltersSearch";
@@ -83,7 +82,7 @@ export const SearchAllFilters = ({
   onFilter,
 }: SearchAllFiltersProps): JSX.Element => {
   const { open: isDrawerOpen } = useDrawer();
-  const desktopSmUp = useBreakpointHelper(BREAKPOINT_FN_NAME.UP, DESKTOP_SM);
+  const bpUpMd = useBreakpointHelper(BREAKPOINT_FN_NAME.UP, "md");
   const autocompleteRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
@@ -91,9 +90,9 @@ export const SearchAllFilters = ({
     isSelectCategoryView(view)
   );
 
-  // Handles background scroll action (desktop only).
+  // Handles background scroll action ("md" and up).
   const handleBackgroundScroll = (overflowStyle: OVERFLOW_STYLE): void => {
-    if (desktopSmUp) {
+    if (bpUpMd) {
       setElementsOverflowStyle(
         [
           document.querySelector(SELECTOR.BODY),
@@ -160,13 +159,13 @@ export const SearchAllFilters = ({
       }}
     >
       <Autocomplete
-        clearOnBlur={desktopSmUp}
+        clearOnBlur={bpUpMd}
         data-testid={TEST_IDS.SEARCH_ALL_FILTERS}
         filterOptions={(options): string[] => options}
         freeSolo
         ListboxComponent={Listbox}
-        onBlur={desktopSmUp ? onCloseSearch : undefined}
-        onClose={desktopSmUp ? onCloseSearch : undefined}
+        onBlur={bpUpMd ? onCloseSearch : undefined}
+        onClose={bpUpMd ? onCloseSearch : undefined}
         onFocus={onOpenSearch}
         onOpen={onOpen}
         open={open}
@@ -186,7 +185,7 @@ export const SearchAllFilters = ({
             },
           })
         }
-        slotProps={desktopSmUp ? DEFAULT_SLOT_PROPS : DRAWER_SLOT_PROPS}
+        slotProps={bpUpMd ? DEFAULT_SLOT_PROPS : DRAWER_SLOT_PROPS}
       />
     </ListboxContext.Provider>
   );

--- a/src/components/Filter/components/SearchAllFiltersSearch/components/SearchCloseButton/searchCloseButton.tsx
+++ b/src/components/Filter/components/SearchAllFiltersSearch/components/SearchCloseButton/searchCloseButton.tsx
@@ -5,18 +5,14 @@ import {
   BREAKPOINT_FN_NAME,
   useBreakpointHelper,
 } from "../../../../../../hooks/useBreakpointHelper";
-import { DESKTOP_SM } from "../../../../../../theme/common/breakpoints";
 import { ListboxContext } from "../../../SearchAllFilters/searchAllFilters";
 
 export const SearchCloseButton = (): JSX.Element => {
-  const desktopSmDown = useBreakpointHelper(
-    BREAKPOINT_FN_NAME.DOWN,
-    DESKTOP_SM
-  );
+  const bpDownMd = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "md");
   const { onClearSearch, onCloseSearch, open, searchTerm } =
     useContext(ListboxContext);
-  const showButton = open && (desktopSmDown || searchTerm);
-  const onClickFn = desktopSmDown ? onCloseSearch : onClearSearch;
+  const showButton = open && (bpDownMd || searchTerm);
+  const onClickFn = bpDownMd ? onCloseSearch : onClearSearch;
   return (
     <Fragment>
       {showButton && (

--- a/src/components/Index/components/EntityView/components/controls/ExportButton/exportButton.styles.ts
+++ b/src/components/Index/components/EntityView/components/controls/ExportButton/exportButton.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Box } from "@mui/material";
-import { mediaTabletDown } from "../../../../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../../../../styles/common/mixins/breakpoints";
 
 export const StyledBox = styled(Box)`
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     display: none;
   }
 `;

--- a/src/components/Index/components/EntityView/components/controls/FilterButton/filterButton.styles.ts
+++ b/src/components/Index/components/EntityView/components/controls/FilterButton/filterButton.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
-import { mediaDesktopSmallUp } from "../../../../../../../styles/common/mixins/breakpoints";
+import { bpUpMd } from "../../../../../../../styles/common/mixins/breakpoints";
 
 export const StyledButton = styled(Button)`
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     display: none;
   }
 `;

--- a/src/components/Index/components/EntityView/components/layout/Summary/summary.styles.ts
+++ b/src/components/Index/components/EntityView/components/layout/Summary/summary.styles.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
+import { bpDown1024 } from "../../../../../../../styles/common/mixins/breakpoints";
 import { Dot } from "../../../../../../common/Dot/dot";
 
 export const StyledGrid = styled(Grid)`
@@ -9,7 +10,7 @@ export const StyledGrid = styled(Grid)`
   max-width: fit-content;
   padding: 12px 16px;
 
-  ${({ theme }) => theme.breakpoints.down(1024)} {
+  ${bpDown1024} {
     display: none;
   }
 `;

--- a/src/components/Index/components/EntityView/components/slots/EntityViewSlot/entityViewSlot.styles.ts
+++ b/src/components/Index/components/EntityView/components/slots/EntityViewSlot/entityViewSlot.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
-import { mediaTabletDown } from "../../../../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../../../../styles/common/mixins/breakpoints";
 
 export const StyledGrid = styled(Grid)`
   display: grid;
@@ -11,7 +11,7 @@ export const StyledGrid = styled(Grid)`
     display: none;
   }
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 16px 0;
   }
 `;

--- a/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.styles.ts
+++ b/src/components/Index/components/EntityView/components/views/ChartView/components/Chart/chart.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { FONT } from "../../../../../../../../../styles/common/constants/font";
-import { mediaTabletDown } from "../../../../../../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../../../../../../styles/common/mixins/breakpoints";
 import { BarX } from "../../../../../../../../Plot/components/BarX/barX";
 
 export const StyledBarX = styled(BarX)`
@@ -18,7 +18,7 @@ export const StyledBarX = styled(BarX)`
           text-anchor: end;
         }
 
-        ${mediaTabletDown} {
+        ${bpDownSm} {
           display: none;
           &:nth-of-type(1),
           &:nth-last-of-type(1) {

--- a/src/components/Index/index.styles.ts
+++ b/src/components/Index/index.styles.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
 import { LayoutSpacing } from "../../hooks/UseLayoutSpacing/types";
 import { PALETTE } from "../../styles/common/constants/palette";
-import { mediaTabletDown } from "../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../styles/common/mixins/breakpoints";
 import { FluidPaper } from "../common/Paper/components/FluidPaper/fluidPaper";
 
 export const StyledGridEntityView = styled(Grid, {
@@ -63,7 +63,7 @@ export const StyledGridEntityList = styled(Grid)`
   margin: 16px;
   overflow: hidden;
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     margin: 16px 0;
   }
 `;

--- a/src/components/Layout/components/BackPage/backPageView.styles.ts
+++ b/src/components/Layout/components/BackPage/backPageView.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { TABLET } from "../../../../theme/common/breakpoints";
+import { bpDownSm, bpUpSm } from "../../../../styles/common/mixins/breakpoints";
 import { Sections } from "../../../common/Sections/sections";
 
 export const BackPageView = styled.div`
@@ -12,7 +12,7 @@ export const BackPageView = styled.div`
   margin: 0 16px;
   padding: 24px 0;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     grid-template-columns: repeat(12, 1fr);
     margin: 0 auto;
     max-width: min(calc(100% - 32px), 1232px);
@@ -30,7 +30,7 @@ export const BackPageHero = styled.div`
 export const BackPageTabs = styled.div`
   grid-column: 1 / -1;
 
-  ${({ theme }) => theme.breakpoints.down(TABLET)} {
+  ${bpDownSm} {
     margin-left: -16px;
     margin-right: -16px;
   }
@@ -46,7 +46,7 @@ export const BackPageContent = styled.div`
   margin-left: -16px;
   margin-right: -16px;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     display: grid;
     gap: 16px;
     grid-template-columns: inherit;
@@ -66,7 +66,7 @@ export const DetailPageOverviewContent = styled(BackPageContent)`
   gap: 1px;
   padding: 1px 0;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     background-color: transparent;
     padding: 0;
   }
@@ -94,14 +94,14 @@ export const BackPageContentSingleColumn = styled(BackPageContentColumn)`
 
 // Main column.
 export const BackPageContentMainColumn = styled(BackPageContentColumn)`
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     ${mainColumn};
   }
 `;
 
 // Side column.
 export const BackPageContentSideColumn = styled(BackPageContentColumn)`
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     ${sideColumn};
   }
 `;
@@ -116,7 +116,7 @@ export const DetailPageOverviewContentMainColumn = styled(Sections)`
     display: contents; // required to override nested GridPaper.
   }
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     align-self: flex-start;
     display: grid;
     ${mainColumn};
@@ -138,7 +138,7 @@ export const DetailPageOverviewContentSideColumn = styled(Sections)`
     display: contents; // required to override nested GridPaper.
   }
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     align-self: flex-start;
     display: grid;
     ${sideColumn};

--- a/src/components/Layout/components/BackPage/components/BackPageHero/backPageHero.styles.ts
+++ b/src/components/Layout/components/BackPage/components/BackPageHero/backPageHero.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Stack } from "@mui/material";
-import { mediaTabletUp } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../../../styles/common/mixins/breakpoints";
 import { CallToActionButton as CTAButton } from "../../../../../common/Button/components/CallToActionButton/callToActionButton";
 
 export const BackPageHeroHeadline = styled.div`
@@ -10,7 +10,7 @@ export const BackPageHeroHeadline = styled.div`
     grid-column: 1 / -1; // Title and breadcrumbs consume full width of available grid.
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     display: flex;
     flex: 1;
     gap: 88px;
@@ -29,7 +29,7 @@ export const CallToActionButton = styled(CTAButton)`
   align-self: center;
   justify-self: flex-start;
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     justify-self: flex-end;
   }
 `;

--- a/src/components/Layout/components/BackPage/components/BackPageHero/components/Actions/actions.styles.ts
+++ b/src/components/Layout/components/BackPage/components/BackPageHero/components/Actions/actions.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { mediaTabletUp } from "../../../../../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../../../../../styles/common/mixins/breakpoints";
 
 export const BackPageHeroActions = styled.div`
   align-items: center;
@@ -8,7 +8,7 @@ export const BackPageHeroActions = styled.div`
   gap: 16px;
   justify-self: flex-start;
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     justify-self: flex-end;
   }
 `;

--- a/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
+++ b/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
@@ -3,8 +3,8 @@ import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
 import {
   bpDownSm,
-  media1366Up,
-  mediaDesktopSmallUp,
+  bpUp1366,
+  bpUpMd,
 } from "../../../../styles/common/mixins/breakpoints";
 import { PanelBackgroundColor } from "./common/entities";
 
@@ -39,7 +39,7 @@ export const ContentLayout = styled.div<LayoutProps>`
   height: 100%;
   margin: 0 auto;
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     ${({ hasNavigation }) =>
       hasNavigation
         ? css`
@@ -54,7 +54,7 @@ export const ContentLayout = styled.div<LayoutProps>`
           `};
   }
 
-  ${media1366Up} {
+  ${bpUp1366} {
     grid-template-areas: "navigation content outline";
     grid-template-columns:
       ${NAV_GRID_WIDTH}px
@@ -86,7 +86,7 @@ export const NavigationGrid = styled.div<GridProps>`
   display: none;
   grid-area: navigation;
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     display: block;
   }
 `;
@@ -102,7 +102,7 @@ export const OutlineGrid = styled("div")<GridProps>`
   display: none;
   grid-area: outline;
 
-  ${media1366Up} {
+  ${bpUp1366} {
     display: block;
   }
 `;

--- a/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
+++ b/src/components/Layout/components/ContentLayout/contentLayout.styles.ts
@@ -2,9 +2,9 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
 import {
+  bpDownSm,
   media1366Up,
   mediaDesktopSmallUp,
-  mediaTabletDown,
 } from "../../../../styles/common/mixins/breakpoints";
 import { PanelBackgroundColor } from "./common/entities";
 
@@ -125,7 +125,7 @@ export const Content = styled.div`
   max-width: ${CONTENT_MAX_WIDTH}px;
   padding: ${PADDING_Y}px 40px;
 
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     padding: ${PADDING_Y}px 16px;
   }
 `;

--- a/src/components/Layout/components/Footer/footer.styles.ts
+++ b/src/components/Layout/components/Footer/footer.styles.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { AppBar as MAppBar } from "@mui/material";
 import { FONT } from "../../../../styles/common/constants/font";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../styles/common/mixins/breakpoints";
 import { Socials as DXSocials } from "../../../common/Socials/socials";
 import { Link as DXLink } from "../../../Links/components/Link/link";
 
@@ -19,7 +19,7 @@ export const AppBar = styled(MAppBar)`
     padding: 0 16px;
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     padding: 0;
 
     .MuiToolbar-root {
@@ -37,7 +37,7 @@ export const Links = styled.div`
   flex-direction: column;
   gap: 24px;
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     flex-direction: row;
   }
 `;

--- a/src/components/Layout/components/Header/components/Content/components/Slogan/slogan.styles.ts
+++ b/src/components/Layout/components/Header/components/Content/components/Slogan/slogan.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Divider as MDivider } from "@mui/material";
-import { mediaDesktopSmallUp } from "../../../../../../../../styles/common/mixins/breakpoints";
+import { bpUpMd } from "../../../../../../../../styles/common/mixins/breakpoints";
 
 export const Slogan = styled.div`
   padding: 8px 24px;
@@ -9,7 +9,7 @@ export const Slogan = styled.div`
     display: block;
   }
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     flex: none;
     padding: 0;
 

--- a/src/components/Layout/components/Sidebar/components/SidebarButton/sidebarButton.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarButton/sidebarButton.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
 import {
+  bpUpMd,
   bpUpSm,
-  mediaDesktopSmallUp,
 } from "../../../../../../styles/common/mixins/breakpoints";
 import { ButtonSecondary } from "../../../../../common/Button/components/ButtonSecondary/buttonSecondary";
 
@@ -15,7 +15,7 @@ export const SidebarButton = styled(ButtonSecondary)`
     justify-self: flex-end;
   }
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     display: none;
   }
 `;

--- a/src/components/Layout/components/Sidebar/components/SidebarButton/sidebarButton.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarButton/sidebarButton.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
 import {
+  bpUpSm,
   mediaDesktopSmallUp,
-  mediaTabletUp,
 } from "../../../../../../styles/common/mixins/breakpoints";
 import { ButtonSecondary } from "../../../../../common/Button/components/ButtonSecondary/buttonSecondary";
 
@@ -10,7 +10,7 @@ export const SidebarButton = styled(ButtonSecondary)`
   grid-column: 1 / -1;
   padding: 10px;
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     grid-column: 2;
     justify-self: flex-end;
   }

--- a/src/components/Layout/components/Sidebar/components/SidebarDrawer/sidebarDrawer.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarDrawer/sidebarDrawer.styles.ts
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { Popover as MPopover } from "@mui/material";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
-import { mediaDesktopSmallDown } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpDownMd } from "../../../../../../styles/common/mixins/breakpoints";
 import { IconButton as DXIconButton } from "../../../../../common/IconButton/iconButton";
 
 export const TemporarySidebar = styled(MPopover)`
   &.MuiPopover-root {
-    ${mediaDesktopSmallDown} {
+    ${bpDownMd} {
       & .MuiPaper-root {
         background-color: ${PALETTE.SMOKE_LIGHT};
         box-shadow: 0 1px 4px 0 transparent; // required; possible bug - box shadow "none" affects rendering of main content.

--- a/src/components/Layout/components/Sidebar/components/SidebarPositioner/sidebarPositioner.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarPositioner/sidebarPositioner.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { mediaDesktopSmallUp } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpUpMd } from "../../../../../../styles/common/mixins/breakpoints";
 
 interface Props {
   headerHeight: number;
@@ -11,7 +11,7 @@ export const SidebarPositioner = styled("div")<Props>`
   overflow: visible;
   padding: 16px 0;
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     max-height: 100vh;
     overflow: auto;
     padding: ${({ headerHeight }) => headerHeight}px 0 0;

--- a/src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { mediaDesktopSmallUp } from "../../../../../../styles/common/mixins/breakpoints";
+import { bpUpMd } from "../../../../../../styles/common/mixins/breakpoints";
 
 export const SidebarTools = styled.div`
   display: grid;
@@ -12,7 +12,7 @@ export const SidebarTools = styled.div`
     grid-column: 1 / -1; // SearchAllFilters component to utilize full width of the grid.
   }
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     padding: 8px 16px;
   }
 `;

--- a/src/components/Layout/components/Sidebar/sidebar.tsx
+++ b/src/components/Layout/components/Sidebar/sidebar.tsx
@@ -5,7 +5,6 @@ import {
   useBreakpointHelper,
 } from "../../../../hooks/useBreakpointHelper";
 import { TEST_IDS } from "../../../../tests/testIds";
-import { DESKTOP_SM } from "../../../../theme/common/breakpoints";
 import { useDrawer } from "../../../common/Drawer/provider/hook";
 import { SidebarDrawer } from "./components/SidebarDrawer/sidebarDrawer";
 import { SidebarPositioner } from "./components/SidebarPositioner/sidebarPositioner";
@@ -13,11 +12,8 @@ import { Sidebar as PermanentSidebar } from "./sidebar.styles";
 
 export const Sidebar = ({ children }: ChildrenProps): JSX.Element => {
   const { onClose, open } = useDrawer();
-  const desktopSmDown = useBreakpointHelper(
-    BREAKPOINT_FN_NAME.DOWN,
-    DESKTOP_SM
-  );
-  const drawerSidebar = desktopSmDown;
+  const bpDownMd = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "md");
+  const drawerSidebar = bpDownMd;
   const Bar = drawerSidebar ? SidebarDrawer : PermanentSidebar;
   const barProps = drawerSidebar
     ? { onClose, open }
@@ -25,10 +21,10 @@ export const Sidebar = ({ children }: ChildrenProps): JSX.Element => {
 
   // Closes an open, controlled drawer sidebar with a change of breakpoint.
   useEffect(() => {
-    if (open && !desktopSmDown) {
+    if (open && !bpDownMd) {
       onClose();
     }
-  }, [desktopSmDown, onClose, open]);
+  }, [bpDownMd, onClose, open]);
 
   return (
     <Bar {...barProps}>

--- a/src/components/Loading/loading.styles.ts
+++ b/src/components/Loading/loading.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { COLOR_MIXES } from "../../styles/common/constants/colorMixes";
-import { TABLET } from "../../theme/common/breakpoints";
+import { bpDownSm } from "../../styles/common/mixins/breakpoints";
 import { Paper, PAPER_PANEL_STYLE } from "../common/Paper/paper";
 import { LOADING_PANEL_STYLE, LoadingPanelStyle } from "./loading";
 
@@ -49,7 +49,7 @@ export const LoadingPaper = styled(Paper)<Props>`
     css`
       border-radius: 8px;
 
-      ${theme.breakpoints.down(TABLET)} {
+      ${bpDownSm({ theme })} {
         border-left: none;
         border-radius: 0;
         border-right: none;

--- a/src/components/Login/login.styles.ts
+++ b/src/components/Login/login.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
-import { TABLET } from "../../theme/common/breakpoints";
+import { bpUpSm } from "../../styles/common/mixins/breakpoints";
 import { Section, SectionActions } from "../common/Section/section.styles";
 
 export const LoginWrapper = styled.div`
@@ -17,7 +17,7 @@ export const LoginSection = styled(Section)`
   gap: 24px 0;
   padding: 32px;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     padding: 32px;
   }
 `;

--- a/src/components/Support/components/SupportRequest/components/Dialog/dialog.styles.ts
+++ b/src/components/Support/components/SupportRequest/components/Dialog/dialog.styles.ts
@@ -3,8 +3,7 @@ import { Fab as MFab, Popover as MPopover } from "@mui/material";
 import { COLOR_MIXES } from "../../../../../../styles/common/constants/colorMixes";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
 import { SHADOWS } from "../../../../../../styles/common/constants/shadows";
-import { mediaTabletUp } from "../../../../../../styles/common/mixins/breakpoints";
-import { tabletUp } from "../../../../../../theme/common/breakpoints";
+import { bpUpSm } from "../../../../../../styles/common/mixins/breakpoints";
 
 interface Props {
   open: boolean;
@@ -17,7 +16,7 @@ export const Fab = styled(MFab)<Props>`
   right: 16px;
   z-index: ${({ open }) => (open ? 1350 : 1050)}; // Above backdrop component.
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     bottom: 72px;
   }
 `;
@@ -31,7 +30,7 @@ export const Popover = styled(MPopover)`
       border-radius: 8px;
       width: 100%;
 
-      ${tabletUp} {
+      ${bpUpSm} {
         max-width: 496px;
       }
     }

--- a/src/components/Support/components/ViewSupport/viewSupport.styles.ts
+++ b/src/components/Support/components/ViewSupport/viewSupport.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../styles/common/constants/palette";
 import { SHADOWS } from "../../../../styles/common/constants/shadows";
-import { mediaTabletUp } from "../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../styles/common/mixins/breakpoints";
 
 export const Fab = styled("a")`
   align-items: center;
@@ -25,7 +25,7 @@ export const Fab = styled("a")`
     background-color: ${PALETTE.PRIMARY_DARK};
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     bottom: 72px;
   }
 `;

--- a/src/components/Table/components/DownloadEntityResults/downloadEntityResults.styles.ts
+++ b/src/components/Table/components/DownloadEntityResults/downloadEntityResults.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
-import { mediaTabletDown } from "../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../styles/common/mixins/breakpoints";
 
 export const StyledButton = styled(Button)`
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     display: none;
   }
 `;

--- a/src/components/Table/components/TableToolbar/components/RowPreview/components/RowDrawer/rowDrawer.styles.ts
+++ b/src/components/Table/components/TableToolbar/components/RowPreview/components/RowDrawer/rowDrawer.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../../../../../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../../../../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../../../../../styles/common/mixins/breakpoints";
 import { DrawerTitle as DXDrawerTitle } from "../../../../../../../common/Drawer/components/DrawerTitle/drawerTitle";
 import { Drawer as DXDrawer } from "../../../../../../../common/Drawer/drawer";
 
@@ -16,7 +16,7 @@ export const Drawer = styled(DXDrawer)`
       width: 100%;
     }
 
-    ${mediaTabletUp} {
+    ${bpUpSm} {
       .MuiDrawer-paper {
         max-width: min(506px, 50vw);
       }

--- a/src/components/Table/components/TableToolbar/components/RowPreview/components/Section/components/RowDetail/rowDetail.styles.ts
+++ b/src/components/Table/components/TableToolbar/components/RowPreview/components/Section/components/RowDetail/rowDetail.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { FONT } from "../../../../../../../../../../styles/common/constants/font";
 import {
+  bpUpMd,
   bpUpSm,
-  mediaDesktopSmallUp,
 } from "../../../../../../../../../../styles/common/mixins/breakpoints";
 
 export const Section = styled.div`
@@ -42,7 +42,7 @@ export const Section = styled.div`
     }
   }
 
-  ${mediaDesktopSmallUp} {
+  ${bpUpMd} {
     grid-template-columns: 194px minmax(0, 1fr);
   }
 `;

--- a/src/components/Table/components/TableToolbar/components/RowPreview/components/Section/components/RowDetail/rowDetail.styles.ts
+++ b/src/components/Table/components/TableToolbar/components/RowPreview/components/Section/components/RowDetail/rowDetail.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { FONT } from "../../../../../../../../../../styles/common/constants/font";
 import {
+  bpUpSm,
   mediaDesktopSmallUp,
-  mediaTabletUp,
 } from "../../../../../../../../../../styles/common/mixins/breakpoints";
 
 export const Section = styled.div`
@@ -28,7 +28,7 @@ export const Section = styled.div`
     text-transform: none;
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     gap: 0 8px;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     padding: 8px 24px;

--- a/src/components/Table/table.styles.ts
+++ b/src/components/Table/table.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { PALETTE } from "../../styles/common/constants/palette";
-import { mediaTabletDown } from "../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../styles/common/mixins/breakpoints";
 import { GridTable as Table } from "./common/gridTable.styles";
 
 interface Props {
@@ -26,7 +26,7 @@ export const GridTable = styled(Table, {
   shouldForwardProp: (prop) => prop !== "collapsable",
 })<Props>`
   // Collapsable.
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     ${({ collapsable }) =>
       collapsable &&
       css`

--- a/src/components/Table/table.tsx
+++ b/src/components/Table/table.tsx
@@ -15,7 +15,6 @@ import {
 import { useExploreMode } from "../../hooks/useExploreMode/useExploreMode";
 import { useExploreState } from "../../hooks/useExploreState";
 import { ExploreActionKind } from "../../providers/exploreState";
-import { TABLET } from "../../theme/common/breakpoints";
 import { Loading, LOADING_PANEL_STYLE } from "../Loading/loading";
 import { NoResults } from "../NoResults/noResults";
 import { getColumnTrackSizing } from "../TableCreator/options/columnTrackSizing/utils";
@@ -39,14 +38,14 @@ export const Table = <T extends RowData>({
   loading,
   table,
 }: TableProps<T>): JSX.Element => {
-  const tabletDown = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, TABLET);
+  const bpDownSm = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "sm");
   const exploreMode = useExploreMode();
   const { exploreDispatch, exploreState } = useExploreState();
   const { paginationState } = exploreState;
   const { currentPage, pages } = paginationState;
   const { disablePagination = false } = listView || {};
   const clientFiltering = isClientFilteringEnabled(exploreMode);
-  const rowDirection = tabletDown
+  const rowDirection = bpDownSm
     ? ROW_DIRECTION.VERTICAL
     : ROW_DIRECTION.DEFAULT;
   const { rows, scrollElementRef, virtualizer } = useVirtualization({

--- a/src/components/common/Banner/banner.styles.ts
+++ b/src/components/common/Banner/banner.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Alert } from "@mui/material";
 import { FONT } from "../../../styles/common/constants/font";
-import { mediaDesktopUp } from "../../../styles/common/mixins/breakpoints";
+import { bpUpLg } from "../../../styles/common/mixins/breakpoints";
 
 export const StyledAlert = styled(Alert)`
   justify-content: center;
@@ -23,7 +23,7 @@ export const StyledAlert = styled(Alert)`
     padding: 0;
   }
 
-  ${mediaDesktopUp} {
+  ${bpUpLg} {
     padding: 8px 16px;
   }
 `;

--- a/src/components/common/Banner/components/CookieBanner/cookieBanner.styles.ts
+++ b/src/components/common/Banner/components/CookieBanner/cookieBanner.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Alert } from "@mui/material";
 import { FONT } from "../../../../../styles/common/constants/font";
-import { mediaTabletUp } from "../../../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../../../styles/common/mixins/breakpoints";
 
 export const StyledAlert = styled(Alert)`
   bottom: 0;
@@ -25,7 +25,7 @@ export const StyledAlert = styled(Alert)`
     padding: 0;
   }
 
-  ${mediaTabletUp} {
+  ${bpUpSm} {
     box-sizing: content-box;
     margin: 16px;
     max-width: 400px;

--- a/src/components/common/Card/card.styles.ts
+++ b/src/components/common/Card/card.styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { TABLET } from "../../../theme/common/breakpoints";
+import { bpUpSm } from "../../../styles/common/mixins/breakpoints";
 import { SectionContent } from "../Section/section.styles";
 
 export const CardSection = styled.div`
@@ -7,7 +7,7 @@ export const CardSection = styled.div`
   gap: 16px;
   padding: 20px 16px;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     padding: 20px;
   }
 `;

--- a/src/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
+++ b/src/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
-import { mediaTabletDown } from "../../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../../styles/common/mixins/breakpoints";
 import { RoundedPaper } from "../RoundedPaper/roundedPaper";
 
 export const StyledPaper = styled(RoundedPaper)`
-  ${mediaTabletDown} {
+  ${bpDownSm} {
     border-left: none;
     border-radius: 0;
     border-right: none;

--- a/src/components/common/Paper/paper.styles.ts
+++ b/src/components/common/Paper/paper.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { PALETTE } from "../../../styles/common/constants/palette";
-import { TABLET } from "../../../theme/common/breakpoints";
+import { bpDownSm } from "../../../styles/common/mixins/breakpoints";
 import { Paper } from "./paper";
 
 /**
@@ -36,7 +36,7 @@ export const RoundedPaper = styled(Paper)`
 /* eslint-enable valid-jsdoc -- disable require param */
 export const FluidPaper = styled(RoundedPaper)`
   & {
-    ${({ theme }) => theme.breakpoints.down(TABLET)} {
+    ${bpDownSm} {
       border-left: none;
       border-radius: 0;
       border-right: none;

--- a/src/components/common/Section/components/CollapsableSection/collapsableSection.styles.ts
+++ b/src/components/common/Section/components/CollapsableSection/collapsableSection.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { ButtonBase, Typography } from "@mui/material";
 import { PALETTE } from "../../../../../styles/common/constants/palette";
-import { TABLET } from "../../../../../theme/common/breakpoints";
+import { bpUpSm } from "../../../../../styles/common/mixins/breakpoints";
 
 export const CollapsableSection = styled.div`
   background-color: ${PALETTE.COMMON_WHITE};
@@ -10,7 +10,7 @@ export const CollapsableSection = styled.div`
   min-width: 0; /* required to ellipsis any flex child */
   padding: 4px 0;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     gap: 8px;
     padding: 20px;
   }
@@ -21,7 +21,7 @@ export const SectionSummary = styled(ButtonBase)`
   justify-content: space-between;
   padding: 16px;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     padding: 0;
   }
 `;
@@ -33,7 +33,7 @@ export const SectionText = styled(Typography)`
   gap: 16px;
   padding: 0 16px 16px;
 
-  ${({ theme }) => theme.breakpoints.up(TABLET)} {
+  ${bpUpSm} {
     padding: 0;
   }
 ` as typeof Typography;

--- a/src/components/common/Section/components/CollapsableSection/collapsableSection.tsx
+++ b/src/components/common/Section/components/CollapsableSection/collapsableSection.tsx
@@ -6,7 +6,6 @@ import {
   useBreakpointHelper,
 } from "../../../../../hooks/useBreakpointHelper";
 import { TYPOGRAPHY_PROPS } from "../../../../../styles/common/mui/typography";
-import { TABLET } from "../../../../../theme/common/breakpoints";
 import { SectionTitle } from "../SectionTitle/sectionTitle";
 import {
   CollapsableSection as Section,
@@ -25,11 +24,11 @@ export const CollapsableSection = ({
   collapsable = false,
   title,
 }: CollapsableSectionProps): JSX.Element => {
-  const mobile = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, TABLET);
+  const bpDownSm = useBreakpointHelper(BREAKPOINT_FN_NAME.DOWN, "sm");
   const [expanded, setExpanded] = useState<boolean>(false);
   const [transitionDuration, setTransitionDuration] =
     useState<CollapseProps["timeout"]>(0);
-  const disabled = !mobile || !collapsable;
+  const disabled = !bpDownSm || !collapsable;
   const ExpandIcon = expanded ? RemoveRounded : AddRounded;
   const SectionContent = (
     <SectionText
@@ -46,14 +45,14 @@ export const CollapsableSection = ({
 
   // Toggles expanded state on change of media breakpoint.
   useEffect(() => {
-    setExpanded(!mobile);
-  }, [mobile]);
+    setExpanded(!bpDownSm);
+  }, [bpDownSm]);
 
   // Sets collapseTimeout state on change of media breakpoint.
   // Delays setting transitionDuration state for mobile breakpoint to facilitate the immediate transition from
   // tablet to mobile.
   useEffect(() => {
-    if (mobile) {
+    if (bpDownSm) {
       const duration = setTimeout(() => {
         setTransitionDuration("auto");
       }, 100);
@@ -63,7 +62,7 @@ export const CollapsableSection = ({
     } else {
       setTransitionDuration(0);
     }
-  }, [mobile]);
+  }, [bpDownSm]);
 
   return (
     <Section>

--- a/src/components/common/Section/section.styles.ts
+++ b/src/components/common/Section/section.styles.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
 import { PALETTE } from "../../../styles/common/constants/palette";
-import { mediaTabletUp } from "../../../styles/common/mixins/breakpoints";
+import { bpUpSm } from "../../../styles/common/mixins/breakpoints";
 import { ThemeProps } from "../../../theme/types";
 
 export const sectionMargin = css`
@@ -20,7 +20,7 @@ export const sectionMarginXsm = css`
 export const sectionPadding = ({ theme }: ThemeProps) => css`
   padding: 20px 16px;
 
-  ${mediaTabletUp({ theme })} {
+  ${bpUpSm({ theme })} {
     padding: 20px;
   }
 `;

--- a/src/styles/common/mixins/breakpoints.ts
+++ b/src/styles/common/mixins/breakpoints.ts
@@ -1,4 +1,4 @@
-import { DESKTOP, DESKTOP_SM, TABLET } from "../../../theme/common/breakpoints";
+import { DESKTOP_SM } from "../../../theme/common/breakpoints";
 import { ThemeProps } from "../../../theme/types";
 
 export const bpDown820 = ({ theme }: ThemeProps): string =>
@@ -6,6 +6,9 @@ export const bpDown820 = ({ theme }: ThemeProps): string =>
 
 export const bpDown1024 = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down(1024);
+
+export const bpDownSm = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.down("sm");
 
 export const bpUpLg = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("lg");
@@ -23,13 +26,7 @@ export const mediaDesktopSmallUp = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up(DESKTOP_SM);
 
 export const mediaDesktopUp = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up(DESKTOP);
-
-export const mediaTabletDown = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.down(TABLET);
-
-export const mediaTabletUp = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up(TABLET);
+  theme.breakpoints.up("lg");
 
 export const media1366Up = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up(1366);

--- a/src/styles/common/mixins/breakpoints.ts
+++ b/src/styles/common/mixins/breakpoints.ts
@@ -1,4 +1,3 @@
-import { DESKTOP_SM } from "../../../theme/common/breakpoints";
 import { ThemeProps } from "../../../theme/types";
 
 export const bpDown820 = ({ theme }: ThemeProps): string =>
@@ -20,10 +19,10 @@ export const bpUpXs = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("xs");
 
 export const mediaDesktopSmallDown = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.down(DESKTOP_SM);
+  theme.breakpoints.down("md");
 
 export const mediaDesktopSmallUp = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up(DESKTOP_SM);
+  theme.breakpoints.up("md");
 
 export const mediaDesktopUp = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("lg");

--- a/src/styles/common/mixins/breakpoints.ts
+++ b/src/styles/common/mixins/breakpoints.ts
@@ -6,26 +6,26 @@ export const bpDown820 = ({ theme }: ThemeProps): string =>
 export const bpDown1024 = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down(1024);
 
+export const bpUp1366 = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.up(1366);
+
+export const bpDownLg = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.down("lg");
+
+export const bpDownMd = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.down("md");
+
 export const bpDownSm = ({ theme }: ThemeProps): string =>
   theme.breakpoints.down("sm");
 
 export const bpUpLg = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("lg");
 
+export const bpUpMd = ({ theme }: ThemeProps): string =>
+  theme.breakpoints.up("md");
+
 export const bpUpSm = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("sm");
 
 export const bpUpXs = ({ theme }: ThemeProps): string =>
   theme.breakpoints.up("xs");
-
-export const mediaDesktopSmallDown = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.down("md");
-
-export const mediaDesktopSmallUp = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up("md");
-
-export const mediaDesktopUp = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up("lg");
-
-export const media1366Up = ({ theme }: ThemeProps): string =>
-  theme.breakpoints.up(1366);

--- a/src/theme/common/breakpoints.ts
+++ b/src/theme/common/breakpoints.ts
@@ -1,4 +1,4 @@
-import { Breakpoint, ThemeOptions } from "@mui/material";
+import { ThemeOptions } from "@mui/material";
 
 /**
  * Creates breakpoint configuration for theme creation.
@@ -17,24 +17,3 @@ export const breakpoints = (
     ...themeOptions.breakpoints?.values,
   },
 });
-
-/**
- * Breakpoints
- */
-enum BREAKPOINTS {
-  DESKTOP = 1440,
-  DESKTOP_SM = 1280,
-  MOBILE = 0,
-  TABLET = 768,
-}
-
-/**
- * Breakpoint key constants
- */
-const BREAKPOINT_KEY: Record<keyof typeof BREAKPOINTS, Breakpoint> = {
-  DESKTOP: "lg",
-  DESKTOP_SM: "md",
-  MOBILE: "xs",
-  TABLET: "sm",
-};
-export const DESKTOP_SM = BREAKPOINT_KEY.DESKTOP_SM;

--- a/src/theme/common/breakpoints.ts
+++ b/src/theme/common/breakpoints.ts
@@ -37,23 +37,4 @@ const BREAKPOINT_KEY: Record<keyof typeof BREAKPOINTS, Breakpoint> = {
   MOBILE: "xs",
   TABLET: "sm",
 };
-export const DESKTOP = BREAKPOINT_KEY.DESKTOP;
 export const DESKTOP_SM = BREAKPOINT_KEY.DESKTOP_SM;
-export const MOBILE = BREAKPOINT_KEY.MOBILE;
-export const TABLET = BREAKPOINT_KEY.TABLET;
-
-/**
- * Breakpoints constants
- */
-export const desktop = BREAKPOINTS.DESKTOP;
-export const desktopSm = BREAKPOINTS.DESKTOP_SM;
-export const mobile = BREAKPOINTS.MOBILE;
-export const tablet = BREAKPOINTS.TABLET;
-
-/**
- * Breakpoints queries
- */
-export const desktopUp = `@media (min-width: ${desktop}px)`;
-export const desktopSmUp = `@media (min-width: ${desktopSm}px)`;
-export const mobileUp = `@media (min-width: ${mobile}px)`;
-export const tabletUp = `@media (min-width: ${tablet}px)`;

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -40,6 +40,15 @@ const DEFAULT_BODY_400: TypographyStyle = {
   lineHeight: "20px",
 };
 
+const DEFAULT_BREAKPOINTS = {
+  values: {
+    lg: 1440,
+    md: 1280,
+    sm: 768,
+    xs: 0,
+  },
+};
+
 const DEFAULT_PALETTE_ALERT = {
   light: "#FED3D1",
   lightest: "#FFF4F4",
@@ -198,6 +207,16 @@ describe("Theme Configuration", () => {
           );
         });
       });
+    });
+  });
+
+  describe("Breakpoint Configuration", () => {
+    it("should use default breakpoint values when no custom options provided", () => {
+      expect(theme.breakpoints.values).toEqual(DEFAULT_BREAKPOINTS.values);
+    });
+
+    it("should override breakpoints when custom values provided", () => {
+      expect(customTheme.breakpoints.values).toEqual(CUSTOM_BREAKPOINTS.values);
     });
   });
 

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -101,6 +101,12 @@ const DEFAULT_PALETTE_WARNING = {
   main: "#B54708",
 };
 
+const DEFAULT_SHADOWS = [
+  "none",
+  "0 1px 4px 0 #00000012",
+  "0 8px 8px -4px #10182808, 0 20px 24px -4px #10182814",
+];
+
 const CUSTOM_OPTIONS: ThemeOptions = {
   breakpoints: CUSTOM_BREAKPOINTS,
   palette: { primary: CUSTOM_PALETTE_PRIMARY },
@@ -206,6 +212,14 @@ describe("Theme Configuration", () => {
             `var(--palette-${color}-${shade}, ${value})`
           );
         });
+      });
+    });
+
+    it("should have shadow values exposed as CSS variables", () => {
+      expect(vars.shadows).toBeDefined();
+      vars.shadows.forEach((shadow, i) => {
+        // Full pattern test.
+        expect(shadow).toEqual(`var(--shadows-${i}, ${theme.shadows[i]})`);
       });
     });
   });
@@ -321,6 +335,22 @@ describe("Theme Configuration", () => {
         dark: DEFAULT_PALETTE_PRIMARY.dark,
         lightest: DEFAULT_PALETTE_PRIMARY.lightest,
       });
+    });
+  });
+
+  describe("Shadow Configuration", () => {
+    it("should initialize with default shadow settings", () => {
+      expect(theme.shadows).toBeDefined();
+    });
+
+    it("should have the correct number of shadows", () => {
+      expect(theme.shadows.length).toBe(25);
+    });
+
+    it("should have the correct default shadow values", () => {
+      expect(theme.shadows[0]).toBe(DEFAULT_SHADOWS[0]);
+      expect(theme.shadows[1]).toBe(DEFAULT_SHADOWS[1]);
+      expect(theme.shadows[2]).toBe(DEFAULT_SHADOWS[2]);
     });
   });
 


### PR DESCRIPTION
Closes #428.

This pull request refactors the usage of breakpoint helpers across multiple components to standardize naming conventions and improve code clarity. The main change is replacing older breakpoint constants (like `mediaTabletDown`, `mediaTabletUp`, `DESKTOP_SM`, and `TABLET`) with new, consistently named helpers (`bpDownSm`, `bpUpSm`, `bpDownMd`, `bpUpMd`). This update affects both style files and React components, ensuring uniformity in responsive design handling.

**Breakpoint Helper Refactoring**

* Replaced all instances of `mediaTabletDown` and `mediaTabletUp` with `bpDownSm` and `bpUpSm` in style files such as `description.styles.ts`, `entity.styles.ts`, `filtersLayout.styles.ts`, `titleLayout.styles.ts`, `dataDictionary.styles.ts`, `exportForm.styles.ts`, and `manifestDownloadEntity.styles.ts` to standardize breakpoint usage. [[1]](diffhunk://#diff-a61d82df2129617b1a4046c9f7073ad0e07024de4e8900efc72931e6a7a2aebeL4-R11) [[2]](diffhunk://#diff-061a643c0bbef3560c0e8c8048fd0c2f1bb8972c0acb4e0d0f031bd6b5028970L3-R10) [[3]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL6-R6) [[4]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L5-R5) [[5]](diffhunk://#diff-08a9dee42e7fb0acba8a1754b8db71281ccbbcc6b06c1e5891b455e67648e906L2-R2) [[6]](diffhunk://#diff-53588f8653d748daa106440388e93236b528b840e64cc2300f5ba0c39011e704L6-R6) [[7]](diffhunk://#diff-6367debc938332e87d4f53161ace797cd3d38e6665b87c549db55e13ac292bf4L5-R13)
* Updated corresponding style rules to use the new breakpoint helpers, ensuring consistent responsive padding and margin behaviors. [[1]](diffhunk://#diff-a61d82df2129617b1a4046c9f7073ad0e07024de4e8900efc72931e6a7a2aebeL41-R38) [[2]](diffhunk://#diff-6d6fecfa620cc0d7fdf58c38b6c0584afd309de352f2c59070d13ac0d822e68bL34-R34) [[3]](diffhunk://#diff-b337a0a979ea402634fe0a07ec148c9a617269c43258ddc081725029ff7efb48L23-R23) [[4]](diffhunk://#diff-08a9dee42e7fb0acba8a1754b8db71281ccbbcc6b06c1e5891b455e67648e906L20-R17) [[5]](diffhunk://#diff-53588f8653d748daa106440388e93236b528b840e64cc2300f5ba0c39011e704L15-R15) [[6]](diffhunk://#diff-53588f8653d748daa106440388e93236b528b840e64cc2300f5ba0c39011e704L55-R55) [[7]](diffhunk://#diff-53588f8653d748daa106440388e93236b528b840e64cc2300f5ba0c39011e704L67-R67) [[8]](diffhunk://#diff-53588f8653d748daa106440388e93236b528b840e64cc2300f5ba0c39011e704L84-R84) [[9]](diffhunk://#diff-6367debc938332e87d4f53161ace797cd3d38e6665b87c549db55e13ac292bf4L28-R28) [[10]](diffhunk://#diff-6b7e2f660becc66dbb53f531ae4c93730cd5a7eb95c84e94c62df8b448d6a9d1L15-R15)

**Component Logic Updates**

* Refactored React components to use new breakpoint helper names (`bpDownSm`, `bpDownMd`, `bpUpMd`) instead of older constants (`TABLET`, `DESKTOP_SM`), including updates to logic for responsive layouts and event handling in `table.tsx`, `VariableSizeList.tsx`, and `searchAllFilters.tsx`. [[1]](diffhunk://#diff-95555819637ab8d3ce655e1fa97ebf388fd5ec44d3d3165937ee7ac3310411c0L55-R56) [[2]](diffhunk://#diff-9a4538ce838ab40ec845fa55656145d9f646a2c6a7063efcc964a182b89449a8L135-R134) [[3]](diffhunk://#diff-d4acdfbc06326393a46fbadbb297b3f2f0403aa9f1f655806e6b46360ab444dbL86-R95)
* Updated function parameters and usages in `VariableSizeList.tsx` to match new breakpoint naming, improving code readability and maintainability. [[1]](diffhunk://#diff-9a4538ce838ab40ec845fa55656145d9f646a2c6a7063efcc964a182b89449a8L160-R159) [[2]](diffhunk://#diff-9a4538ce838ab40ec845fa55656145d9f646a2c6a7063efcc964a182b89449a8L205-R201) [[3]](diffhunk://#diff-9a4538ce838ab40ec845fa55656145d9f646a2c6a7063efcc964a182b89449a8L273-R280)

**Documentation and Comments**

* Adjusted comments throughout the codebase to reflect the new breakpoint helper names and clarify the responsive behaviors being implemented. [[1]](diffhunk://#diff-d4acdfbc06326393a46fbadbb297b3f2f0403aa9f1f655806e6b46360ab444dbL86-R95) [[2]](diffhunk://#diff-9a4538ce838ab40ec845fa55656145d9f646a2c6a7063efcc964a182b89449a8L273-R280)

These changes collectively make the codebase more consistent and easier to maintain, especially regarding responsive design logic and styling.