### PR TITLE
feat: update column filter adapter to render custom filter values (#694)

### DIFF
--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -1,6 +1,9 @@
 import { Column, RowData, Table } from "@tanstack/react-table";
 import { isRangeCategoryConfig } from "../../../../../../common/categories/config/range/typeGuards";
-import { CategoryConfig } from "../../../../../../common/categories/config/types";
+import {
+  CategoryConfig,
+  SelectCategoryConfig,
+} from "../../../../../../common/categories/config/types";
 import { RangeCategoryView } from "../../../../../../common/categories/views/range/types";
 import { CategoryView } from "../../../../../../common/categories/views/types";
 import {
@@ -10,6 +13,7 @@ import {
 import { FILTER_SORT } from "../../../../../../common/filters/sort/config/types";
 import { sortCategoryValueViews } from "../../../../../../common/filters/sort/models/utils";
 import { CategoryGroup } from "../../../../../../config/entities";
+import { getSelectCategoryValue } from "../../../../../../hooks/useCategoryFilter";
 import { getColumnHeader } from "../../../../../Table/common/utils";
 import { CategoryFilter } from "../../../Filters/filters";
 import { SurfaceProps } from "../../../surfaces/types";
@@ -142,7 +146,7 @@ function mapCategoryFilter<T extends RowData>(
         categoryView = mapColumnToSelectCategoryView(
           column,
           filterSort,
-          categoryConfig
+          categoryConfig as SelectCategoryConfig
         );
       }
 
@@ -198,11 +202,13 @@ function mapColumnToRangeCategoryView<T extends RowData>(
 function mapColumnToSelectCategoryView<T extends RowData>(
   column: Column<T>,
   filterSort: FILTER_SORT,
-  categoryConfig?: CategoryConfig
+  categoryConfig?: SelectCategoryConfig
 ): SelectCategoryView {
   const facetedUniqueValues = column.getFacetedUniqueValues();
   const isDisabled = facetedUniqueValues.size === 0;
-  const values = mapColumnToSelectCategoryValueView(column, filterSort);
+  const values = mapColumnToSelectCategoryValueView(column, filterSort).map(
+    categoryConfig?.mapSelectCategoryValue || getSelectCategoryValue
+  );
   return {
     annotation: undefined,
     enableChartView: false,


### PR DESCRIPTION
Closes #694.

This pull request refines type usage and value mapping for select category filters in the TanStack table filter adapter. The main changes ensure that the code correctly distinguishes between category types and applies the appropriate mapping function for select category values.

**Type safety improvements:**

* Updated the `categoryConfig` parameter in `mapColumnToSelectCategoryView` and related calls to use `SelectCategoryConfig` instead of the more generic `CategoryConfig`, ensuring type correctness for select category filters. [[1]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL145-R149) [[2]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL201-R211)

**Value mapping enhancements:**

* Modified the mapping of select category values to use either the custom `mapSelectCategoryValue` function from `categoryConfig` or the default `getSelectCategoryValue` function, improving flexibility and correctness in how values are displayed. [[1]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR16) [[2]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL201-R211)

**Import organization:**

* Added imports for `SelectCategoryConfig` and `getSelectCategoryValue` to support the above changes and maintain code clarity. [[1]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dL3-R6) [[2]](diffhunk://#diff-5e01db48c15fa896c04b38e531a226b2d5c6b6746545adf8c2eee93a42669a3dR16)