### PR TITLE
feat: migrate NIH account link check to ECM API #819

### DIFF
--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
@@ -19,7 +19,7 @@ export const ConnectTerraToNIHAccount = ({
 }: ConnectTerraToNIHAccountProps): JSX.Element | null => {
   const onGotoTutorial = (): void => {
     window.open(
-      "https://support.terra.bio/hc/en-us/articles/19124069598235-Access-controlled-data-files-by-linking-your-NIH-account-in-Terra",
+      "https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data-Launching-3-25-26",
       ANCHOR_TARGET.BLANK,
       REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
     );

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/NIHAccountExpiryWarning/nihAccountExpiryWarning.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/NIHAccountExpiryWarning/nihAccountExpiryWarning.tsx
@@ -10,7 +10,7 @@ import { Link } from "../../../../../../../Links/components/Link/link";
 
 export const NIHAccountExpiryWarning = (): JSX.Element | null => {
   const expiryStatus = useAuthenticationNIHExpiry();
-  const { isReady, linkExpired, linkExpireTime, linkWillExpire } =
+  const { expirationTimestamp, isReady, linkExpired, linkWillExpire } =
     expiryStatus || {};
 
   if (!isReady) return null;
@@ -18,12 +18,12 @@ export const NIHAccountExpiryWarning = (): JSX.Element | null => {
   return linkWillExpire || linkExpired ? (
     <Alert {...ALERT_PROPS.STANDARD_WARNING} component={FluidPaper}>
       <span>
-        <span>{getExpiryMessage(linkExpired, linkExpireTime)}</span>{" "}
+        <span>{getExpiryMessage(linkExpired, expirationTimestamp)}</span>{" "}
         <span>
           Please{" "}
           <Link
             label="renew your account"
-            url="https://support.terra.bio/hc/en-us/articles/19124069598235"
+            url="https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data-Launching-3-25-26"
           />{" "}
           link.
         </span>
@@ -34,27 +34,33 @@ export const NIHAccountExpiryWarning = (): JSX.Element | null => {
 
 /**
  * Calculates the remaining days until the link expires.
- * @param expireTime - Link expiration time in seconds.
+ * @param expirationTimestamp - Expiration timestamp as an ISO 8601 date-time string.
  * @returns remaining days until the link expires.
  */
-function getExpireTimeInDays(expireTime?: number): number {
-  if (!expireTime) {
+function getExpireTimeInDays(expirationTimestamp?: string): number {
+  if (!expirationTimestamp) {
     return 0;
   }
-  return Math.max(Math.ceil(expireTimeInSeconds(expireTime) / 60 / 60 / 24), 0);
+  return Math.max(
+    Math.ceil(expireTimeInSeconds(expirationTimestamp) / 60 / 60 / 24),
+    0,
+  );
 }
 
 /**
  * Returns an expiration message indicating whether the provided link has already expired or is set to expire.
  * @param linkExpired - Link expired flag.
- * @param expireTime - Link expiration time in seconds.
+ * @param expirationTimestamp - Expiration timestamp as an ISO 8601 date-time string.
  * @returns expiration message.
  */
-function getExpiryMessage(linkExpired?: boolean, expireTime?: number): string {
+function getExpiryMessage(
+  linkExpired?: boolean,
+  expirationTimestamp?: string,
+): string {
   if (linkExpired) {
     return "Your NIH account link has expired.";
   }
   return `Your NIH account link will expire in ${getExpireTimeInDays(
-    expireTime,
+    expirationTimestamp,
   )} days.`;
 }

--- a/src/hooks/authentication/terra/useAuthenticationNIHExpiry.ts
+++ b/src/hooks/authentication/terra/useAuthenticationNIHExpiry.ts
@@ -4,9 +4,9 @@ import { REQUEST_STATUS } from "../../../providers/authentication/terra/hooks/co
 const WARNING_WINDOW_SECONDS = 60 * 60 * 24 * 5; // 5 days.
 
 interface UseAuthenticationNIHExpiry {
+  expirationTimestamp?: string;
   isReady: boolean;
   linkExpired?: boolean;
-  linkExpireTime?: number;
   linkWillExpire?: boolean;
 }
 
@@ -17,13 +17,13 @@ interface UseAuthenticationNIHExpiry {
 export const useAuthenticationNIHExpiry = (): UseAuthenticationNIHExpiry => {
   const { terraNIHProfileLoginStatus } = useTerraProfile();
   const { requestStatus, response } = terraNIHProfileLoginStatus;
-  const { linkExpireTime } = response || {};
+  const { expirationTimestamp } = response || {};
   const isReady = requestStatus === REQUEST_STATUS.COMPLETED;
-  const linkExpired = hasLinkedNIHAccountExpired(linkExpireTime);
-  const linkWillExpire = isLinkedNIHAccountWillExpire(linkExpireTime);
+  const linkExpired = hasLinkedNIHAccountExpired(expirationTimestamp);
+  const linkWillExpire = isLinkedNIHAccountWillExpire(expirationTimestamp);
   return {
+    expirationTimestamp,
     isReady,
-    linkExpireTime,
     linkExpired,
     linkWillExpire,
   };
@@ -31,31 +31,33 @@ export const useAuthenticationNIHExpiry = (): UseAuthenticationNIHExpiry => {
 
 /**
  * Calculates the remaining time in seconds until the given expiration time.
- * @param expireTime - Expire time in seconds.
+ * @param expirationTimestamp - Expiration timestamp as an ISO 8601 date-time string.
  * @returns remaining time in seconds.
  */
-export function expireTimeInSeconds(expireTime: number): number {
-  return expireTime - Date.now() / 1000;
+export function expireTimeInSeconds(expirationTimestamp: string): number {
+  return new Date(expirationTimestamp).getTime() / 1000 - Date.now() / 1000;
 }
 
 /**
  * Returns true if the linked NIH account has expired.
- * @param expireTime - Expire time in seconds.
+ * @param expirationTimestamp - Expiration timestamp as an ISO 8601 date-time string.
  * @returns true if the linked NIH account has expired.
  */
-function hasLinkedNIHAccountExpired(expireTime?: number): boolean | undefined {
-  if (!expireTime) return;
-  return expireTimeInSeconds(expireTime) < 0;
+function hasLinkedNIHAccountExpired(
+  expirationTimestamp?: string,
+): boolean | undefined {
+  if (!expirationTimestamp) return;
+  return expireTimeInSeconds(expirationTimestamp) < 0;
 }
 
 /**
  * Returns true if the linked NIH account will expire in less than a week.
- * @param expireTime - Expire time in seconds.
+ * @param expirationTimestamp - Expiration timestamp as an ISO 8601 date-time string.
  * @returns true if the linked NIH account will expire in less than a week.
  */
 function isLinkedNIHAccountWillExpire(
-  expireTime?: number,
+  expirationTimestamp?: string,
 ): boolean | undefined {
-  if (!expireTime) return;
-  return expireTimeInSeconds(expireTime) < WARNING_WINDOW_SECONDS;
+  if (!expirationTimestamp) return;
+  return expireTimeInSeconds(expirationTimestamp) < WARNING_WINDOW_SECONDS;
 }

--- a/src/providers/authentication/terra/hooks/useFetchTerraNIHProfile.ts
+++ b/src/providers/authentication/terra/hooks/useFetchTerraNIHProfile.ts
@@ -6,11 +6,7 @@ import {
   LOGIN_STATUS_PENDING,
   TERRA_SERVICE_ID,
 } from "./common/constants";
-import {
-  LoginResponseError,
-  LoginStatus,
-  REQUEST_STATUS,
-} from "./common/entities";
+import { LoginStatus, REQUEST_STATUS } from "./common/entities";
 import {
   getAuthenticationRequestOptions,
   initLoginStatus,
@@ -19,17 +15,12 @@ import { getServiceEndpoint } from "./utils";
 
 const ENDPOINT_ID = "nihStatus";
 
-interface DatasetPermission {
-  authorized: boolean;
-  name: string;
-}
-
 type Status = LoginStatus<TerraNIHResponse>;
 
 export interface TerraNIHResponse {
-  datasetPermissions: DatasetPermission[];
-  linkedNihUsername: string;
-  linkExpireTime: number;
+  authenticated?: boolean;
+  expirationTimestamp: string;
+  externalUserId: string;
 }
 
 /**
@@ -53,18 +44,30 @@ export const useFetchTerraNIHProfile = (token?: string): Status => {
       }
       setLoginStatus(LOGIN_STATUS_PENDING as Status);
       fetch(endpoint, getAuthenticationRequestOptions(accessToken))
-        .then((response) => response.json())
-        .then((response: LoginResponseError | TerraNIHResponse) => {
-          if (isResponseError(response)) {
-            setLoginStatus(LOGIN_STATUS_FAILED as Status);
-          } else {
+        .then((response) => {
+          if (response.status === 404) {
             setLoginStatus((prevStatus) => ({
               ...prevStatus,
-              isSuccess: isResponseSuccess(response),
+              isSuccess: false,
               requestStatus: REQUEST_STATUS.COMPLETED,
-              response,
+              response: undefined,
             }));
+            return;
           }
+          if (!response.ok) {
+            setLoginStatus(LOGIN_STATUS_FAILED as Status);
+            return;
+          }
+          return response.json();
+        })
+        .then((response?: TerraNIHResponse) => {
+          if (!response) return;
+          setLoginStatus((prevStatus) => ({
+            ...prevStatus,
+            isSuccess: isResponseSuccess(response),
+            requestStatus: REQUEST_STATUS.COMPLETED,
+            response,
+          }));
         })
         .catch((err) => {
           console.log(err); // TODO handle error.
@@ -84,21 +87,10 @@ export const useFetchTerraNIHProfile = (token?: string): Status => {
 };
 
 /**
- * Returns true if response is an error response.
- * @param response - Response.
- * @returns true if response is an error response.
- */
-function isResponseError(
-  response: TerraNIHResponse | LoginResponseError,
-): response is LoginResponseError {
-  return Boolean((response as LoginResponseError).statusCode);
-}
-
-/**
- * Returns true if the user accepted terms of service version is current.
+ * Returns true if the user has a linked external account.
  * @param response - Response.
  * @returns true if response is successful.
  */
 function isResponseSuccess(response: TerraNIHResponse): boolean {
-  return Boolean(response.linkedNihUsername);
+  return Boolean(response.externalUserId);
 }


### PR DESCRIPTION
## Summary

- Replace Firecloud Orchestration `/api/nih/status` endpoint with External Credentials Manager `/api/oauth/v1/{provider}` API
- Update `TerraNIHResponse` interface to match ECM response shape (`externalUserId`, `expirationTimestamp`, `authenticated`)
- Handle HTTP 404 as "not linked" state instead of error
- Parse ISO 8601 timestamps instead of epoch seconds for link expiry
- Update support article URLs to new RAS integration guide

Closes #819

## Test plan

- [ ] Verify TypeScript compilation passes (`npm run test-compile`)
- [ ] Verify existing tests pass (`npm test`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Integration test with data-browser after DataBiosphere/data-browser#4694 updates the endpoint URL
- [ ] Verify expiry warning displays correctly with ECM timestamp format
- [x] Verify 404 response (unlinked account) shows correct UI state
- [ ] Verify "renew your account" and "Go to Tutorial" links point to new RAS article

🤖 Generated with [Claude Code](https://claude.com/claude-code)