### PR TITLE
feat: update entity list summary component to optionally display summary label (#679)

### DIFF
--- a/src/components/Index/components/EntityView/components/layout/Summary/summary.tsx
+++ b/src/components/Index/components/EntityView/components/layout/Summary/summary.tsx
@@ -26,12 +26,14 @@ export const Summary = ({
           <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_500}>
             {count}
           </Typography>
-          <Typography
-            color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-            variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
-          >
-            {label}
-          </Typography>
+          {label && (
+            <Typography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400}
+            >
+              {label}
+            </Typography>
+          )}
         </Fragment>
       ))}
     </StyledGrid>


### PR DESCRIPTION
Closes #679.

This pull request makes a small improvement to the `Summary` component by ensuring that the `label` is only rendered if it exists, preventing empty or unnecessary label elements from being displayed.

* Conditional rendering of the `label` in the `Summary` component to avoid rendering empty labels. (`src/components/Index/components/EntityView/components/layout/Summary/summary.tsx`)

<img width="509" height="87" alt="image" src="https://github.com/user-attachments/assets/bb9442d6-62bc-4f06-8844-09edf6eee2dc" />
