### PR TITLE
fix: update any typography header fonts using css vars with breakpoint overrides (#620)

### DIFF
--- a/src/components/DataDictionary/components/Description/description.styles.ts
+++ b/src/components/DataDictionary/components/Description/description.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { FONT } from "../../../../styles/common/constants/font";
 import { PALETTE } from "../../../../styles/common/constants/palette";
-import { bpDownSm, bpUpSm } from "../../../../styles/common/mixins/breakpoints";
+import { bpDownSm } from "../../../../styles/common/mixins/breakpoints";
 import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 import { MarkdownRenderer } from "../../../MarkdownRenderer/markdownRenderer";
 
@@ -34,11 +34,6 @@ export const StyledMarkdownRenderer = styled(MarkdownRenderer)`
     font: ${FONT.HEADING_SMALL};
     font-size: 18px;
     line-height: 26px;
-
-    ${bpUpSm} {
-      font-size: 18px;
-      line-height: 26px;
-    }
   }
 
   hr {
@@ -48,6 +43,6 @@ export const StyledMarkdownRenderer = styled(MarkdownRenderer)`
   }
 
   p {
-    font: inherit;
+    font: ${FONT.BODY_400_2_LINES};
   }
 `;

--- a/src/components/Support/components/SupportRequest/components/SupportRequestForm/supportRequestForm.styles.ts
+++ b/src/components/Support/components/SupportRequest/components/SupportRequestForm/supportRequestForm.styles.ts
@@ -1,11 +1,5 @@
 import styled from "@emotion/styled";
-import { FONT } from "../../../../../../styles/common/constants/font";
 import { GridPaperSection } from "../../../../../common/Section/section.styles";
-
-export const Title = styled.h3`
-  font: ${FONT.HEADING_SMALL};
-  margin: 0;
-`;
 
 export const Section = styled(GridPaperSection)`
   min-width: 0;

--- a/src/components/Support/components/SupportRequest/components/SupportRequestForm/supportRequestForm.tsx
+++ b/src/components/Support/components/SupportRequest/components/SupportRequestForm/supportRequestForm.tsx
@@ -34,7 +34,7 @@ import {
   RequestValue,
 } from "./common/entities";
 import { createSupportRequest, uploadAttachment } from "./common/utils";
-import { Section, Title } from "./supportRequestForm.styles";
+import { Section } from "./supportRequestForm.styles";
 
 export interface SupportRequestFormProps {
   setFormSubmitted: Dispatch<SetStateAction<boolean>>;
@@ -183,7 +183,12 @@ export const SupportRequestForm = ({
         <GridPaper>
           <Section>
             <SectionContent>
-              <Title>Contact Us</Title>
+              <Typography
+                component="h3"
+                variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+              >
+                Contact Us
+              </Typography>
               <Typography
                 color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
                 variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}

--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -109,7 +109,7 @@ const MuiBreadcrumbs: Components["MuiBreadcrumbs"] = {
   },
 };
 
-const MuiButton: Components["MuiButton"] = {
+const MuiButton: Components<Theme>["MuiButton"] = {
   defaultProps: {
     disableRipple: true,
     disableTouchRipple: true,
@@ -276,9 +276,9 @@ const MuiButton: Components["MuiButton"] = {
       props: {
         variant: "backNav", // associated with "nav" variant.
       },
-      style: {
+      style: ({ theme }) => ({
+        ...theme.typography["heading-small"],
         color: PALETTE.INK_MAIN,
-        font: FONT.HEADING_SMALL,
         minWidth: 0,
         textTransform: "capitalize",
         whiteSpace: "nowrap",
@@ -286,7 +286,7 @@ const MuiButton: Components["MuiButton"] = {
         "&:hover": {
           backgroundColor: PALETTE.SMOKE_LIGHT,
         },
-      },
+      }),
     },
     {
       props: {
@@ -568,9 +568,9 @@ const MuiDialogContent: Components["MuiDialogContent"] = {
 const MuiDialogTitle: Components<Theme>["MuiDialogTitle"] = {
   styleOverrides: {
     root: ({ theme }) => ({
+      ...theme.typography.heading,
       alignItems: "center",
       display: "grid",
-      font: FONT.HEADING,
       gridAutoFlow: "column",
       padding: 20,
       [bpUpSm({ theme })]: {},


### PR DESCRIPTION
Closes #620.

This pull request refactors typography usage across several components to standardize styles and rely more on the global theme, improving maintainability and consistency. It removes direct font assignments in favor of using theme-based typography and updates component imports accordingly. The changes also clean up unused code and simplify style definitions.

**Typography standardization and theme usage:**

* Replaced direct font assignments (e.g., `FONT.HEADING_SMALL`, `FONT.BODY_400_2_LINES`) in `description.styles.ts` and `supportRequestForm.styles.ts` with theme-based typography references, and removed unused imports. [[1]](diffhunk://#diff-a61d82df2129617b1a4046c9f7073ad0e07024de4e8900efc72931e6a7a2aebeL51-R46) [[2]](diffhunk://#diff-b562459df43b8d42e7c9fe6ab6bfee4cf924889ca5e9bc5149210483bac85076L2-L9)
* Updated Material UI component overrides in `components.ts` to use theme typography objects (e.g., `theme.typography["heading-small"]`, `theme.typography.heading`) instead of raw font values. [[1]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852L279-R289) [[2]](diffhunk://#diff-20f1accc5bd2f0494c93e63f67809b0ea347caa85a02a0191ec89589d367f852R571-L573)
* Fixed the `MuiButton` type definition to use the correct generic, improving type safety.

**Component and style cleanup:**

* Removed the unused `Title` styled component from `supportRequestForm.styles.ts` and updated imports and usage in `supportRequestForm.tsx` to use the `Typography` component with the appropriate variant. [[1]](diffhunk://#diff-b562459df43b8d42e7c9fe6ab6bfee4cf924889ca5e9bc5149210483bac85076L2-L9) [[2]](diffhunk://#diff-ac8cb9271012ba3eb0fd75f353f97e234d1a95b8e24e635ff4b56dabe829e2c3L37-R37) [[3]](diffhunk://#diff-ac8cb9271012ba3eb0fd75f353f97e234d1a95b8e24e635ff4b56dabe829e2c3L186-R191)
* Removed redundant responsive font-size overrides from `StyledMarkdownRenderer` in `description.styles.ts`.