### PR TITLE
refactor: align table download feature more closely with tanstack standards (#659)

### DIFF
--- a/src/components/Table/common/columnDef.ts
+++ b/src/components/Table/common/columnDef.ts
@@ -9,10 +9,10 @@ export const COLUMN_DEF: Record<string, ColumnDef<RowData>> = {
   ROW_POSITION: {
     cell: RowPositionCell,
     enableColumnFilter: false,
-    enableDownload: false,
     enableGrouping: false,
     enableHiding: false,
     enableSorting: false,
+    enableTableDownload: false,
     header: "",
     id: COLUMN_IDENTIFIER.ROW_POSITION,
     meta: {
@@ -25,10 +25,10 @@ export const COLUMN_DEF: Record<string, ColumnDef<RowData>> = {
   ROW_SELECTION: {
     cell: RowSelectionCell,
     enableColumnFilter: false,
-    enableDownload: false,
     enableGrouping: false,
     enableHiding: false,
     enableSorting: false,
+    enableTableDownload: false,
     header: HeadSelectionCell,
     id: COLUMN_IDENTIFIER.ROW_SELECTION,
     meta: {

--- a/src/components/Table/components/TableFeatures/TableDownload/tableDownload.tsx
+++ b/src/components/Table/components/TableFeatures/TableDownload/tableDownload.tsx
@@ -9,7 +9,7 @@ export const TableDownload = <T extends RowData>({
   className,
   table,
 }: TableDownloadProps<T>): JSX.Element | null => {
-  if (!table.getIsDownloadEnabled()) return null;
+  if (!table.options.enableTableDownload) return null;
   return (
     <StyledButton
       {...BUTTON_PROPS.SECONDARY_CONTAINED}

--- a/src/components/Table/featureOptions/tableDownload/constants.ts
+++ b/src/components/Table/featureOptions/tableDownload/constants.ts
@@ -3,7 +3,7 @@ import { TableDownloadOptions } from "../../features/TableDownload/types";
 
 export const TABLE_DOWNLOAD_OPTIONS: Pick<
   TableDownloadOptions<RowData>,
-  "enableDownload"
+  "enableTableDownload"
 > = {
-  enableDownload: false,
+  enableTableDownload: false,
 };

--- a/src/components/Table/features/TableDownload/constants.ts
+++ b/src/components/Table/features/TableDownload/constants.ts
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-table";
 import {
   downloadData,
-  getCanDownload,
+  getCanTableDownload,
   getIsDownloadEnabled,
   onDownload,
 } from "./utils";
@@ -17,7 +17,8 @@ export const TABLE_DOWNLOAD: TableFeature = {
     column: Column<TData, TValue>,
     table: Table<TData>
   ): void => {
-    column.getCanDownload = (): boolean => getCanDownload(column, table);
+    column.getCanTableDownload = (): boolean =>
+      getCanTableDownload(column, table);
   },
   createTable: <T extends RowData>(table: Table<T>): void => {
     table.downloadData = (): void => downloadData(table);

--- a/src/components/Table/features/TableDownload/constants.ts
+++ b/src/components/Table/features/TableDownload/constants.ts
@@ -9,7 +9,7 @@ import {
   downloadData,
   getCanTableDownload,
   getIsDownloadEnabled,
-  onDownload,
+  onTableDownload,
 } from "./utils";
 
 export const TABLE_DOWNLOAD: TableFeature = {
@@ -26,5 +26,5 @@ export const TABLE_DOWNLOAD: TableFeature = {
   },
   getDefaultOptions: <T extends RowData>(): Partial<
     TableOptionsResolved<T>
-  > => ({ enableTableDownload: false, onDownload }),
+  > => ({ enableTableDownload: false, onTableDownload }),
 };

--- a/src/components/Table/features/TableDownload/constants.ts
+++ b/src/components/Table/features/TableDownload/constants.ts
@@ -5,12 +5,7 @@ import {
   TableFeature,
   TableOptionsResolved,
 } from "@tanstack/react-table";
-import {
-  downloadData,
-  getCanTableDownload,
-  getIsDownloadEnabled,
-  onTableDownload,
-} from "./utils";
+import { downloadData, getCanTableDownload, onTableDownload } from "./utils";
 
 export const TABLE_DOWNLOAD: TableFeature = {
   createColumn: <TData extends RowData, TValue>(
@@ -22,7 +17,6 @@ export const TABLE_DOWNLOAD: TableFeature = {
   },
   createTable: <T extends RowData>(table: Table<T>): void => {
     table.downloadData = (): void => downloadData(table);
-    table.getIsDownloadEnabled = (): boolean => getIsDownloadEnabled(table);
   },
   getDefaultOptions: <T extends RowData>(): Partial<
     TableOptionsResolved<T>

--- a/src/components/Table/features/TableDownload/constants.ts
+++ b/src/components/Table/features/TableDownload/constants.ts
@@ -26,5 +26,5 @@ export const TABLE_DOWNLOAD: TableFeature = {
   },
   getDefaultOptions: <T extends RowData>(): Partial<
     TableOptionsResolved<T>
-  > => ({ enableDownload: false, onDownload }),
+  > => ({ enableTableDownload: false, onDownload }),
 };

--- a/src/components/Table/features/TableDownload/onDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/onDownload/utils.ts
@@ -72,5 +72,5 @@ export function getBlob<T extends RowData>(table: Table<T>): Blob | undefined {
 export function getDownloadableColumns<T extends RowData>(
   table: Table<T>
 ): Column<T>[] {
-  return table.getAllColumns().filter((column) => column.getCanDownload());
+  return table.getAllColumns().filter((column) => column.getCanTableDownload());
 }

--- a/src/components/Table/features/TableDownload/types.ts
+++ b/src/components/Table/features/TableDownload/types.ts
@@ -16,5 +16,5 @@ export interface TableDownloadInstance {
 export interface TableDownloadOptions<T extends RowData> {
   downloadFilename?: string;
   enableTableDownload?: boolean;
-  onDownload?: (table: Table<T>) => void;
+  onTableDownload?: (table: Table<T>) => void;
 }

--- a/src/components/Table/features/TableDownload/types.ts
+++ b/src/components/Table/features/TableDownload/types.ts
@@ -1,7 +1,7 @@
 import { RowData, Table } from "@tanstack/react-table";
 
 export interface TableDownloadColumn {
-  getCanDownload: () => boolean;
+  getCanTableDownload: () => boolean;
 }
 
 export interface TableDownloadColumnDef {

--- a/src/components/Table/features/TableDownload/types.ts
+++ b/src/components/Table/features/TableDownload/types.ts
@@ -5,7 +5,7 @@ export interface TableDownloadColumn {
 }
 
 export interface TableDownloadColumnDef {
-  enableDownload?: boolean;
+  enableTableDownload?: boolean;
 }
 
 export interface TableDownloadInstance {
@@ -15,6 +15,6 @@ export interface TableDownloadInstance {
 
 export interface TableDownloadOptions<T extends RowData> {
   downloadFilename?: string;
-  enableDownload?: boolean;
+  enableTableDownload?: boolean;
   onDownload?: (table: Table<T>) => void;
 }

--- a/src/components/Table/features/TableDownload/types.ts
+++ b/src/components/Table/features/TableDownload/types.ts
@@ -10,7 +10,6 @@ export interface TableDownloadColumnDef {
 
 export interface TableDownloadInstance {
   downloadData: () => void;
-  getIsDownloadEnabled: () => boolean;
 }
 
 export interface TableDownloadOptions<T extends RowData> {

--- a/src/components/Table/features/TableDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/utils.ts
@@ -27,23 +27,12 @@ export function getCanTableDownload<T extends RowData, TValue>(
 }
 
 /**
- * Returns true if download is enabled for the table.
- * @param table - Table.
- * @returns True if download is enabled for the table.
- */
-export function getIsDownloadEnabled<T extends RowData>(
-  table: Table<T>
-): boolean {
-  return table.options.enableTableDownload ?? false;
-}
-
-/**
  * Default download function that downloads the table data as a TSV file.
  * @param table - Table.
  */
 export function onTableDownload<T extends RowData>(table: Table<T>): void {
   // Check if download is enabled.
-  if (!getIsDownloadEnabled(table)) return;
+  if (!(table.options.enableTableDownload ?? false)) return;
 
   // Generate the blob.
   const blob = getBlob(table);

--- a/src/components/Table/features/TableDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/utils.ts
@@ -22,7 +22,7 @@ export function getCanTableDownload<T extends RowData, TValue>(
 ): boolean {
   return (
     (column.columnDef.enableTableDownload ?? true) &&
-    (table.options.enableDownload ?? false)
+    (table.options.enableTableDownload ?? false)
   );
 }
 
@@ -34,7 +34,7 @@ export function getCanTableDownload<T extends RowData, TValue>(
 export function getIsDownloadEnabled<T extends RowData>(
   table: Table<T>
 ): boolean {
-  return table.options.enableDownload ?? false;
+  return table.options.enableTableDownload ?? false;
 }
 
 /**

--- a/src/components/Table/features/TableDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/utils.ts
@@ -21,7 +21,7 @@ export function getCanDownload<T extends RowData, TValue>(
   table: Table<T>
 ): boolean {
   return (
-    (column.columnDef.enableDownload ?? true) &&
+    (column.columnDef.enableTableDownload ?? true) &&
     (table.options.enableDownload ?? false)
   );
 }

--- a/src/components/Table/features/TableDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/utils.ts
@@ -7,7 +7,7 @@ import { getBlob } from "./onDownload/utils";
  * @param table - Table.
  */
 export function downloadData<T extends RowData>(table: Table<T>): void {
-  table.options.onDownload?.(table);
+  table.options.onTableDownload?.(table);
 }
 
 /**
@@ -41,7 +41,7 @@ export function getIsDownloadEnabled<T extends RowData>(
  * Default download function that downloads the table data as a TSV file.
  * @param table - Table.
  */
-export function onDownload<T extends RowData>(table: Table<T>): void {
+export function onTableDownload<T extends RowData>(table: Table<T>): void {
   // Check if download is enabled.
   if (!getIsDownloadEnabled(table)) return;
 

--- a/src/components/Table/features/TableDownload/utils.ts
+++ b/src/components/Table/features/TableDownload/utils.ts
@@ -16,7 +16,7 @@ export function downloadData<T extends RowData>(table: Table<T>): void {
  * @param table - Table.
  * @returns True if column can be downloaded.
  */
-export function getCanDownload<T extends RowData, TValue>(
+export function getCanTableDownload<T extends RowData, TValue>(
   column: Column<T, TValue>,
   table: Table<T>
 ): boolean {

--- a/types/data-explorer-ui.d.ts
+++ b/types/data-explorer-ui.d.ts
@@ -250,7 +250,7 @@ declare module "@tanstack/react-table" {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TData and TValue are unused variables.
   interface ColumnDefBase<TData extends RowData, TValue> {
-    enableDownload?: boolean;
+    enableTableDownload?: boolean;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- TData and TValue are unused variables.


### PR DESCRIPTION
Closes #659.

This pull request refactors the table download feature to consistently use the `enableTableDownload` naming convention instead of the previous `enableDownload`, and updates related method and property names for clarity and consistency. The changes affect type definitions, feature options, utility functions, and component logic.

**Refactor to use `enableTableDownload` and related API updates:**

* Renamed all occurrences of `enableDownload` to `enableTableDownload` in type definitions, constants, and column definitions, including in `TableDownloadOptions`, `TableDownloadColumnDef`, and default options. [[1]](diffhunk://#diff-023deee38c25e8733b5da2fb5a7f73d711803b232d75cac6e1f9e05a22a5c431L4-R18) [[2]](diffhunk://#diff-649889f26cec8360ae1e9a323c41f2c889a18d1b4afb9259a49afa7ae4f7f911L6-R8) [[3]](diffhunk://#diff-14ad2e8b0d939a14917151e7999606522411cfc4ce4ff3fc7ca6af43a6fbf1e9L12-R15) [[4]](diffhunk://#diff-14ad2e8b0d939a14917151e7999606522411cfc4ce4ff3fc7ca6af43a6fbf1e9L28-R31) [[5]](diffhunk://#diff-cf88449028813557ca92c66d9a77be8dfdf11ac00326c8bf6455abc9a5f2f0f3L8-R23)
* Renamed methods and properties related to download capability: `getCanDownload` → `getCanTableDownload`, `getIsDownloadEnabled` (removed), `onDownload` → `onTableDownload`, and updated their usage across the codebase. [[1]](diffhunk://#diff-cf88449028813557ca92c66d9a77be8dfdf11ac00326c8bf6455abc9a5f2f0f3L8-R23) [[2]](diffhunk://#diff-72d0b5f7cb079450f73db9d6977ed388cc8238dac79475d699825f0973d7dcf8L75-R75) [[3]](diffhunk://#diff-bca31c7e85140961ffb6a5abab738b40902bba69dd7ac63195e2d98706614b2fL19-R35) [[4]](diffhunk://#diff-bca31c7e85140961ffb6a5abab738b40902bba69dd7ac63195e2d98706614b2fL10-R10) [[5]](diffhunk://#diff-023deee38c25e8733b5da2fb5a7f73d711803b232d75cac6e1f9e05a22a5c431L4-R18)
* Updated the `TableDownload` component and related logic to check `table.options.enableTableDownload` instead of the previous method/property.
* Removed obsolete methods such as `getIsDownloadEnabled` and their references from table feature creation and utility files. [[1]](diffhunk://#diff-cf88449028813557ca92c66d9a77be8dfdf11ac00326c8bf6455abc9a5f2f0f3L8-R23) [[2]](diffhunk://#diff-bca31c7e85140961ffb6a5abab738b40902bba69dd7ac63195e2d98706614b2fL19-R35)
* Updated the default options and feature constants to use the new naming and handler (`enableTableDownload`, `onTableDownload`). [[1]](diffhunk://#diff-cf88449028813557ca92c66d9a77be8dfdf11ac00326c8bf6455abc9a5f2f0f3L8-R23) [[2]](diffhunk://#diff-649889f26cec8360ae1e9a323c41f2c889a18d1b4afb9259a49afa7ae4f7f911L6-R8)

These changes improve code clarity, maintainability, and ensure a consistent API for enabling and handling table downloads.

