### PR TITLE
fix: update nih account title to include researcher auth service (ras) (#832)

### DIFF
--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
@@ -38,7 +38,7 @@ export const ConnectTerraToNIHAccount = ({
           tutorial below.
         </p>
       }
-      title="Connect Terra to your NIH account"
+      title="Connect Terra to your NIH Researcher Auth Service (RAS) account"
     />
   );
 };

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount.tsx
@@ -34,8 +34,8 @@ export const ConnectTerraToNIHAccount = ({
       step={step}
       text={
         <p>
-          Next, connect your Terra account to your NIH account by following the
-          tutorial below.
+          Next, connect your Terra account to your NIH Researcher Auth Service
+          (RAS) account by following the tutorial below.
         </p>
       }
       title="Connect Terra to your NIH Researcher Auth Service (RAS) account"


### PR DESCRIPTION
## Summary
- Updates the ConnectTerraToNIHAccount title from "Connect Terra to your NIH account" to "Connect Terra to your NIH Researcher Auth Service (RAS) account"

## Test plan
- [x] Verify the updated title renders correctly in the Terra setup form

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1095" height="789" alt="image" src="https://github.com/user-attachments/assets/6a99face-e309-4f2e-9f24-c00d018c4555" />
