### PR TITLE
feat: update columnfiltersadapter to handle grouping of column filters (#632)

### DIFF
--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/types.ts
@@ -1,7 +1,16 @@
-import { RowData, Table } from "@tanstack/react-table";
+import {
+  RowData,
+  Table,
+  TableMeta as TanStackTableMeta,
+} from "@tanstack/react-table";
+import { CategoryGroup } from "../../../../../../config/entities";
 import { SurfaceProps } from "../../../surfaces/types";
 
 export interface ColumnFiltersAdapterProps<T extends RowData> {
   renderSurface: (props: SurfaceProps) => JSX.Element | null;
   table: Table<T>;
+}
+export interface ColumnFiltersTableMeta<T extends RowData>
+  extends TanStackTableMeta<T> {
+  categoryGroups?: CategoryGroup[];
 }

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -1,9 +1,47 @@
 import { Column, RowData, Table } from "@tanstack/react-table";
+import { CategoryConfig } from "common/categories/config/types";
 import { CategoryView } from "../../../../../../common/categories/views/types";
 import { SelectCategoryValueView } from "../../../../../../common/entities";
+import { CategoryGroup } from "../../../../../../config/entities";
 import { getColumnHeader } from "../../../../../Table/common/utils";
 import { getSortedFacetedValues } from "../../../../../Table/featureOptions/facetedColumn/utils";
+import { CategoryFilter } from "../../../Filters/filters";
 import { SurfaceProps } from "../../../surfaces/types";
+import { ColumnFiltersTableMeta } from "./types";
+
+/**
+ * Adapter for TanStack table to category configs.
+ * @param table - Table.
+ * @returns Category configs.
+ */
+function buildCategoryConfigs<T extends RowData>(
+  table: Table<T>
+): CategoryConfig[] {
+  return table
+    .getAllColumns()
+    .filter((column) => column.getCanFilter())
+    .map(mapCategoryConfig);
+}
+
+/**
+ * Adapter for TanStack table to category filters.
+ * @param table - Table.
+ * @param categoryGroups - Category groups.
+ * @returns Category filters.
+ */
+function buildCategoryFilters<T extends RowData>(
+  table: Table<T>,
+  categoryGroups: CategoryGroup[]
+): SurfaceProps["categoryFilters"] {
+  return categoryGroups.reduce<SurfaceProps["categoryFilters"]>(
+    (acc, categoryGroup) => {
+      const categoryFilter = mapCategoryFilter(table, categoryGroup);
+      if (categoryFilter) acc.push(categoryFilter);
+      return acc;
+    },
+    []
+  );
+}
 
 /**
  * Adapter for TanStack table column filters to category filters.
@@ -13,13 +51,19 @@ import { SurfaceProps } from "../../../surfaces/types";
 export function buildColumnFilters<T extends RowData>(
   table: Table<T>
 ): SurfaceProps["categoryFilters"] {
-  // Build the category views; single category filter.
-  const categoryViews = table
-    .getAllColumns()
-    .filter((column) => column.getCanFilter())
-    .map(mapColumnToCategoryView);
+  const { options } = table;
+  const { meta = {} } = options;
+  const { categoryGroups } = meta as ColumnFiltersTableMeta<T>;
 
-  return [{ categoryViews }];
+  if (!categoryGroups) {
+    // Build single category group with all (filterable) columns.
+    const categoryConfigs: CategoryConfig[] = buildCategoryConfigs(table);
+    // Build category filters from single category group.
+    return buildCategoryFilters(table, [{ categoryConfigs, label: "" }]);
+  }
+
+  // Build category filters from category groups.
+  return buildCategoryFilters(table, categoryGroups);
 }
 
 /**
@@ -39,13 +83,56 @@ export function getColumnFiltersCount<T extends RowData>(
 }
 
 /**
- * Adapter for TanStack column to category view.
- * Currently supports only select category views.
+ * Adapter for TanStack column to category config.
  * @param column - Column.
+ * @returns Category config.
+ */
+function mapCategoryConfig<T extends RowData>(
+  column: Column<T>
+): CategoryConfig {
+  return {
+    key: column.id,
+    label: getColumnHeader(column),
+  };
+}
+
+/**
+ * Adapter for TanStack table to category filter.
+ * @param table - Table.
+ * @param categoryGroup - Category group.
+ * @returns Category filter.
+ */
+function mapCategoryFilter<T extends RowData>(
+  table: Table<T>,
+  categoryGroup: CategoryGroup
+): CategoryFilter | undefined {
+  const { categoryConfigs, label } = categoryGroup;
+
+  const categoryViews = categoryConfigs.reduce<CategoryView[]>(
+    (acc, categoryConfig) => {
+      const column = table.getColumn(categoryConfig.key);
+      if (!column) return acc;
+      if (!column.getCanFilter()) return acc;
+      const categoryView = mapColumnToCategoryView(column, categoryConfig);
+      return [...acc, categoryView];
+    },
+    []
+  );
+
+  if (categoryViews.length === 0) return;
+
+  return { categoryViews, label };
+}
+
+/**
+ * Adapter for TanStack column to category view.
+ * @param column - Column.
+ * @param categoryConfig - Category config.
  * @returns Category view.
  */
 function mapColumnToCategoryView<T extends RowData>(
-  column: Column<T>
+  column: Column<T>,
+  categoryConfig?: CategoryConfig
 ): CategoryView {
   const facetedUniqueValues = column.getFacetedUniqueValues();
   const isDisabled = facetedUniqueValues.size === 0;
@@ -57,6 +144,7 @@ function mapColumnToCategoryView<T extends RowData>(
     key: column.id,
     label: getColumnHeader(column),
     values,
+    ...categoryConfig,
   };
 }
 

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -1,5 +1,5 @@
 import { Column, RowData, Table } from "@tanstack/react-table";
-import { CategoryConfig } from "common/categories/config/types";
+import { CategoryConfig } from "../../../../../../common/categories/config/types";
 import { CategoryView } from "../../../../../../common/categories/views/types";
 import { SelectCategoryValueView } from "../../../../../../common/entities";
 import { CategoryGroup } from "../../../../../../config/entities";


### PR DESCRIPTION
Closes #632.

This pull request enhances the flexibility of the TanStack table filter adapter by introducing support for category groups and improving how category filters are constructed. The main changes focus on allowing multiple category groups, making the system more extensible and modular.

**Support for category groups and improved filter construction:**

* Added `ColumnFiltersTableMeta` type to extend TanStack's `TableMeta` with optional `categoryGroups`, enabling the use of grouped category filters.
* Updated `buildColumnFilters` to check for `categoryGroups` in table meta; if present, it builds filters from groups, otherwise it falls back to a single group with all filterable columns.
* Introduced helper functions: `buildCategoryConfigs`, `buildCategoryFilters`, `mapCategoryConfig`, and `mapCategoryFilter` to modularize and clarify the process of mapping table columns to category configs and filters. [[1]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR2-R44) [[2]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR85-R135)
* Enhanced `mapColumnToCategoryView` to accept an optional `categoryConfig` and merge its properties, allowing for more customizable category views.

<img width="1483" height="840" alt="image" src="https://github.com/user-attachments/assets/7044d4c7-9168-4dcb-983f-3bdb5a49ae30" />
