### PR TITLE
feat: add research/search mode toggle with config and feature flag (#779)

### DIFF
--- a/src/components/Filter/components/SearchAllFilters/searchAllFilters.styles.ts
+++ b/src/components/Filter/components/SearchAllFilters/searchAllFilters.styles.ts
@@ -3,6 +3,8 @@ import { Autocomplete } from "@mui/material";
 
 export const StyledAutocomplete = styled(Autocomplete)`
   &.MuiAutocomplete-root {
+    grid-column: 1 / -1;
+
     .MuiOutlinedInput-root {
       padding: 0 12px;
 

--- a/src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts
+++ b/src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
 import { bpUpMd } from "../../../../../../styles/common/mixins/breakpoints";
 
+/**
+ * Container for sidebar tools, including the mode toggle and filter controls.
+ * @deprecated - This styled component is deprecated and will be removed in a future release.
+ */
 export const SidebarTools = styled.div`
   display: grid;
   gap: 8px 0;

--- a/src/components/common/ToggleButtonGroup/provider/context.ts
+++ b/src/components/common/ToggleButtonGroup/provider/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+import { ToggleButtonGroupContextProps } from "./types";
+
+export const ToggleButtonGroupContext = createContext<
+  ToggleButtonGroupContextProps<unknown>
+>({
+  onChange: undefined,
+  value: null,
+});

--- a/src/components/common/ToggleButtonGroup/provider/hook.ts
+++ b/src/components/common/ToggleButtonGroup/provider/hook.ts
@@ -1,0 +1,16 @@
+import { ToggleButtonGroupProps } from "@mui/material";
+import { useContext } from "react";
+import { ToggleButtonGroupContext } from "./context";
+import { ToggleButtonGroupContextProps } from "./types";
+
+/**
+ * Returns the toggle button group context.
+ * @returns toggle button group context.
+ */
+export const useToggleButtonGroup = <
+  T extends ToggleButtonGroupProps["value"],
+>(): ToggleButtonGroupContextProps<T> => {
+  return useContext(
+    ToggleButtonGroupContext,
+  ) as ToggleButtonGroupContextProps<T>;
+};

--- a/src/components/common/ToggleButtonGroup/provider/provider.tsx
+++ b/src/components/common/ToggleButtonGroup/provider/provider.tsx
@@ -1,0 +1,34 @@
+import { ToggleButtonGroupProps } from "@mui/material";
+import { JSX, MouseEvent, useCallback, useState } from "react";
+import { ToggleButtonGroupContext } from "./context";
+import { ToggleButtonGroupProviderProps } from "./types";
+
+/**
+ * ToggleButtonGroup provider component.
+ * Manages toggle button group state for child components.
+ * @param props - Component props.
+ * @param props.children - Child elements to render.
+ * @param props.initialValue - Initial value for the toggle button group.
+ * @returns ToggleButtonGroup provider component.
+ */
+export function ToggleButtonGroupProvider<
+  T extends ToggleButtonGroupProps["value"],
+>({
+  children,
+  initialValue = null,
+}: ToggleButtonGroupProviderProps<T>): JSX.Element {
+  const [value, setValue] = useState<T | null>(initialValue);
+
+  const onChange = useCallback(
+    (_: MouseEvent<HTMLElement>, value: T) => setValue(value),
+    [],
+  );
+
+  return (
+    <ToggleButtonGroupContext.Provider value={{ onChange, value }}>
+      {typeof children === "function"
+        ? children({ onChange, value })
+        : children}
+    </ToggleButtonGroupContext.Provider>
+  );
+}

--- a/src/components/common/ToggleButtonGroup/provider/types.ts
+++ b/src/components/common/ToggleButtonGroup/provider/types.ts
@@ -1,0 +1,17 @@
+import { ToggleButtonGroupProps } from "@mui/material";
+import { ReactNode } from "react";
+
+export type ToggleButtonGroupContextProps<
+  T extends ToggleButtonGroupProps["value"],
+> = Pick<ToggleButtonGroupProps, "onChange"> & {
+  value: T | null;
+};
+
+export type ToggleButtonGroupProviderProps<
+  T extends ToggleButtonGroupProps["value"],
+> = {
+  children:
+    | ReactNode
+    | ((props: ToggleButtonGroupContextProps<T>) => ReactNode);
+  initialValue?: T | null;
+};

--- a/src/config/entities.ts
+++ b/src/config/entities.ts
@@ -29,6 +29,13 @@ import { FileManifestState } from "../providers/fileManifestState";
 import { SystemStatus, SystemStatusResponse } from "../providers/systemStatus";
 
 /**
+ * AI configuration.
+ */
+export interface AiConfig {
+  enabled: boolean;
+}
+
+/**
  * Interface to define the analytics configuration for a given site.
  */
 export interface AnalyticsConfig {
@@ -364,6 +371,7 @@ interface TrackingConfig {
  * Interface that will hold the whole configuration for a given site.
  */
 export interface SiteConfig {
+  ai?: AiConfig;
   analytics?: AnalyticsConfig;
   appTitle: string;
   authentication?: AuthenticationConfig;

--- a/src/tests/testIds.ts
+++ b/src/tests/testIds.ts
@@ -13,6 +13,7 @@ export const TEST_IDS = {
   FILTER_SORT_MENU: "filter-sort-menu",
   FILTER_TERM: "filter-term",
   SEARCH_ALL_FILTERS: "search-all-filters",
+  SEARCH_CONTROLS: "search-controls",
   SIDEBAR: "sidebar",
   SIDEBAR_DRAWER: "sidebar-drawer",
   TABLE_FIRST_CELL: "table-first-cell",

--- a/src/views/ExploreView/exploreView.tsx
+++ b/src/views/ExploreView/exploreView.tsx
@@ -16,7 +16,6 @@ import { SearchAllFilters } from "../../components/Filter/components/SearchAllFi
 import { SURFACE_TYPE } from "../../components/Filter/components/surfaces/types";
 import { Index as IndexView } from "../../components/Index/index";
 import { SidebarLabel } from "../../components/Layout/components/Sidebar/components/SidebarLabel/sidebarLabel";
-import { SidebarTools } from "../../components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles";
 import { Sidebar } from "../../components/Layout/components/Sidebar/sidebar";
 import { CategoryGroup } from "../../config/entities";
 import { useStateSyncManager } from "../../hooks/stateSyncManager/hook";
@@ -34,6 +33,8 @@ import { useUpdateFilterSort } from "./hooks/UseUpdateFilterSort/hook";
 import { buildStateSyncManagerContext } from "./utils";
 import { ModeProvider } from "./mode/provider/provider";
 import { ToggleButtonGroup } from "./mode/components/ToggleButtonGroup/toggleButtonGroup";
+import { StyledGrid } from "./search/filters/filters.styles";
+import { StyledStack } from "./search/sidebar/sidebar.styles";
 
 export interface ExploreViewProps extends AzulEntitiesStaticResponse {
   className?: string;
@@ -141,30 +142,32 @@ export const ExploreView = (props: ExploreViewProps): JSX.Element => {
         <DrawerProvider>
           {categoryViews && !!categoryViews.length && (
             <Sidebar>
-              <ToggleButtonGroup
-                onChange={modeProps.onChange}
-                value={modeProps.value}
-              />
-              <SidebarTools data-testid={TEST_IDS.FILTER_CONTROLS}>
-                <SidebarLabel label={"Filters"} />
-                <Stack direction="row" gap={4}>
-                  <ClearAllFilters />
-                  <FilterSort
-                    enabled={filterSortEnabled}
-                    filterSort={filterSort}
-                    onFilterSortChange={onFilterSortChange}
-                  />
-                </Stack>
-                <SearchAllFilters
-                  categoryViews={categoryViews}
-                  onFilter={onFilterChange.bind(null, true)}
-                  surfaceType={
-                    mdDown
-                      ? SURFACE_TYPE.POPPER_DRAWER
-                      : SURFACE_TYPE.POPPER_MENU
-                  }
+              <StyledStack data-testid={TEST_IDS.SEARCH_CONTROLS} useFlexGap>
+                <ToggleButtonGroup
+                  onChange={modeProps.onChange}
+                  value={modeProps.value}
                 />
-              </SidebarTools>
+                <StyledGrid data-testid={TEST_IDS.FILTER_CONTROLS}>
+                  <SidebarLabel label={"Filters"} />
+                  <Stack direction="row" gap={4}>
+                    <ClearAllFilters />
+                    <FilterSort
+                      enabled={filterSortEnabled}
+                      filterSort={filterSort}
+                      onFilterSortChange={onFilterSortChange}
+                    />
+                  </Stack>
+                  <SearchAllFilters
+                    categoryViews={categoryViews}
+                    onFilter={onFilterChange.bind(null, true)}
+                    surfaceType={
+                      mdDown
+                        ? SURFACE_TYPE.POPPER_DRAWER
+                        : SURFACE_TYPE.POPPER_MENU
+                    }
+                  />
+                </StyledGrid>
+              </StyledStack>
               <Filters
                 categoryFilters={categoryFilters}
                 onFilter={onFilterChange.bind(null, false)}

--- a/src/views/ExploreView/exploreView.tsx
+++ b/src/views/ExploreView/exploreView.tsx
@@ -32,6 +32,8 @@ import { SELECT_CATEGORY_KEY } from "../../providers/exploreState/constants";
 import { TEST_IDS } from "../../tests/testIds";
 import { useUpdateFilterSort } from "./hooks/UseUpdateFilterSort/hook";
 import { buildStateSyncManagerContext } from "./utils";
+import { ModeProvider } from "./mode/provider/provider";
+import { ToggleButtonGroup } from "./mode/components/ToggleButtonGroup/toggleButtonGroup";
 
 export interface ExploreViewProps extends AzulEntitiesStaticResponse {
   className?: string;
@@ -134,43 +136,53 @@ export const ExploreView = (props: ExploreViewProps): JSX.Element => {
   }, [entityListType, exploreDispatch]);
 
   return (
-    <DrawerProvider>
-      {categoryViews && !!categoryViews.length && (
-        <Sidebar>
-          <SidebarTools data-testid={TEST_IDS.FILTER_CONTROLS}>
-            <SidebarLabel label={"Filters"} />
-            <Stack direction="row" gap={4}>
-              <ClearAllFilters />
-              <FilterSort
-                enabled={filterSortEnabled}
-                filterSort={filterSort}
-                onFilterSortChange={onFilterSortChange}
+    <ModeProvider>
+      {(modeProps) => (
+        <DrawerProvider>
+          {categoryViews && !!categoryViews.length && (
+            <Sidebar>
+              <ToggleButtonGroup
+                onChange={modeProps.onChange}
+                value={modeProps.value}
               />
-            </Stack>
-            <SearchAllFilters
-              categoryViews={categoryViews}
-              onFilter={onFilterChange.bind(null, true)}
-              surfaceType={
-                mdDown ? SURFACE_TYPE.POPPER_DRAWER : SURFACE_TYPE.POPPER_MENU
-              }
-            />
-          </SidebarTools>
-          <Filters
+              <SidebarTools data-testid={TEST_IDS.FILTER_CONTROLS}>
+                <SidebarLabel label={"Filters"} />
+                <Stack direction="row" gap={4}>
+                  <ClearAllFilters />
+                  <FilterSort
+                    enabled={filterSortEnabled}
+                    filterSort={filterSort}
+                    onFilterSortChange={onFilterSortChange}
+                  />
+                </Stack>
+                <SearchAllFilters
+                  categoryViews={categoryViews}
+                  onFilter={onFilterChange.bind(null, true)}
+                  surfaceType={
+                    mdDown
+                      ? SURFACE_TYPE.POPPER_DRAWER
+                      : SURFACE_TYPE.POPPER_MENU
+                  }
+                />
+              </SidebarTools>
+              <Filters
+                categoryFilters={categoryFilters}
+                onFilter={onFilterChange.bind(null, false)}
+                surfaceType={mdDown ? SURFACE_TYPE.DRAWER : SURFACE_TYPE.MENU}
+                trackFilterOpened={trackingConfig?.trackFilterOpened}
+              />
+            </Sidebar>
+          )}
+          <IndexView
+            className={props.className}
             categoryFilters={categoryFilters}
-            onFilter={onFilterChange.bind(null, false)}
-            surfaceType={mdDown ? SURFACE_TYPE.DRAWER : SURFACE_TYPE.MENU}
-            trackFilterOpened={trackingConfig?.trackFilterOpened}
+            entityListType={entityListType}
+            entityName={label}
+            loading={loading}
           />
-        </Sidebar>
+        </DrawerProvider>
       )}
-      <IndexView
-        className={props.className}
-        categoryFilters={categoryFilters}
-        entityListType={entityListType}
-        entityName={label}
-        loading={loading}
-      />
-    </DrawerProvider>
+    </ModeProvider>
   );
 };
 

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/constants.ts
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/constants.ts
@@ -9,6 +9,7 @@ export const TOGGLE_BUTTON_GROUP_PROPS: ToggleButtonGroupProps = {
 export const TOGGLE_BUTTONS: (Omit<ToggleButtonOwnProps, "value"> & {
   value: MODE;
 })[] = [
+  // `disabled` and `selected` are temporary until we have the mode context fully implemented and can set the value based on that context.
   { children: "Research", disabled: true, value: MODE.RESEARCH },
-  { children: "Search", value: MODE.SEARCH },
+  { children: "Search", selected: true, value: MODE.SEARCH },
 ];

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/constants.ts
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/constants.ts
@@ -1,0 +1,14 @@
+import { ToggleButtonOwnProps, ToggleButtonGroupProps } from "@mui/material";
+import { MODE } from "../../types";
+
+export const TOGGLE_BUTTON_GROUP_PROPS: ToggleButtonGroupProps = {
+  exclusive: true,
+  fullWidth: true,
+};
+
+export const TOGGLE_BUTTONS: (Omit<ToggleButtonOwnProps, "value"> & {
+  value: MODE;
+})[] = [
+  { children: "Research", disabled: true, value: MODE.RESEARCH },
+  { children: "Search", value: MODE.SEARCH },
+];

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/stories/toggleButtonGroup.stories.tsx
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/stories/toggleButtonGroup.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ToggleButtonGroup } from "../toggleButtonGroup";
+import { MODE } from "../../../types";
+import { fn } from "storybook/test";
+
+const meta: Meta<typeof ToggleButtonGroup> = {
+  component: ToggleButtonGroup,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const DEFAULT: Story = {
+  args: {
+    onChange: fn(),
+    value: MODE.SEARCH,
+  },
+};

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.styles.ts
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.styles.ts
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import { ToggleButtonGroup } from "@mui/material";
+import { PALETTE } from "../../../../../styles/common/constants/palette";
+
+export const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
+  .MuiToggleButton-root {
+    padding: 6px 16px;
+    text-transform: none;
+
+    &.Mui-disabled {
+      color: ${PALETTE.INK_LIGHT};
+    }
+  }
+`;

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -1,0 +1,22 @@
+import { ToggleButton, ToggleButtonGroupProps } from "@mui/material";
+import { JSX } from "react";
+import { TOGGLE_BUTTON_GROUP_PROPS, TOGGLE_BUTTONS } from "./constants";
+import { StyledToggleButtonGroup } from "./toggleButtonGroup.styles";
+
+export const ToggleButtonGroup = ({
+  className,
+  ...props /* ToggleButtonGroupProps */
+}: ToggleButtonGroupProps): JSX.Element | null => {
+  if (!props.onChange) return null;
+  return (
+    <StyledToggleButtonGroup
+      className={className}
+      {...TOGGLE_BUTTON_GROUP_PROPS}
+      {...props}
+    >
+      {TOGGLE_BUTTONS.map((tButtonProps) => (
+        <ToggleButton key={tButtonProps.value} {...tButtonProps} />
+      ))}
+    </StyledToggleButtonGroup>
+  );
+};

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -3,6 +3,13 @@ import { JSX } from "react";
 import { TOGGLE_BUTTON_GROUP_PROPS, TOGGLE_BUTTONS } from "./constants";
 import { StyledToggleButtonGroup } from "./toggleButtonGroup.styles";
 
+/**
+ * ToggleButtonGroup component for ExploreView. Renders a group of toggle buttons based on the provided props.
+ * Switches between "Search" mode for filter-driven exploration and "Research" mode for AI-assisted discovery.
+ * @param props - MUI toggle button group props.
+ * @param props.className - Optional class name.
+ * @returns Rendered component or null if onChange prop is not provided.
+ */
 export const ToggleButtonGroup = ({
   className,
   ...props /* ToggleButtonGroupProps */

--- a/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -6,14 +6,14 @@ import { StyledToggleButtonGroup } from "./toggleButtonGroup.styles";
 /**
  * ToggleButtonGroup component for ExploreView. Renders a group of toggle buttons based on the provided props.
  * Switches between "Search" mode for filter-driven exploration and "Research" mode for AI-assisted discovery.
- * @param props - MUI toggle button group props.
- * @param props.className - Optional class name.
+ * @param props - Component props.
+ * @param props.className - Class name.
  * @returns Rendered component or null if onChange prop is not provided.
  */
 export const ToggleButtonGroup = ({
   className,
   ...props /* ToggleButtonGroupProps */
-}: ToggleButtonGroupProps): JSX.Element | null => {
+}: Omit<ToggleButtonGroupProps, "children">): JSX.Element | null => {
   if (!props.onChange) return null;
   return (
     <StyledToggleButtonGroup

--- a/src/views/ExploreView/mode/constants.ts
+++ b/src/views/ExploreView/mode/constants.ts
@@ -1,0 +1,3 @@
+export const FEATURE_FLAG = {
+  CHAT: "chat",
+} as const;

--- a/src/views/ExploreView/mode/provider/context.ts
+++ b/src/views/ExploreView/mode/provider/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+import { ModeContextProps } from "./types";
+
+export const ModeContext = createContext<ModeContextProps>({});

--- a/src/views/ExploreView/mode/provider/hook.ts
+++ b/src/views/ExploreView/mode/provider/hook.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { ModeContext } from "./context";
+import { ModeContextProps } from "./types";
+
+/**
+ * Returns the mode context.
+ * @returns Mode context with value and onChange, or empty object if feature disabled.
+ */
+export const useMode = (): ModeContextProps => {
+  return useContext(ModeContext);
+};

--- a/src/views/ExploreView/mode/provider/provider.tsx
+++ b/src/views/ExploreView/mode/provider/provider.tsx
@@ -1,0 +1,34 @@
+import { JSX } from "react";
+import { ToggleButtonGroupProvider } from "../../../../components/common/ToggleButtonGroup/provider/provider";
+import { useConfig } from "../../../../hooks/useConfig";
+import { useFeatureFlag } from "../../../../hooks/useFeatureFlag/useFeatureFlag";
+import { FEATURE_FLAG } from "../constants";
+import { MODE } from "../types";
+import { ModeContext } from "./context";
+import { ModeProviderProps } from "./types";
+
+/**
+ * Mode provider component "search" or "research" i.e. self-directed search vs. chat-based search.
+ * Either mode is available based on the "chat" feature flag, or by configuration.
+ * Wraps children with mode context based on whether the feature is enabled or not.
+ * @param props - Component props.
+ * @param props.children - Children.
+ * @returns Mode provider component.
+ */
+export function ModeProvider({ children }: ModeProviderProps): JSX.Element {
+  const flagEnabled = useFeatureFlag(FEATURE_FLAG.CHAT);
+  const { config } = useConfig();
+  const { ai } = config;
+  const enabled = flagEnabled || ai?.enabled;
+  return (
+    <ToggleButtonGroupProvider<MODE> initialValue={MODE.SEARCH}>
+      {(props) => (
+        <ModeContext.Provider value={enabled ? props : {}}>
+          {typeof children === "function"
+            ? children(enabled ? props : {})
+            : children}
+        </ModeContext.Provider>
+      )}
+    </ToggleButtonGroupProvider>
+  );
+}

--- a/src/views/ExploreView/mode/provider/types.ts
+++ b/src/views/ExploreView/mode/provider/types.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+import { ToggleButtonGroupContextProps } from "../../../../components/common/ToggleButtonGroup/provider/types";
+import { MODE } from "../types";
+
+export type ModeContextProps = Partial<ToggleButtonGroupContextProps<MODE>>;
+
+export type ModeProviderProps = {
+  children: ReactNode | ((props: ModeContextProps) => ReactNode);
+};

--- a/src/views/ExploreView/mode/types.ts
+++ b/src/views/ExploreView/mode/types.ts
@@ -1,0 +1,4 @@
+export enum MODE {
+  RESEARCH = "RESEARCH",
+  SEARCH = "SEARCH",
+}

--- a/src/views/ExploreView/search/filters/filters.styles.ts
+++ b/src/views/ExploreView/search/filters/filters.styles.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const StyledGrid = styled.div`
+  display: grid;
+  gap: 8px 16px;
+  grid-template-columns: 1fr auto;
+`;

--- a/src/views/ExploreView/search/sidebar/sidebar.styles.ts
+++ b/src/views/ExploreView/search/sidebar/sidebar.styles.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { Stack } from "@mui/material";
+import { bpUpMd } from "../../../../styles/common/mixins/breakpoints";
+
+export const StyledStack = styled(Stack)`
+  gap: 16px 0;
+  margin: 8px 0;
+  padding: 0 16px;
+
+  ${bpUpMd} {
+    padding: 8px 16px;
+  }
+`;

--- a/tests/modeProvider.test.tsx
+++ b/tests/modeProvider.test.tsx
@@ -1,0 +1,188 @@
+import { jest } from "@jest/globals";
+import { act, render, screen } from "@testing-library/react";
+import React, { JSX } from "react";
+import { MODE } from "../src/views/ExploreView/mode/types";
+
+jest.unstable_mockModule("../src/hooks/useFeatureFlag/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/hooks/useConfig", () => ({
+  useConfig: jest.fn(),
+}));
+
+const { useFeatureFlag } =
+  await import("../src/hooks/useFeatureFlag/useFeatureFlag");
+const { useConfig } = await import("../src/hooks/useConfig");
+const { ModeProvider } =
+  await import("../src/views/ExploreView/mode/provider/provider");
+const { useMode } = await import("../src/views/ExploreView/mode/provider/hook");
+
+const TEST_ID_VALUE = "value";
+const TEST_ID_BUTTON = "button";
+const TEST_ID_HAS_ONCHANGE = "has-onchange";
+
+/**
+ * Test component that consumes the mode context via hook.
+ * @returns Test component.
+ */
+function TestConsumer(): JSX.Element {
+  const { onChange, value } = useMode();
+  return (
+    <div>
+      <span data-testid={TEST_ID_VALUE}>{value ?? "undefined"}</span>
+      <span data-testid={TEST_ID_HAS_ONCHANGE}>
+        {onChange ? "true" : "false"}
+      </span>
+      <button
+        data-testid={TEST_ID_BUTTON}
+        onClick={(e) =>
+          onChange?.(
+            e as unknown as React.MouseEvent<HTMLElement>,
+            MODE.RESEARCH,
+          )
+        }
+      >
+        Change
+      </button>
+    </div>
+  );
+}
+
+describe("ModeProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFeatureFlag as jest.Mock).mockReturnValue(false);
+    (useConfig as jest.Mock).mockReturnValue({
+      config: {},
+    });
+  });
+
+  it("should render children", () => {
+    render(
+      <ModeProvider>
+        <div data-testid="child">child component</div>
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId("child")).toBeTruthy();
+  });
+
+  it("should provide empty context when feature flag is disabled and config.ai is undefined", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(false);
+    (useConfig as jest.Mock).mockReturnValue({
+      config: {},
+    });
+
+    render(
+      <ModeProvider>
+        <TestConsumer />
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe("undefined");
+    expect(screen.getByTestId(TEST_ID_HAS_ONCHANGE).textContent).toBe("false");
+  });
+
+  it("should provide context with SEARCH as default when feature flag is enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(true);
+
+    render(
+      <ModeProvider>
+        <TestConsumer />
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.SEARCH);
+    expect(screen.getByTestId(TEST_ID_HAS_ONCHANGE).textContent).toBe("true");
+  });
+
+  it("should provide context when config.ai.enabled is true", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(false);
+    (useConfig as jest.Mock).mockReturnValue({
+      config: {
+        ai: {
+          enabled: true,
+        },
+      },
+    });
+
+    render(
+      <ModeProvider>
+        <TestConsumer />
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.SEARCH);
+    expect(screen.getByTestId(TEST_ID_HAS_ONCHANGE).textContent).toBe("true");
+  });
+
+  it("should provide context when either flag or config is enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(true);
+    (useConfig as jest.Mock).mockReturnValue({
+      config: {
+        ai: {
+          enabled: false,
+        },
+      },
+    });
+
+    render(
+      <ModeProvider>
+        <TestConsumer />
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.SEARCH);
+    expect(screen.getByTestId(TEST_ID_HAS_ONCHANGE).textContent).toBe("true");
+  });
+
+  it("should update value on onChange when enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(true);
+
+    render(
+      <ModeProvider>
+        <TestConsumer />
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.SEARCH);
+
+    act(() => {
+      screen.getByTestId(TEST_ID_BUTTON).click();
+    });
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.RESEARCH);
+  });
+
+  it("should pass props to render function children when enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(true);
+
+    render(
+      <ModeProvider>
+        {({ value }) => (
+          <span data-testid={TEST_ID_VALUE}>{value ?? "undefined"}</span>
+        )}
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(MODE.SEARCH);
+  });
+
+  it("should pass empty object to render function children when disabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(false);
+    (useConfig as jest.Mock).mockReturnValue({
+      config: {},
+    });
+
+    render(
+      <ModeProvider>
+        {({ value }) => (
+          <span data-testid={TEST_ID_VALUE}>{value ?? "undefined"}</span>
+        )}
+      </ModeProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe("undefined");
+  });
+});

--- a/tests/toggleButtonGroupProvider.test.tsx
+++ b/tests/toggleButtonGroupProvider.test.tsx
@@ -1,0 +1,125 @@
+import { act, render, screen } from "@testing-library/react";
+import React, { JSX } from "react";
+import { ToggleButtonGroupProvider } from "../src/components/common/ToggleButtonGroup/provider/provider";
+import { useToggleButtonGroup } from "../src/components/common/ToggleButtonGroup/provider/hook";
+
+enum TEST_VALUE {
+  OPTION_A = "OPTION_A",
+  OPTION_B = "OPTION_B",
+}
+
+const TEST_ID_VALUE = "value";
+const TEST_ID_BUTTON = "button";
+
+/**
+ * Test component that consumes the toggle button group context via hook.
+ * @returns Test component.
+ */
+function TestConsumer(): JSX.Element {
+  const { onChange, value } = useToggleButtonGroup<TEST_VALUE>();
+  return (
+    <div>
+      <span data-testid={TEST_ID_VALUE}>{value ?? "null"}</span>
+      <button
+        data-testid={TEST_ID_BUTTON}
+        onClick={(e) =>
+          onChange?.(
+            e as unknown as React.MouseEvent<HTMLElement>,
+            TEST_VALUE.OPTION_B,
+          )
+        }
+      >
+        Change
+      </button>
+    </div>
+  );
+}
+
+describe("ToggleButtonGroupProvider", () => {
+  it("should render children", () => {
+    render(
+      <ToggleButtonGroupProvider>
+        <div data-testid="child">child component</div>
+      </ToggleButtonGroupProvider>,
+    );
+
+    expect(screen.getByTestId("child")).toBeTruthy();
+  });
+
+  it("should set initial value to null by default", () => {
+    render(
+      <ToggleButtonGroupProvider>
+        <TestConsumer />
+      </ToggleButtonGroupProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe("null");
+  });
+
+  it("should set initial value when provided", () => {
+    render(
+      <ToggleButtonGroupProvider<TEST_VALUE> initialValue={TEST_VALUE.OPTION_A}>
+        <TestConsumer />
+      </ToggleButtonGroupProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(
+      TEST_VALUE.OPTION_A,
+    );
+  });
+
+  it("should update value on onChange", () => {
+    render(
+      <ToggleButtonGroupProvider<TEST_VALUE> initialValue={TEST_VALUE.OPTION_A}>
+        <TestConsumer />
+      </ToggleButtonGroupProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(
+      TEST_VALUE.OPTION_A,
+    );
+
+    act(() => {
+      screen.getByTestId(TEST_ID_BUTTON).click();
+    });
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(
+      TEST_VALUE.OPTION_B,
+    );
+  });
+
+  it("should pass props to render function children", () => {
+    render(
+      <ToggleButtonGroupProvider<TEST_VALUE> initialValue={TEST_VALUE.OPTION_A}>
+        {({ onChange, value }) => (
+          <div>
+            <span data-testid={TEST_ID_VALUE}>{value}</span>
+            <button
+              data-testid={TEST_ID_BUTTON}
+              onClick={(e) =>
+                onChange?.(
+                  e as unknown as React.MouseEvent<HTMLElement>,
+                  TEST_VALUE.OPTION_B,
+                )
+              }
+            >
+              Change
+            </button>
+          </div>
+        )}
+      </ToggleButtonGroupProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(
+      TEST_VALUE.OPTION_A,
+    );
+
+    act(() => {
+      screen.getByTestId(TEST_ID_BUTTON).click();
+    });
+
+    expect(screen.getByTestId(TEST_ID_VALUE).textContent).toBe(
+      TEST_VALUE.OPTION_B,
+    );
+  });
+});


### PR DESCRIPTION
Closes #779.

This pull request introduces a new mode selection feature ("search" vs. "research") for the Explore view, controlled by a feature flag or configuration. It adds a context-based provider for managing the mode, a toggle button group UI for switching modes, and updates the Explore view layout to accommodate these changes. Additionally, it includes some minor style and test ID updates, and deprecates an old sidebar tools component.

**Mode selection and management:**

* Added a `ModeProvider` component that supplies mode context ("search" or "research") based on the "chat" feature flag or AI configuration, using a `ToggleButtonGroupProvider` for state management. (`src/views/ExploreView/mode/provider/provider.tsx`, `src/views/ExploreView/mode/provider/context.ts`, `src/views/ExploreView/mode/provider/types.ts`, `src/views/ExploreView/mode/provider/hook.ts`, `src/views/ExploreView/mode/types.ts`, `src/views/ExploreView/mode/constants.ts`, `src/config/entities.ts`, `src/config/entities.ts`) [[1]](diffhunk://#diff-f7d1fa6e20022787fce21d98c6c46d8b9c7e034faf63b1b7fce192987b14ec5dR1-R34) [[2]](diffhunk://#diff-b29121cf44f313e2ed81f2b89947b52a7505a63a8a3ebee9a6fa675b6bae7670R1-R4) [[3]](diffhunk://#diff-29fd5833a3156b489bb85ec1532e26c51ed2bc79efc514c7dd8a638337ddd713R1-R9) [[4]](diffhunk://#diff-05850629f3c4c402f6e23bf84f5d13499eb09f59d15aa41fe170580d095d3a1eR1-R11) [[5]](diffhunk://#diff-71061176222d7d11cbd04b8a08c86a7042fb995f99e9ec6cf6235a13ff9b8ce5R1-R4) [[6]](diffhunk://#diff-66168756692286cbcea883c64480f4282dd1f244d60766c2833a51b28b9605ecR1-R3) [[7]](diffhunk://#diff-e0aec6646bd3a2614a8c84b38aecb148d5a4fedaa52afc81c9bb394aa18f28aaR31-R37) [[8]](diffhunk://#diff-e0aec6646bd3a2614a8c84b38aecb148d5a4fedaa52afc81c9bb394aa18f28aaR374)
* Integrated the new `ModeProvider` and `ToggleButtonGroup` into the Explore view, updating the sidebar layout and replacing the deprecated `SidebarTools` component. (`src/views/ExploreView/exploreView.tsx`, `src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts`) [[1]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dL19) [[2]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dR34-R37) [[3]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dR140-R150) [[4]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dL154-R170) [[5]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dR187-R188) [[6]](diffhunk://#diff-61109e652e1902ff6621ac1438eee32571a2256842a9d1f7cdbfb0ed2979c11dR4-R7)

**Toggle button group implementation:**

* Added a generic, context-based toggle button group provider and hook for managing group state, along with supporting types. (`src/components/common/ToggleButtonGroup/provider/context.ts`, `src/components/common/ToggleButtonGroup/provider/hook.ts`, `src/components/common/ToggleButtonGroup/provider/provider.tsx`, `src/components/common/ToggleButtonGroup/provider/types.ts`) [[1]](diffhunk://#diff-a609efd816c567df23312f956f91c638052090d7b9d12fc9b32a2bc4c34b7dc6R1-R9) [[2]](diffhunk://#diff-9bd56f6989521096c1b98cf47989ddc5dc0cba88bdb81b29a474821938da4107R1-R16) [[3]](diffhunk://#diff-f5eaf76b43e68b7aa8359a0f56973540b6492b4b3a81c7392ab5cfaa1a90b042R1-R34) [[4]](diffhunk://#diff-4b2354320854d2a3cf1f20954b3cb276592bb380a5a3631e9e4b0cac56767112R1-R17)
* Implemented the `ToggleButtonGroup` UI component with storybook stories and custom styles for mode selection. (`src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.tsx`, `src/views/ExploreView/mode/components/ToggleButtonGroup/constants.ts`, `src/views/ExploreView/mode/components/ToggleButtonGroup/toggleButtonGroup.styles.ts`, `src/views/ExploreView/mode/components/ToggleButtonGroup/stories/toggleButtonGroup.stories.tsx`) [[1]](diffhunk://#diff-127152aa0992a3a29aa6339ae0625fdb9f8e5ba1245963a6abe8074f1f455c5aR1-R22) [[2]](diffhunk://#diff-9c1701a57b4cdcc47b0953755eb79121deb1d781921b654c95da7a93922838beR1-R15) [[3]](diffhunk://#diff-f25792c70cea7181c5da2d821e3a8f08fdf049ba39fc6f3d4819b99eefc674bfR1-R14) [[4]](diffhunk://#diff-97db675dc4d3a2ba96a42147f6c853be01000ff011bb0b868c568fdd1eed16ddR1-R19)

**Layout and style adjustments:**

* Updated layout and styles for the Explore view's sidebar and filter controls to use new styled components and grid layouts. (`src/views/ExploreView/search/filters/filters.styles.ts`, `src/views/ExploreView/search/sidebar/sidebar.styles.ts`, `src/components/Filter/components/SearchAllFilters/searchAllFilters.styles.ts`) [[1]](diffhunk://#diff-2717185ccdb593e1bf8538606fcce6ea142686ede93c8ead0254243cbf63bfb1R1-R7) [[2]](diffhunk://#diff-08d1cd5bc3823fd81e518e1db5b66268df22589cee5a3d0f409a4562c0cc6c0dR34-R37) [[3]](diffhunk://#diff-3d127d040a7fa88532e657b2ae95c57dd580ec406c7534d1a8050980454392aeR6-R7)

**Other minor changes:**

* Added new test IDs for search controls. (`src/tests/testIds.ts`)
* Deprecated the old `SidebarTools` styled component. (`src/components/Layout/components/Sidebar/components/SidebarTools/sidebarTools.styles.ts`)

<img width="1662" height="1254" alt="image" src="https://github.com/user-attachments/assets/ed69df35-3fa6-477b-a368-118c1e756f18" />
