### PR TITLE
fix: update metadata download to use azul_url

### DIFF
--- a/src/hooks/useFileManifest/useFileManifestSpreadsheet.ts
+++ b/src/hooks/useFileManifest/useFileManifestSpreadsheet.ts
@@ -105,6 +105,6 @@ function getManifestSpreadsheet(
 
   return {
     fileName: file.files[0]?.name,
-    fileUrl: buildFetchFileUrl(file.files[0]?.url),
+    fileUrl: buildFetchFileUrl(file.files[0]?.azul_url),
   };
 }


### PR DESCRIPTION
## Ticket
Closes #816

## Summary
- Update `useFileManifestSpreadsheet` hook to use `azul_url` instead of `url` when building file download URLs

The Azul API now returns `azul_url` instead of `url` for file objects. This change aligns findable-ui with the API response format, fixing the "metadata is not available" issue on project pages.

## Test plan
- [x] Verify project metadata downloads work in HCA Data Browser
- [x] Confirm the metadata spreadsheet link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1454" height="1290" alt="image" src="https://github.com/user-attachments/assets/c5433430-6395-4336-a8ef-658cd4c8c902" />
