### PR TITLE
feat: add href to selected toggle buttons for navigation

### DIFF
--- a/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -7,9 +7,8 @@ import { StyledToggleButtonGroup } from "./toggleButtonGroup.styles";
 import { Beta } from "../../../../../../components/common/Chip/components/Beta/beta";
 
 /**
- * ToggleButtonGroup component for navigating to ResearchView.
- * Only navigates to ResearchView when the "Research" button is clicked, otherwise remains on ExploreView.
- * @returns ToggleButtonGroup JSX element.
+ * ToggleButtonGroup component for navigating between ExploreView and ResearchView.
+ * @returns ToggleButtonGroup JSX element, or null if routes are not configured.
  */
 export const ToggleButtonGroup = (): JSX.Element | null => {
   const { routes } = useAiRoutes() || {};

--- a/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -22,7 +22,12 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
         <ToggleButton component={Link} href={routes.research} value="research">
           Research <Beta />
         </ToggleButton>
-        <ToggleButton selected value="search">
+        <ToggleButton
+          component={Link}
+          href={routes.search}
+          selected
+          value="search"
+        >
           Search
         </ToggleButton>
       </StyledToggleButtonGroup>

--- a/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -18,7 +18,12 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
   return (
     <StyledBox>
       <StyledToggleButtonGroup exclusive>
-        <ToggleButton selected value="research">
+        <ToggleButton
+          component={Link}
+          href={routes.research}
+          selected
+          value="research"
+        >
           Research <Beta />
         </ToggleButton>
         <ToggleButton component={Link} href={routes.search} value="search">

--- a/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -6,9 +6,8 @@ import { useAiRoutes } from "../../../../../hooks/ai/useAiRoutes/hook";
 import { Beta } from "../../../../../components/common/Chip/components/Beta/beta";
 
 /**
- * ToggleButtonGroup component for navigating to ExploreView.
- * Only navigates to ExploreView when the "Search" button is clicked, otherwise remains on ResearchView.
- * @returns ToggleButtonGroup JSX element.
+ * ToggleButtonGroup component for navigating between ResearchView and ExploreView.
+ * @returns ToggleButtonGroup JSX element, or null if routes are not configured.
  */
 export const ToggleButtonGroup = (): JSX.Element | null => {
   const { routes } = useAiRoutes() || {};


### PR DESCRIPTION
## Summary
- Adds `component={Link}` and `href` to the selected toggle buttons in both the Research and Explore views
- Enables navigation back to the research/search datasets page when a user is on a detail page (e.g., `/research/datasets/[studyId]`)

Closes #804

## Test plan
- [x] Navigate to a study detail page (`/research/datasets/[studyId]`), click "Research" toggle — should navigate back to `/research/datasets`
- [x] Verify selected state styling is preserved on both toggle buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)