### PR TITLE
feat: update row selection component to display disabled state (#663)

### DIFF
--- a/src/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
+++ b/src/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
@@ -2,17 +2,19 @@ import { Checkbox as MCheckbox } from "@mui/material";
 import { CellContext, RowData } from "@tanstack/react-table";
 import React from "react";
 import { CheckedIcon } from "../../../../../common/CustomIcon/components/CheckedIcon/checkedIcon";
+import { UncheckedDisabledIcon } from "../../../../../common/CustomIcon/components/UncheckedDisabledIcon/uncheckedDisabledIcon";
 import { UncheckedIcon } from "../../../../../common/CustomIcon/components/UncheckedIcon/uncheckedIcon";
 
 export const RowSelectionCell = <T extends RowData, TValue = unknown>({
   row,
 }: CellContext<T, TValue>): JSX.Element => {
-  const { getIsSelected, getToggleSelectedHandler } = row;
+  const { getCanSelect, getIsSelected, getToggleSelectedHandler } = row;
   return (
     <MCheckbox
       checked={getIsSelected()}
       checkedIcon={<CheckedIcon />}
-      icon={<UncheckedIcon />}
+      disabled={!getCanSelect()}
+      icon={getCanSelect() ? <UncheckedIcon /> : <UncheckedDisabledIcon />}
       /*
        * Prevents click events from bubbling up to parent components
        * (such as CardActionArea or Accordion) when the checkbox is activated.

--- a/src/components/common/CustomIcon/components/UncheckedDisabledIcon/uncheckedDisabledIcon.tsx
+++ b/src/components/common/CustomIcon/components/UncheckedDisabledIcon/uncheckedDisabledIcon.tsx
@@ -1,0 +1,27 @@
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import React from "react";
+import { PALETTE } from "../../../../../styles/common/constants/palette";
+
+export const UncheckedDisabledIcon = ({
+  fontSize = "xsmall",
+  viewBox = "0 0 18 18",
+  ...props
+}: SvgIconProps): JSX.Element => {
+  return (
+    <SvgIcon fontSize={fontSize} viewBox={viewBox} {...props}>
+      <path
+        d="M4 0.5H14C15.933 0.5 17.5 2.067 17.5 4V14C17.5 15.933 15.933 17.5 14 17.5H4C2.067 17.5 0.5 15.933 0.5 14V4C0.5 2.067 2.067 0.5 4 0.5Z"
+        stroke={PALETTE.SMOKE_MAIN}
+      />
+      <rect
+        x="0.5"
+        y="0.5"
+        width="17"
+        height="17"
+        rx="3.5"
+        fill={PALETTE.SMOKE_LIGHT}
+        stroke={PALETTE.SMOKE_MAIN}
+      />
+    </SvgIcon>
+  );
+};


### PR DESCRIPTION
Closes #663.

This pull request improves the row selection experience in tables by adding a new disabled state icon for unselectable rows and updating the selection cell logic to use it. The key changes are grouped below:

**UI Enhancements for Row Selection:**

* Added a new `UncheckedDisabledIcon` component to visually represent disabled (unselectable) checkboxes, using specific colors from the palette for consistency.
* Updated `RowSelectionCell` to:
  - Use the new `UncheckedDisabledIcon` when a row cannot be selected.
  - Disable the checkbox for unselectable rows by leveraging a new `getCanSelect` property.
  - Ensure the correct icon is shown based on whether the row can be selected or not.

<img width="1826" height="1286" alt="image" src="https://github.com/user-attachments/assets/8077d457-5cde-412f-abb9-09873fdcc109" />
