### PR TITLE
feat: render the research toggle button after the search toggle (#809)

### DIFF
--- a/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -18,9 +18,6 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
   return (
     <StyledBox>
       <StyledToggleButtonGroup exclusive>
-        <ToggleButton component={Link} href={routes.research} value="research">
-          Research <Beta />
-        </ToggleButton>
         <ToggleButton
           component={Link}
           href={routes.search}
@@ -28,6 +25,9 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
           value="search"
         >
           Search
+        </ToggleButton>
+        <ToggleButton component={Link} href={routes.research} value="research">
+          Research <Beta />
         </ToggleButton>
       </StyledToggleButtonGroup>
     </StyledBox>

--- a/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -17,6 +17,9 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
   return (
     <StyledBox>
       <StyledToggleButtonGroup exclusive>
+        <ToggleButton component={Link} href={routes.search} value="search">
+          Search
+        </ToggleButton>
         <ToggleButton
           component={Link}
           href={routes.research}
@@ -24,9 +27,6 @@ export const ToggleButtonGroup = (): JSX.Element | null => {
           value="research"
         >
           Research <Beta />
-        </ToggleButton>
-        <ToggleButton component={Link} href={routes.search} value="search">
-          Search
         </ToggleButton>
       </StyledToggleButtonGroup>
     </StyledBox>


### PR DESCRIPTION
Closes #809.

This pull request updates the order of the "Search" and "Research" toggle buttons in the `ToggleButtonGroup` components for both the Explore and Research views. The main goal is to ensure consistency in the button order across these views.

**UI Consistency Updates:**

* In `src/views/ExploreView/entityList/filters/components/ToggleButtonGroup/toggleButtonGroup.tsx`, the "Research" button has been moved after the "Search" button to match the intended order. [[1]](diffhunk://#diff-5b791e1ab41e6b436bce8635bc550a787217519eb2ba050b340da5d3907b5db5L21-L23) [[2]](diffhunk://#diff-5b791e1ab41e6b436bce8635bc550a787217519eb2ba050b340da5d3907b5db5R29-R31)
* In `src/views/ResearchView/assistant/components/ToggleButtonGroup/toggleButtonGroup.tsx`, the "Search" button has been moved before the "Research" button, also ensuring the order is consistent with the Explore view. [[1]](diffhunk://#diff-db9de474cf05997decc93618dd64658d2d856ed2380311f78a27925998c569e4R20-R22) [[2]](diffhunk://#diff-db9de474cf05997decc93618dd64658d2d856ed2380311f78a27925998c569e4L28-L30)

<img width="2260" height="1031" alt="image" src="https://github.com/user-attachments/assets/d67c7ed2-c491-4136-9f22-7358a5882802" />
