### PR TITLE
fix: reintstate file download button component (#667)

### DIFF
--- a/src/components/common/Button/components/FileDownloadButton/fileDownloadButton.tsx
+++ b/src/components/common/Button/components/FileDownloadButton/fileDownloadButton.tsx
@@ -1,0 +1,27 @@
+import { Box } from "@mui/material";
+import React, { useEffect, useRef } from "react";
+
+export interface FileDownloadButtonProps {
+  fileName?: string;
+  fileUrl?: string;
+}
+
+export const FileDownloadButton = ({
+  fileName,
+  fileUrl,
+}: FileDownloadButtonProps): JSX.Element => {
+  const downloadRef = useRef<HTMLAnchorElement>(null);
+
+  // Initiates file download when file url request is successful.
+  useEffect(() => {
+    if (downloadRef.current && fileName && fileUrl) {
+      downloadRef.current.setAttribute("href", fileUrl);
+      downloadRef.current.setAttribute("download", fileName);
+      downloadRef.current.click();
+    }
+  }, [fileName, fileUrl]);
+
+  return (
+    <Box component="a" download ref={downloadRef} sx={{ display: "none" }} />
+  );
+};


### PR DESCRIPTION
Closes #667.

This pull request adds a new `FileDownloadButton` component to the codebase, which provides a way to programmatically trigger file downloads in the UI.

New component for file downloads:

* Added the `FileDownloadButton` React component in `src/components/common/Button/components/FileDownloadButton/fileDownloadButton.tsx`, allowing files to be downloaded automatically when the file name and URL are provided. The component uses a hidden anchor tag and the `useEffect` hook to initiate the download.