### PR TITLE
fix: update column filter adapter to always show filter values with a zero count (#696)

### DIFF
--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -205,6 +205,16 @@ function mapColumnToSelectCategoryView<T extends RowData>(
   categoryConfig?: SelectCategoryConfig
 ): SelectCategoryView {
   const facetedUniqueValues = column.getFacetedUniqueValues();
+
+  // Selected values for the column.
+  const filterValue = (column.getFilterValue() || []) as unknown[];
+
+  // Update faceted unique values with selected filters that are not in the faceted unique values.
+  for (const value of filterValue) {
+    if (facetedUniqueValues.has(value)) continue;
+    facetedUniqueValues.set(value, 0);
+  }
+
   const isDisabled = facetedUniqueValues.size === 0;
   const values = mapColumnToSelectCategoryValueView(column, filterSort).map(
     categoryConfig?.mapSelectCategoryValue || getSelectCategoryValue
@@ -235,12 +245,6 @@ function mapColumnToSelectCategoryValueView<T extends RowData>(
 
   // Selected values for the column.
   const filterValue = (column.getFilterValue() || []) as unknown[];
-
-  // Update faceted unique values with selected filters that are not in the faceted unique values.
-  for (const value of filterValue) {
-    if (facetedUniqueValues.has(value)) continue;
-    facetedUniqueValues.set(value, 0);
-  }
 
   // Build the select category values.
   const categoryValueViews: SelectCategoryValueView[] = [];


### PR DESCRIPTION
Closes #696.

This pull request updates the filter adapter logic to ensure that selected filter values are always displayed, even if they are not present in the faceted unique values. The change improves the user experience by making sure all selected filters are visible in the UI.

Filter value handling:

* In `utils.ts`, the `mapColumnToSelectCategoryValueView` function now adds any selected filter values that are missing from `facetedUniqueValues`, ensuring they are included in the select category view.