### PR TITLE
feat: update export/download ui (#848)

### DIFF
--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -1,6 +1,29 @@
 import styled from "@emotion/styled";
-import { ButtonPrimary } from "../../../common/Button/components/ButtonPrimary/buttonPrimary";
+import { Card } from "@mui/material";
+import { sectionPadding } from "../../../common/Section/section.styles";
 
-export const ExportButton = styled(ButtonPrimary)`
-  text-transform: none; // overrides MuiButton theme text-transform "capitalize".
-`;
+export const StyledCard = styled(Card)`
+  .MuiCardActionArea-root {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr auto;
+    ${sectionPadding};
+    text-decoration: none;
+
+    &.Mui-disabled {
+      opacity: 0.6;
+    }
+
+    .MuiCardContent-root {
+      padding: 0;
+
+      h3 {
+        margin-bottom: 4px;
+      }
+    }
+
+    .MuiCardActions-root {
+      padding: 0;
+    }
+  }
+` as typeof Card;

--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -1,20 +1,21 @@
-import { Tooltip, Typography } from "@mui/material";
+import { ChevronRightRounded } from "@mui/icons-material";
+import {
+  CardActionArea,
+  CardActions,
+  CardContent,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
 import { JSX, ReactNode } from "react";
 import { useDownloadStatus } from "../../../../hooks/useDownloadStatus";
+import { SVG_ICON_PROPS } from "../../../../styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "../../../../styles/common/mui/typography";
-import { FluidPaper } from "../../../common/Paper/paper.styles";
-import { SectionTitle } from "../../../common/Section/components/SectionTitle/sectionTitle";
-import {
-  Section,
-  SectionActions,
-  SectionContent,
-} from "../../../common/Section/section.styles";
+import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 import { TrackingProps } from "../../../types";
-import { ExportButton } from "./exportMethod.styles";
+import { StyledCard } from "./exportMethod.styles";
 
 export interface ExportMethodProps extends TrackingProps {
-  buttonLabel: string;
   description: ReactNode;
   footnote?: ReactNode;
   isAccessible?: boolean;
@@ -23,7 +24,6 @@ export interface ExportMethodProps extends TrackingProps {
 }
 
 export const ExportMethod = ({
-  buttonLabel,
   description,
   footnote,
   isAccessible = true,
@@ -33,38 +33,42 @@ export const ExportMethod = ({
 }: ExportMethodProps): JSX.Element => {
   const { disabled, message } = useDownloadStatus();
   return (
-    <FluidPaper>
-      <Section>
-        <SectionContent>
-          <SectionTitle title={title} />
-          <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}>
-            {description}
-          </Typography>
-        </SectionContent>
-        <SectionActions>
-          <Tooltip arrow title={message}>
-            <span>
-              <ExportButton
-                component={Link}
-                disabled={disabled || !isAccessible}
-                href={route}
-                id={trackingId}
+    <Tooltip arrow title={message}>
+      <StyledCard component={FluidPaper} elevation={1}>
+        <CardActionArea
+          component={Link}
+          disabled={disabled || !isAccessible}
+          href={route}
+          id={trackingId}
+        >
+          <CardContent>
+            <Typography
+              component="h3"
+              variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XSMALL}
+            >
+              {title}
+            </Typography>
+            <Typography
+              component="div"
+              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}
+            >
+              {description}
+            </Typography>
+            {footnote && (
+              <Typography
+                color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                component="div"
+                variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400_2_LINES}
               >
-                {buttonLabel}
-              </ExportButton>
-            </span>
-          </Tooltip>
-        </SectionActions>
-        {footnote && (
-          <Typography
-            color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-            component="div"
-            variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400_2_LINES}
-          >
-            {footnote}
-          </Typography>
-        )}
-      </Section>
-    </FluidPaper>
+                {footnote}
+              </Typography>
+            )}
+          </CardContent>
+          <CardActions>
+            <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />
+          </CardActions>
+        </CardActionArea>
+      </StyledCard>
+    </Tooltip>
   );
 };

--- a/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
+++ b/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
@@ -1,16 +1,14 @@
-import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { ExportMethod } from "./exportMethod";
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ExportMethod } from "../exportMethod";
 
-const meta = {
+const meta: Meta<typeof ExportMethod> = {
   argTypes: {
-    buttonLabel: { control: "text" },
     description: { control: "text" },
     route: { control: "text" },
     title: { control: "text" },
   },
   component: ExportMethod,
-  title: "Components/Section/Export/ExportMethod",
-} satisfies Meta<typeof ExportMethod>;
+};
 
 export default meta;
 
@@ -18,7 +16,6 @@ type Story = StoryObj<typeof meta>;
 
 export const ExportMethodStory: Story = {
   args: {
-    buttonLabel: "Request curl Command",
     description: "Obtain a curl command for downloading the selected data.",
     route: "/request-curl-command",
     title: "Download Study Data and Metadata (Curl Command)",


### PR DESCRIPTION
## Summary
- Refactored `ExportMethod` from a button-based section layout to a card-based layout using MUI `Card`, `CardActionArea`, `CardContent`, and `CardActions`
- Removed `buttonLabel` prop — the entire card is now clickable with a chevron icon indicator
- Moved story file into `stories/` subdirectory

## Test plan
- [x] Verify export method cards render correctly in storybook
- [x] Verify disabled state displays tooltip and prevents navigation
- [x] Verify card click navigates to the correct route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #848.

<img width="1450" height="1285" alt="image" src="https://github.com/user-attachments/assets/39d71d70-89ea-475f-9cfd-b955f211ccde" />

<img width="1451" height="1288" alt="image" src="https://github.com/user-attachments/assets/aed79abb-919b-48e2-98be-183f78ced76f" />

<img width="1452" height="1235" alt="image" src="https://github.com/user-attachments/assets/7f17bb46-af08-4ae0-9bfb-b138bf02a806" />

<img width="1449" height="1288" alt="image" src="https://github.com/user-attachments/assets/2dcb8046-0309-42b2-85e4-889427d90208" />
