### PR TITLE
fix: update 'open to terra' button to be a href (#825)

### DIFF
--- a/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
+++ b/src/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
@@ -1,5 +1,4 @@
 import { JSX, ElementType } from "react";
-import { ButtonPrimary } from "../../../../../common/Button/components/ButtonPrimary/buttonPrimary";
 import { FluidPaper } from "../../../../../common/Paper/paper.styles";
 import {
   ANCHOR_TARGET,
@@ -10,6 +9,8 @@ import {
   SectionActions,
   SectionContent,
 } from "../../../../export.styles";
+import { BUTTON_PROPS } from "../../../../../../styles/common/mui/button";
+import { Button, Link } from "@mui/material";
 
 export interface ExportToTerraReadyProps {
   ExportToTerraSuccess: ElementType;
@@ -20,13 +21,6 @@ export const ExportToTerraReady = ({
   ExportToTerraSuccess,
   exportURL,
 }: ExportToTerraReadyProps): JSX.Element => {
-  const onOpenTerra = (): void => {
-    window.open(
-      exportURL,
-      ANCHOR_TARGET.BLANK,
-      REL_ATTRIBUTE.NO_OPENER_NO_REFERRER,
-    );
-  };
   return (
     <FluidPaper>
       <Section>
@@ -34,7 +28,16 @@ export const ExportToTerraReady = ({
           <ExportToTerraSuccess />
         </SectionContent>
         <SectionActions>
-          <ButtonPrimary onClick={onOpenTerra}>Open Terra</ButtonPrimary>
+          <Button
+            color={BUTTON_PROPS.COLOR.PRIMARY}
+            component={Link}
+            href={exportURL}
+            rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+            target={ANCHOR_TARGET.BLANK}
+            variant={BUTTON_PROPS.VARIANT.CONTAINED}
+          >
+            Open Terra
+          </Button>
         </SectionActions>
       </Section>
     </FluidPaper>


### PR DESCRIPTION
Closes #825.

This pull request refactors the export-to-Terra functionality to use Material UI components and props for improved consistency and maintainability. The main change is replacing the custom `ButtonPrimary` with a Material UI `Button` that acts as a link, streamlining the user interaction and aligning with the project's UI standards.

UI component refactoring:

* Replaced the custom `ButtonPrimary` with a Material UI `Button` component, using `Link` for navigation and applying standardized button props from `BUTTON_PROPS`. This improves consistency with the rest of the UI and simplifies the code.
* Removed the manual `onOpenTerra` function in favor of using the `href`, `rel`, and `target` attributes directly on the button, reducing unnecessary code and leveraging built-in browser behavior.

Imports and dependency updates:

* Removed the import of `ButtonPrimary` and added imports for `Button`, `Link`, and `BUTTON_PROPS`, reflecting the switch to Material UI components and centralized styling. [[1]](diffhunk://#diff-f1be85d4e543c9e59be729dfa7bf23cf607e252a79c0d08086ddb06a750dc189L2) [[2]](diffhunk://#diff-f1be85d4e543c9e59be729dfa7bf23cf607e252a79c0d08086ddb06a750dc189R12-R13)

<img width="2560" height="857" alt="image" src="https://github.com/user-attachments/assets/38e0f038-21d6-40f3-bc76-aeea4bea1df2" />

