### PR TITLE
fix: allow href clicks in export text to override (and cancel) row clicks (#855)

### DIFF
--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -3,27 +3,39 @@ import { Card } from "@mui/material";
 import { sectionPadding } from "../../../common/Section/section.styles";
 
 export const StyledCard = styled(Card)`
+  ${sectionPadding};
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 1fr auto;
+  position: relative; /* positions card action area */
+
   .MuiCardActionArea-root {
-    display: grid;
-    gap: 16px;
-    grid-template-columns: 1fr auto;
-    ${sectionPadding};
+    height: 100%;
+    left: 0;
+    position: absolute; /* covers entire card */
+    top: 0;
     text-decoration: none;
+    width: 100%;
 
     &.Mui-disabled {
       opacity: 0.6;
     }
+  }
 
-    .MuiCardContent-root {
-      padding: 0;
+  .MuiCardContent-root {
+    padding: 0;
 
-      h3 {
-        margin-bottom: 4px;
-      }
+    h3 {
+      margin-bottom: 4px;
     }
 
-    .MuiCardActions-root {
-      padding: 0;
+    a {
+      position: relative;
+      z-index: 1; // Elevates links above the absolutely positioned CardActionArea overlay.
     }
+  }
+
+  .MuiCardActions-root {
+    padding: 0;
   }
 ` as typeof Card;

--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -11,12 +11,9 @@ export const StyledCard = styled(Card)`
   position: relative; /* positions card action area */
 
   .MuiCardActionArea-root {
-    height: 100%;
-    left: 0;
+    inset: 0;
     position: absolute; /* covers entire card */
-    top: 0;
     text-decoration: none;
-    width: 100%;
 
     &.Mui-disabled {
       background-color: ${PALETTE.COMMON_WHITE};

--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -33,7 +33,7 @@ export const StyledCard = styled(Card)`
 
     a {
       position: relative;
-      z-index: 1; // Elevates links above the absolutely positioned CardActionArea overlay.
+      z-index: 1; /* Elevates links above the absolutely positioned CardActionArea overlay. */
     }
   }
 

--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { Card } from "@mui/material";
+import { PALETTE } from "../../../../styles/common/constants/palette";
 import { sectionPadding } from "../../../common/Section/section.styles";
 
 export const StyledCard = styled(Card)`
@@ -18,6 +19,7 @@ export const StyledCard = styled(Card)`
     width: 100%;
 
     &.Mui-disabled {
+      background-color: ${PALETTE.COMMON_WHITE};
       opacity: 0.6;
     }
   }

--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -36,6 +36,7 @@ export const ExportMethod = ({
     <Tooltip arrow title={message}>
       <StyledCard component={FluidPaper} elevation={1}>
         <CardActionArea
+          aria-label={title}
           component={Link}
           disabled={disabled || !isAccessible}
           href={route}

--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -40,34 +40,33 @@ export const ExportMethod = ({
           disabled={disabled || !isAccessible}
           href={route}
           id={trackingId}
-        >
-          <CardContent>
+        />
+        <CardContent>
+          <Typography
+            component="h3"
+            variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XSMALL}
+          >
+            {title}
+          </Typography>
+          <Typography
+            component="div"
+            variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}
+          >
+            {description}
+          </Typography>
+          {footnote && (
             <Typography
-              component="h3"
-              variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XSMALL}
-            >
-              {title}
-            </Typography>
-            <Typography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
               component="div"
-              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}
+              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400_2_LINES}
             >
-              {description}
+              {footnote}
             </Typography>
-            {footnote && (
-              <Typography
-                color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-                component="div"
-                variant={TYPOGRAPHY_PROPS.VARIANT.BODY_SMALL_400_2_LINES}
-              >
-                {footnote}
-              </Typography>
-            )}
-          </CardContent>
-          <CardActions>
-            <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />
-          </CardActions>
-        </CardActionArea>
+          )}
+        </CardContent>
+        <CardActions>
+          <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />
+        </CardActions>
       </StyledCard>
     </Tooltip>
   );

--- a/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
+++ b/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
@@ -3,7 +3,7 @@ import { ExportMethod } from "../exportMethod";
 
 const meta: Meta<typeof ExportMethod> = {
   argTypes: {
-    description: { control: "text" },
+    description: { control: false },
     route: { control: "text" },
     title: { control: "text" },
   },
@@ -19,12 +19,12 @@ export const ExportMethodStory: Story = {
     description: (
       <div>
         Obtain a curl command for downloading the selected data.{" "}
-        <a href="/" rel="noopener noreferrer" target="_blank">
+        <a href="/learn-more" rel="noopener noreferrer" target="_blank">
           Learn more
         </a>
       </div>
     ),
-    route: "/",
+    route: "/export",
     title: "Download Study Data and Metadata (Curl Command)",
   },
 };

--- a/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
+++ b/src/components/Export/components/ExportMethod/stories/exportMethod.stories.tsx
@@ -16,8 +16,15 @@ type Story = StoryObj<typeof meta>;
 
 export const ExportMethodStory: Story = {
   args: {
-    description: "Obtain a curl command for downloading the selected data.",
-    route: "/request-curl-command",
+    description: (
+      <div>
+        Obtain a curl command for downloading the selected data.{" "}
+        <a href="/" rel="noopener noreferrer" target="_blank">
+          Learn more
+        </a>
+      </div>
+    ),
+    route: "/",
     title: "Download Study Data and Metadata (Curl Command)",
   },
 };


### PR DESCRIPTION
## Summary
- Repositioned `CardActionArea` as an absolutely positioned overlay instead of wrapping content, avoiding nested `<a>` tags (Next.js error)
- Elevated links inside `CardContent` above the overlay with `z-index: 1` so they receive clicks directly
- Updated story with an embedded link to demonstrate the fix

Closes #855

## Test plan
- [x] Verify card click navigates to the export route
- [x] Verify links within card description navigate to their own href (not the card route)
- [x] Verify disabled state still shows tooltip and prevents navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### Disabled State.

<img width="1088" height="849" alt="image" src="https://github.com/user-attachments/assets/08fea6bb-950a-4ba8-9144-f1b21addf163" />
