### PR TITLE
fix: use instant scroll on mount for messages panel

### DIFF
--- a/src/views/ResearchView/assistant/components/Messages/hooks/UseScroll/hook.ts
+++ b/src/views/ResearchView/assistant/components/Messages/hooks/UseScroll/hook.ts
@@ -1,20 +1,23 @@
 import { DependencyList, RefObject, useEffect, useRef } from "react";
 
 /**
- * Provides a ref that auto-scrolls to the bottom when dependencies change.
+ * Provides a ref that scrolls to the bottom when dependencies change.
+ * Uses instant scroll on mount and smooth scroll on subsequent updates.
  * @param deps - Dependency list that triggers scroll on change.
  * @returns A ref to attach to the scrollable container.
  */
 export function useScroll(
   deps: DependencyList,
 ): RefObject<HTMLDivElement | null> {
+  const behaviorRef = useRef<ScrollBehavior>("instant");
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     ref.current?.scrollTo({
-      behavior: "smooth",
+      behavior: behaviorRef.current,
       top: ref.current.scrollHeight,
     });
+    behaviorRef.current = "smooth";
     // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are passed in as an argument
   }, deps);
 


### PR DESCRIPTION
## Summary
- Use instant scroll on mount to avoid distracting smooth scroll when navigating between research pages
- Subsequent scrolls (e.g. new messages) remain smooth

Closes #806

## Test plan
- [x] Navigate between `/research/datasets` and `/research/datasets/[studyId]` — no visible scroll animation
- [x] Submit a query while scrolled up — smooth scroll to new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)