### PR TITLE
feat: create time since component (#703)

### DIFF
--- a/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyElType/keyElType.tsx
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyElType/keyElType.tsx
@@ -1,0 +1,22 @@
+import { Typography, TypographyProps } from "@mui/material";
+import React from "react";
+import { TYPOGRAPHY_PROPS } from "../../../../../../../../styles/common/mui/typography";
+
+export const KeyElType = ({
+  children,
+  color = TYPOGRAPHY_PROPS.COLOR.INK_LIGHT,
+  component = "div",
+  variant = TYPOGRAPHY_PROPS.VARIANT.INHERIT,
+  ...props /* MuiTypographyProps */
+}: TypographyProps): JSX.Element => {
+  return (
+    <Typography
+      color={color}
+      component={component}
+      variant={variant}
+      {...props}
+    >
+      {children}
+    </Typography>
+  );
+};

--- a/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyValueElType/keyValueElType.tsx
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyValueElType/keyValueElType.tsx
@@ -1,0 +1,14 @@
+import { Stack, StackProps } from "@mui/material";
+import React from "react";
+import { KeyValueElTypeProps } from "../../../../../../../../components/common/KeyValuePairs/components/KeyValueElType/keyValueElType";
+
+export const KeyValueElType = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `keyValue` is accepted for compatibility but not used.
+  keyValue,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `keyValueFn` is accepted for compatibility but not used.
+  keyValueFn,
+  ...props /* MuiStackProps */
+}: StackProps &
+  Pick<KeyValueElTypeProps, "keyValue" | "keyValueFn">): JSX.Element => {
+  return <Stack {...props} direction="row" gap={1} useFlexGap />;
+};

--- a/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyValuesElType/keyValuesElType.tsx
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/components/KeyValuesElType/keyValuesElType.tsx
@@ -1,0 +1,8 @@
+import { Stack, StackProps } from "@mui/material";
+import React from "react";
+
+export const KeyValuesElType = ({
+  ...props /* MuiStackProps */
+}: StackProps): JSX.Element => {
+  return <Stack {...props} gap={1} useFlexGap />;
+};

--- a/src/components/Table/components/TableCell/components/KeyValueCell/keyValueCell.tsx
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/keyValueCell.tsx
@@ -1,0 +1,27 @@
+import { CellContext, RowData } from "@tanstack/react-table";
+import React from "react";
+import {
+  KeyValuePairs,
+  KeyValuePairsProps,
+} from "../../../../../../components/common/KeyValuePairs/keyValuePairs";
+import { KeyElType } from "./components/KeyElType/keyElType";
+import { KeyValueElType } from "./components/KeyValueElType/keyValueElType";
+import { KeyValuesElType } from "./components/KeyValuesElType/keyValuesElType";
+
+export const KeyValueCell = <
+  T extends RowData,
+  TValue extends KeyValuePairsProps = KeyValuePairsProps
+>({
+  getValue,
+}: CellContext<T, TValue>): JSX.Element | null => {
+  const props = getValue();
+  if (!props) return null;
+  return (
+    <KeyValuePairs
+      KeyElType={KeyElType}
+      KeyValueElType={KeyValueElType}
+      KeyValuesElType={KeyValuesElType}
+      {...props}
+    />
+  );
+};

--- a/src/components/Table/components/TableCell/components/KeyValueCell/stories/args.ts
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/stories/args.ts
@@ -1,0 +1,12 @@
+import { ComponentProps } from "react";
+import { KeyValueCell } from "../keyValueCell";
+
+export const DEFAULT_ARGS: Partial<ComponentProps<typeof KeyValueCell>> = {
+  getValue: (() => ({
+    keyValuePairs: new Map([
+      ["Updated:", "1 month ago"],
+      ["By:", "tracker-prod@hca.com"],
+      ["Refreshed:", "6 days ago"],
+    ]),
+  })) as ComponentProps<typeof KeyValueCell>["getValue"],
+};

--- a/src/components/Table/components/TableCell/components/KeyValueCell/stories/keyValueCell.stories.tsx
+++ b/src/components/Table/components/TableCell/components/KeyValueCell/stories/keyValueCell.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { KeyValueCell } from "../keyValueCell";
+import { DEFAULT_ARGS } from "./args";
+
+const meta: Meta<typeof KeyValueCell> = {
+  component: KeyValueCell,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: DEFAULT_ARGS,
+};


### PR DESCRIPTION
Closes #703.

This pull request introduces a new `KeyValueCell` component for table cells, designed to display key-value pairs in a flexible and reusable way. The implementation includes supporting subcomponents for rendering keys and values, and provides Storybook stories for easy testing and documentation.

**New KeyValueCell component and supporting subcomponents:**

* Added the `KeyValueCell` component, which renders key-value pairs using the new `KeyElType`, `KeyValueElType`, and `KeyValuesElType` subcomponents. This enables consistent and customizable display of key-value data in table cells.
* Implemented the `KeyElType` subcomponent for rendering individual keys with customizable typography, leveraging MUI's `Typography` and shared style constants.
* Added the `KeyValueElType` and `KeyValuesElType` subcomponents, which use MUI's `Stack` for layout, supporting flexible arrangement of key-value pairs and groups of values. [[1]](diffhunk://#diff-0e29637d0f29114de1ee468968f90a514517383820b6fd399b80a332d86effa6R1-R14) [[2]](diffhunk://#diff-aaa15110e56b7adb400f3b4f0efc0a33dafe68ec938ee94482fad6f96ef11013R1-R8)

**Storybook integration for testing and documentation:**

* Created Storybook stories for the `KeyValueCell` component, including default arguments and example data to facilitate visual testing and documentation. [[1]](diffhunk://#diff-84848543c6d6c879823d8ad33efe3bf9e4581fc61db4320e3c6cf97f84e0a8fcR1-R12) [[2]](diffhunk://#diff-74a6e2c3693a0806994b633f59c24f1806b242ff1759d1c87e79397b8b6c5943R1-R15)

<img width="1377" height="790" alt="image" src="https://github.com/user-attachments/assets/9f9b4e92-ccdf-47f5-a689-b97f55e18134" />
