### PR TITLE
feat: add debug messages to rp (#762)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,7 +57,7 @@ jobs:
           echo "=== Requesting OIDC token for npm ==="
           if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
             if OIDC_RESPONSE=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-              "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm"); then
+              "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" 2>/dev/null); then
               echo "✓ OIDC token request succeeded"
             else
               echo "✗ Failed to get OIDC token"


### PR DESCRIPTION
This pull request adds a debug step to the release workflow to help troubleshoot OIDC token acquisition during the npm publish process. This step provides detailed information about the workflow environment and attempts to fetch and validate the OIDC token, making it easier to diagnose issues with npm provenance publishing.

**Release workflow diagnostics:**

* Added a "Debug OIDC Token" step to `.github/workflows/release-please.yml` that outputs environment details and attempts to request an OIDC token for npm, providing clear messages for success or failure.