### PR TITLE
fix:  revert typography theme styles (#630)

### DIFF
--- a/src/theme/common/typography.ts
+++ b/src/theme/common/typography.ts
@@ -72,9 +72,11 @@ const heading = (theme: Theme): TypographyStyle => ({
   fontFamily: "Inter",
   fontSize: "20px",
   fontWeight: 500,
+  letterSpacing: "-0.2px",
   lineHeight: "28px",
   [bpUpSm({ theme })]: {
     fontSize: "24px",
+    letterSpacing: "-0.4px",
     lineHeight: "32px",
   },
 });
@@ -83,9 +85,11 @@ const headingLarge = (theme: Theme): TypographyStyle => ({
   fontFamily: "Inter",
   fontSize: "24px",
   fontWeight: 500,
+  letterSpacing: "-0.4px",
   lineHeight: "32px",
   [bpUpSm({ theme })]: {
-    fontSize: "32px",
+    fontSize: "30px",
+    letterSpacing: "-0.8px",
     lineHeight: "40px",
   },
 });
@@ -97,6 +101,7 @@ const headingSmall = (theme: Theme): TypographyStyle => ({
   lineHeight: "26px",
   [bpUpSm({ theme })]: {
     fontSize: "20px",
+    letterSpacing: "-0.2px",
     lineHeight: "28px",
   },
 });
@@ -109,8 +114,8 @@ const headingXLarge = (theme: Theme): TypographyStyle => ({
   lineHeight: "40px",
   [bpUpSm({ theme })]: {
     fontSize: "40px",
-    letterSpacing: "-0.4px",
-    lineHeight: "48px",
+    letterSpacing: "-1.4px",
+    lineHeight: "56px",
   },
 });
 


### PR DESCRIPTION
Closes #630.

This pull request updates the typography styles in `src/theme/common/typography.ts` to improve visual consistency and readability across heading sizes. The main changes focus on adjusting letter spacing, font sizes, and line heights for headings at various breakpoints.

**Typography adjustments:**

* Increased negative letter spacing for all heading variants to create tighter text appearance, especially at larger breakpoints. (`heading`, `headingLarge`, `headingSmall`, `headingXLarge`) [[1]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9R75-R79) [[2]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9R88-R92) [[3]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9R104) [[4]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9L112-R118)
* Updated font size and line height for `headingLarge` and `headingXLarge` at larger breakpoints for better hierarchy and legibility. [[1]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9R88-R92) [[2]](diffhunk://#diff-005a20b3d16cacaaf2a1895326d6c1836fdfdbff2d3648128988bff93df92bc9L112-R118)