### PR TITLE
feat: create typography to css helper function (#625)

### DIFF
--- a/src/styles/common/mixins/typography.ts
+++ b/src/styles/common/mixins/typography.ts
@@ -3,7 +3,7 @@ import { ThemeProps } from "../../../theme/types";
 
 /**
  * Returns typography style for the given variant.
- * @param variant - Variant.
+ * @param variant - Typography variant key from the theme configuration.
  * @returns Typography styles.
  */
 export function typographyToCSS(

--- a/src/styles/common/mixins/typography.ts
+++ b/src/styles/common/mixins/typography.ts
@@ -1,0 +1,15 @@
+import { css, SerializedStyles } from "@emotion/react";
+import { ThemeProps } from "../../../theme/types";
+
+/**
+ * Returns typography style for the given variant.
+ * @param variant - Variant.
+ * @returns Typography styles.
+ */
+export function typographyToCSS(
+  variant: keyof ThemeProps["theme"]["typography"]
+) {
+  return (props: ThemeProps): SerializedStyles => {
+    return css(props.theme.typography[variant]);
+  };
+}


### PR DESCRIPTION
Closes #625.

This pull request adds a new utility function to support consistent typography styling using Emotion and theme variants.

New typography utility:

* Added the `typographyToCSS` function in `src/styles/common/mixins/typography.ts` to generate Emotion CSS styles for a given typography variant from the theme.