### PR TITLE
feat: update columnfiltersadapter to handle range category filtering (#634)

### DIFF
--- a/src/common/categories/config/range/typeGuards.ts
+++ b/src/common/categories/config/range/typeGuards.ts
@@ -1,0 +1,14 @@
+import { RangeCategoryView } from "../../views/range/types";
+import { VIEW_KIND } from "../../views/types";
+import { CategoryConfig } from "../types";
+
+/**
+ * Determine if the given category config is a range category.
+ * @param categoryConfig - Category config.
+ * @returns True if the category config is a range category, false otherwise.
+ */
+export function isRangeCategoryConfig(
+  categoryConfig: CategoryConfig
+): categoryConfig is RangeCategoryView {
+  return categoryConfig.viewKind === VIEW_KIND.RANGE;
+}

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/columnFiltersAdapter.tsx
@@ -1,5 +1,6 @@
 import { RowData } from "@tanstack/react-table";
 import { useCallback } from "react";
+import { VIEW_KIND } from "../../../../../../common/categories/views/types";
 import {
   CategoryKey,
   CategoryValueKey,
@@ -22,13 +23,23 @@ export const ColumnFiltersAdapter = <T extends RowData>({
       categoryKey: CategoryKey | ClearAll,
       selectedCategoryValue: CategoryValueKey,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `selected` is not required by TanStack adapter.
-      _selected: boolean
+      _selected: boolean,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `categorySection` is not required by TanStack adapter.
+      _categorySection?: string,
+      viewKind?: VIEW_KIND
     ) => {
       if (categoryKey === CLEAR_ALL) {
         table.resetColumnFilters();
         return;
       }
 
+      // Range filters use direct value assignment (e.g., [min, max] tuple for numeric ranges).
+      if (viewKind === VIEW_KIND.RANGE) {
+        table.getColumn(categoryKey)?.setFilterValue(selectedCategoryValue);
+        return;
+      }
+
+      // Select filters use an updater function to toggle individual values in/out of the filter array.
       table
         .getColumn(categoryKey)
         ?.setFilterValue(updater(selectedCategoryValue));

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -153,7 +153,10 @@ function mapColumnToRangeCategoryView<T extends RowData>(
   const isDisabled = !minMax;
 
   // Selected values for the column.
-  const filterValue = (column.getFilterValue() || []) as [number, number];
+  const filterValue = (column.getFilterValue() || [null, null]) as [
+    number | null,
+    number | null
+  ];
 
   return {
     annotation: undefined,

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -1,7 +1,12 @@
 import { Column, RowData, Table } from "@tanstack/react-table";
+import { isRangeCategoryConfig } from "../../../../../../common/categories/config/range/typeGuards";
 import { CategoryConfig } from "../../../../../../common/categories/config/types";
+import { RangeCategoryView } from "../../../../../../common/categories/views/range/types";
 import { CategoryView } from "../../../../../../common/categories/views/types";
-import { SelectCategoryValueView } from "../../../../../../common/entities";
+import {
+  SelectCategoryValueView,
+  SelectCategoryView,
+} from "../../../../../../common/entities";
 import { CategoryGroup } from "../../../../../../config/entities";
 import { getColumnHeader } from "../../../../../Table/common/utils";
 import { getSortedFacetedValues } from "../../../../../Table/featureOptions/facetedColumn/utils";
@@ -113,7 +118,17 @@ function mapCategoryFilter<T extends RowData>(
       const column = table.getColumn(categoryConfig.key);
       if (!column) return acc;
       if (!column.getCanFilter()) return acc;
-      const categoryView = mapColumnToCategoryView(column, categoryConfig);
+
+      let categoryView: CategoryView;
+
+      if (isRangeCategoryConfig(categoryConfig)) {
+        // Build range category view.
+        categoryView = mapColumnToRangeCategoryView(column, categoryConfig);
+      } else {
+        // Build select category view.
+        categoryView = mapColumnToSelectCategoryView(column, categoryConfig);
+      }
+
       return [...acc, categoryView];
     },
     []
@@ -125,15 +140,44 @@ function mapCategoryFilter<T extends RowData>(
 }
 
 /**
- * Adapter for TanStack column to category view.
+ * Adapter for TanStack column to range category view.
  * @param column - Column.
  * @param categoryConfig - Category config.
- * @returns Category view.
+ * @returns Range category view.
  */
-function mapColumnToCategoryView<T extends RowData>(
+function mapColumnToRangeCategoryView<T extends RowData>(
   column: Column<T>,
   categoryConfig?: CategoryConfig
-): CategoryView {
+): RangeCategoryView {
+  const minMax = column.getFacetedMinMaxValues();
+  const isDisabled = !minMax;
+
+  // Selected values for the column.
+  const filterValue = (column.getFilterValue() || []) as [number, number];
+
+  return {
+    annotation: undefined,
+    isDisabled,
+    key: column.id,
+    label: getColumnHeader(column),
+    max: minMax?.[1] || Infinity,
+    min: minMax?.[0] || -Infinity,
+    selectedMax: filterValue[1],
+    selectedMin: filterValue[0],
+    ...categoryConfig,
+  };
+}
+
+/**
+ * Adapter for TanStack column to select category view.
+ * @param column - Column.
+ * @param categoryConfig - Category config.
+ * @returns Select category view.
+ */
+function mapColumnToSelectCategoryView<T extends RowData>(
+  column: Column<T>,
+  categoryConfig?: CategoryConfig
+): SelectCategoryView {
   const facetedUniqueValues = column.getFacetedUniqueValues();
   const isDisabled = facetedUniqueValues.size === 0;
   const values = mapColumnToSelectCategoryValueView(column);


### PR DESCRIPTION
Closes #634.

This pull request refactors and extends the filtering adapter logic for TanStack tables, introducing support for range filters and category groups. The changes improve how category filters are constructed, making the codebase more modular and flexible for different filter types.

### Filter adapter enhancements

* Added support for range filters by introducing the `isRangeCategoryConfig` type guard and handling `VIEW_KIND.RANGE` in the filter application logic, enabling direct value assignment for numeric ranges. [[1]](diffhunk://#diff-9147d8f723fd54b8983ec74445fe169322e656dbe1bf65d7dc96b51223526c31R1-R14) [[2]](diffhunk://#diff-3642aec699fc505dfb2bc33b72272947aade8749abad7026d2c0e67de613abf6R3) [[3]](diffhunk://#diff-3642aec699fc505dfb2bc33b72272947aade8749abad7026d2c0e67de613abf6L25-R42)
* Refactored the filter-building utilities to support category groups and both select and range category views, allowing for more complex and grouped filter UIs. [[1]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR2-R49) [[2]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL16-R71) [[3]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL42-R180) [[4]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR191)

### Type and interface updates

* Introduced `ColumnFiltersTableMeta` interface to extend TanStack's table meta with optional `categoryGroups`, and updated relevant imports and usages.

These changes make the filter system more robust and ready for advanced use cases involving both grouped and range-based filters.

<img width="1716" height="1154" alt="image" src="https://github.com/user-attachments/assets/22398186-be12-4d64-bbb1-af8f9813d04c" />
