### PR TITLE
fix: improve tooltip ux with delay and better placement (#775)

### DIFF
--- a/src/components/Filter/components/FilterLabel/filterLabel.stories.tsx
+++ b/src/components/Filter/components/FilterLabel/filterLabel.stories.tsx
@@ -5,6 +5,7 @@ import { FilterLabel } from "./filterLabel";
 
 const meta = {
   argTypes: {
+    annotation: { control: "object" },
     count: { control: "number" },
     disabled: { control: "boolean" },
     isOpen: { control: "boolean" },
@@ -27,6 +28,11 @@ type Story = StoryObj<typeof meta>;
 
 export const FilterLabelStory: Story = {
   args: {
+    annotation: {
+      description:
+        "This is a description of the filter label that provides additional context to the user.",
+      label: "Label",
+    },
     count: 123,
     disabled: false,
     isOpen: false,

--- a/src/components/Filter/components/FilterLabel/filterLabel.tsx
+++ b/src/components/Filter/components/FilterLabel/filterLabel.tsx
@@ -26,7 +26,12 @@ export const FilterLabel = ({
 }: FilterLabelProps): JSX.Element => {
   const filterLabel = count ? `${label}\xa0(${count})` : label; // When the count is present, a non-breaking space is used to prevent it from being on its own line
   return (
-    <Tooltip description={annotation?.description} title={annotation?.label}>
+    <Tooltip
+      description={annotation?.description}
+      enterDelay={300}
+      placement="right"
+      title={annotation?.label}
+    >
       <StyledButton
         color="inherit"
         disabled={disabled}

--- a/src/components/Filter/components/Filters/stories/constants.ts
+++ b/src/components/Filter/components/Filters/stories/constants.ts
@@ -105,6 +105,11 @@ const PROCESSED = {
  * Biological Sex select category view
  */
 export const BIOLOGICAL_SEX: SelectCategoryView = {
+  annotation: {
+    description:
+      "The biological sex of the donor organism, typically determined by chromosomal composition.",
+    label: "Biological Sex",
+  },
   key: "biologicalSex",
   label: "Biological Sex",
   values: [MALE, FEMALE],
@@ -114,6 +119,11 @@ export const BIOLOGICAL_SEX: SelectCategoryView = {
  * Genus Species select category view
  */
 export const GENUS_SPECIES: SelectCategoryView = {
+  annotation: {
+    description:
+      "The scientific name of the organism from which the sample was derived.",
+    label: "Genus Species",
+  },
   key: "genusSpecies",
   label: "Genus Species",
   values: [HOMO_SAPIENS, MUS_MUSCLES],
@@ -123,7 +133,11 @@ export const GENUS_SPECIES: SelectCategoryView = {
  * Donor Count range category view
  */
 export const DONOR_COUNT: RangeCategoryView = {
-  key: "Donor Count",
+  annotation: {
+    description: "The number of unique donors contributing to the dataset.",
+    label: "Donor Count",
+  },
+  key: "donorCount",
   label: "Donor Count",
   max: 200,
   min: 10,
@@ -135,6 +149,11 @@ export const DONOR_COUNT: RangeCategoryView = {
  * File Format select category view
  */
 export const FILE_FORMAT: SelectCategoryView = {
+  annotation: {
+    description:
+      "The format of the file, such as BAM, CSV, FASTQ, or TSV, indicating how the data is structured.",
+    label: "File Format",
+  },
   key: "fileFormat",
   label: "File Format",
   values: [BAM, CSV, FASTQ, TSV],
@@ -144,6 +163,11 @@ export const FILE_FORMAT: SelectCategoryView = {
  * File Type select category view
  */
 export const FILE_TYPE: SelectCategoryView = {
+  annotation: {
+    description:
+      "The type of file, indicating whether the data is raw or has been processed.",
+    label: "File Type",
+  },
   isDisabled: true,
   key: "fileType",
   label: "File Type",

--- a/src/components/common/Tabs/tabs.tsx
+++ b/src/components/common/Tabs/tabs.tsx
@@ -81,7 +81,11 @@ function buildTabLabel(
   annotation?: DataDictionaryAnnotation,
 ): ReactElement {
   return (
-    <Tooltip description={annotation?.description} title={annotation?.label}>
+    <Tooltip
+      description={annotation?.description}
+      enterDelay={300}
+      title={annotation?.label}
+    >
       <span>{count ? `${label} (${count})` : label}</span>
     </Tooltip>
   );


### PR DESCRIPTION
Closes #775.

This pull request enhances the annotation and tooltip functionality for filter labels and tab labels in the UI. It introduces annotation metadata to several filter constants and improves the user experience by adding tooltip delays and consistent placement.

Enhancements to filter and tab annotations:

* Added `annotation` objects with descriptive metadata (label and description) to filter category constants (`BIOLOGICAL_SEX`, `GENUS_SPECIES`, `DONOR_COUNT`, `FILE_FORMAT`, `FILE_TYPE`) to provide additional context for users. [[1]](diffhunk://#diff-e9256b4d2e2a63cddaa30049693e8d9d52e8ed4caf41ead99240df34d18fd978R108-R112) [[2]](diffhunk://#diff-e9256b4d2e2a63cddaa30049693e8d9d52e8ed4caf41ead99240df34d18fd978R122-R126) [[3]](diffhunk://#diff-e9256b4d2e2a63cddaa30049693e8d9d52e8ed4caf41ead99240df34d18fd978L126-R140) [[4]](diffhunk://#diff-e9256b4d2e2a63cddaa30049693e8d9d52e8ed4caf41ead99240df34d18fd978R152-R156) [[5]](diffhunk://#diff-e9256b4d2e2a63cddaa30049693e8d9d52e8ed4caf41ead99240df34d18fd978R166-R170)
* Updated the `FilterLabel` and tab label components to pass the `annotation` prop to `Tooltip`, and configured tooltips with a 300ms enter delay and consistent placement for improved usability. [[1]](diffhunk://#diff-6c878dfde12c174e0ecb096f61cad37f4b7e62274ba4fea649ff5cd3bf5cfb7eL29-R34) [[2]](diffhunk://#diff-92304baa8d9ec2ef623c29be1f82ede2f7e812274d9c4a17cc1b6ec9a08895ccL84-R88)

Storybook and testing improvements:

* Modified the filter label Storybook story to include an `annotation` object, enabling testing and demonstration of the new annotation functionality. [[1]](diffhunk://#diff-a927e5f0d7a9c682457b8b74c3221cce3d1cc08acd376bd5ef9cca1637dcf87eR8) [[2]](diffhunk://#diff-a927e5f0d7a9c682457b8b74c3221cce3d1cc08acd376bd5ef9cca1637dcf87eR31-R35)

<img width="1429" height="1257" alt="image" src="https://github.com/user-attachments/assets/466e9b8f-919d-4476-ad18-978ad0a9e36e" />
