### PR TITLE
fix: set poweredbyclevercanary image height to 32px

### DIFF
--- a/src/components/Layout/components/Footer/components/PoweredByCleverCanary/poweredByCleverCanary.tsx
+++ b/src/components/Layout/components/Footer/components/PoweredByCleverCanary/poweredByCleverCanary.tsx
@@ -22,8 +22,8 @@ export const PoweredByCleverCanary = ({
     <Logo
       alt={alt}
       className={className}
-      link="https://www.clevercanary.com"
       height={32}
+      link="https://www.clevercanary.com"
       src={props.src}
       target={ANCHOR_TARGET.BLANK}
     />

--- a/src/components/Layout/components/Footer/components/PoweredByCleverCanary/poweredByCleverCanary.tsx
+++ b/src/components/Layout/components/Footer/components/PoweredByCleverCanary/poweredByCleverCanary.tsx
@@ -23,6 +23,7 @@ export const PoweredByCleverCanary = ({
       alt={alt}
       className={className}
       link="https://www.clevercanary.com"
+      height={32}
       src={props.src}
       target={ANCHOR_TARGET.BLANK}
     />


### PR DESCRIPTION
## Summary
- Sets the image height to `32px` in the `PoweredByCleverCanary` component

Closes #844

## Test plan
- [x] Verify the image renders at 32px height in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)