### PR TITLE
fix: bug/ui issue: horizontal table scroll triggers browser history navigation (#702)

### DIFF
--- a/src/theme/common/components.ts
+++ b/src/theme/common/components.ts
@@ -513,6 +513,9 @@ const MuiCssBaseline: Components["MuiCssBaseline"] = {
       fontFamily: "Roboto Mono, monospace",
       fontSize: 12,
     },
+    html: {
+      overscrollBehaviorX: "contain",
+    },
     img: {
       display: "block",
     },


### PR DESCRIPTION
Closes #702.

This pull request introduces a minor update to the `MuiCssBaseline` component styles to improve horizontal scrolling behavior.

* Added `overscrollBehaviorX: "contain"` to the `html` element styles in `components.ts` to prevent unwanted horizontal scroll chaining.