### PR TITLE
feat: create new tabletoolbar with download button - independent of explorestate (#653)

### DIFF
--- a/src/components/Table/components/TableToolbar2/tableToolbar2.styles.ts
+++ b/src/components/Table/components/TableToolbar2/tableToolbar2.styles.ts
@@ -1,0 +1,18 @@
+import styled from "@emotion/styled";
+import { Toolbar as MToolbar, Stack } from "@mui/material";
+import { PALETTE } from "../../../../styles/common/constants/palette";
+
+export const StyledToolbar = styled(MToolbar)`
+  align-items: center;
+  background-color: ${PALETTE.COMMON_WHITE};
+  display: flex;
+  padding: 16px;
+`;
+
+export const StyledStack = styled(Stack)`
+  align-items: center;
+  flex: 1;
+  flex-direction: row;
+  gap: 8px;
+  justify-content: flex-end;
+`;

--- a/src/components/Table/components/TableToolbar2/tableToolbar2.tsx
+++ b/src/components/Table/components/TableToolbar2/tableToolbar2.tsx
@@ -1,0 +1,17 @@
+import { RowData } from "@tanstack/react-table";
+import React from "react";
+import { TableDownload } from "../TableFeatures/TableDownload/tableDownload";
+import { StyledStack, StyledToolbar } from "./tableToolbar2.styles";
+import { TableToolbar2Props } from "./types";
+
+export const TableToolbar2 = <T extends RowData>({
+  table,
+}: TableToolbar2Props<T>): JSX.Element => {
+  return (
+    <StyledToolbar>
+      <StyledStack>
+        <TableDownload table={table} />
+      </StyledStack>
+    </StyledToolbar>
+  );
+};

--- a/src/components/Table/components/TableToolbar2/types.ts
+++ b/src/components/Table/components/TableToolbar2/types.ts
@@ -1,0 +1,5 @@
+import { RowData, Table } from "@tanstack/react-table";
+
+export interface TableToolbar2Props<T extends RowData> {
+  table: Table<T>;
+}


### PR DESCRIPTION
Closes #653.

<img width="1715" height="950" alt="image" src="https://github.com/user-attachments/assets/01167da2-165d-43c4-acd2-27b437c909b7" />

<img width="1257" height="394" alt="image" src="https://github.com/user-attachments/assets/f3e6c994-c4fd-44fb-8005-e62928ea1480" />
