### PR TITLE
feat: add disabled prop with coming soon chip to exportmethod (#861)

### DIFF
--- a/src/components/Export/components/ExportMethod/constants.ts
+++ b/src/components/Export/components/ExportMethod/constants.ts
@@ -1,0 +1,8 @@
+import { ChipProps } from "@mui/material";
+import { CHIP_PROPS as MUI_CHIP_PROPS } from "../../../../styles/common/mui/chip";
+
+export const CHIP_PROPS: Partial<ChipProps> = {
+  color: MUI_CHIP_PROPS.COLOR.DEFAULT,
+  label: "Coming Soon",
+  variant: MUI_CHIP_PROPS.VARIANT.STATUS,
+};

--- a/src/components/Export/components/ExportMethod/exportMethod.styles.ts
+++ b/src/components/Export/components/ExportMethod/exportMethod.styles.ts
@@ -1,9 +1,16 @@
 import styled from "@emotion/styled";
-import { Card } from "@mui/material";
+import { Card, CardProps } from "@mui/material";
 import { PALETTE } from "../../../../styles/common/constants/palette";
 import { sectionPadding } from "../../../common/Section/section.styles";
 
-export const StyledCard = styled(Card)`
+interface Props extends CardProps {
+  disabled?: boolean;
+}
+
+export const StyledCard = styled(Card, {
+  shouldForwardProp: (prop) => prop !== "disabled",
+})<Props>`
+  background-color: ${({ disabled }) => (disabled ? PALETTE.SMOKE_LIGHTEST : PALETTE.COMMON_WHITE)};
   ${sectionPadding};
   display: grid;
   gap: 16px;
@@ -14,11 +21,6 @@ export const StyledCard = styled(Card)`
     inset: 0;
     position: absolute; /* covers entire card */
     text-decoration: none;
-
-    &.Mui-disabled {
-      background-color: ${PALETTE.COMMON_WHITE};
-      opacity: 0.6;
-    }
   }
 
     .MuiCardContent-root {
@@ -37,4 +39,4 @@ export const StyledCard = styled(Card)`
   .MuiCardActions-root {
     padding: 0;
   }
-` as typeof Card;
+`;

--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -20,8 +20,8 @@ import { CHIP_PROPS } from "./constants";
 import { StyledCard } from "./exportMethod.styles";
 
 export interface ExportMethodProps extends TrackingProps {
+  comingSoon?: boolean;
   description: ReactNode;
-  disabled?: boolean;
   footnote?: ReactNode;
   icon?: ReactNode;
   isAccessible?: boolean;
@@ -30,8 +30,8 @@ export interface ExportMethodProps extends TrackingProps {
 }
 
 export const ExportMethod = ({
+  comingSoon,
   description,
-  disabled: disabledProp,
   footnote,
   icon,
   isAccessible = true,
@@ -40,7 +40,7 @@ export const ExportMethod = ({
   trackingId,
 }: ExportMethodProps): JSX.Element => {
   const { disabled: downloadStatusDisabled, message } = useDownloadStatus();
-  const disabled = disabledProp || downloadStatusDisabled || !isAccessible;
+  const disabled = comingSoon || downloadStatusDisabled || !isAccessible;
   return (
     <Tooltip arrow title={message}>
       <StyledCard component={FluidPaper} disabled={disabled} elevation={1}>
@@ -83,7 +83,7 @@ export const ExportMethod = ({
           )}
         </CardContent>
         <CardActions>
-          {disabledProp ? (
+          {comingSoon ? (
             <Chip {...CHIP_PROPS} />
           ) : (
             <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />

--- a/src/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/src/components/Export/components/ExportMethod/exportMethod.tsx
@@ -3,6 +3,7 @@ import {
   CardActionArea,
   CardActions,
   CardContent,
+  Chip,
   Stack,
   Tooltip,
   Typography,
@@ -15,10 +16,12 @@ import { SVG_ICON_PROPS } from "../../../../styles/common/mui/svgIcon";
 import { TYPOGRAPHY_PROPS } from "../../../../styles/common/mui/typography";
 import { FluidPaper } from "../../../common/Paper/components/FluidPaper/fluidPaper";
 import { TrackingProps } from "../../../types";
+import { CHIP_PROPS } from "./constants";
 import { StyledCard } from "./exportMethod.styles";
 
 export interface ExportMethodProps extends TrackingProps {
   description: ReactNode;
+  disabled?: boolean;
   footnote?: ReactNode;
   icon?: ReactNode;
   isAccessible?: boolean;
@@ -28,6 +31,7 @@ export interface ExportMethodProps extends TrackingProps {
 
 export const ExportMethod = ({
   description,
+  disabled: disabledProp,
   footnote,
   icon,
   isAccessible = true,
@@ -35,14 +39,15 @@ export const ExportMethod = ({
   title,
   trackingId,
 }: ExportMethodProps): JSX.Element => {
-  const { disabled, message } = useDownloadStatus();
+  const { disabled: downloadStatusDisabled, message } = useDownloadStatus();
+  const disabled = disabledProp || downloadStatusDisabled || !isAccessible;
   return (
     <Tooltip arrow title={message}>
-      <StyledCard component={FluidPaper} elevation={1}>
+      <StyledCard component={FluidPaper} disabled={disabled} elevation={1}>
         <CardActionArea
           aria-label={title}
           component={Link}
-          disabled={disabled || !isAccessible}
+          disabled={disabled}
           href={route}
           id={trackingId}
         />
@@ -78,7 +83,11 @@ export const ExportMethod = ({
           )}
         </CardContent>
         <CardActions>
-          <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />
+          {disabledProp ? (
+            <Chip {...CHIP_PROPS} />
+          ) : (
+            <ChevronRightRounded color={SVG_ICON_PROPS.COLOR.INK_LIGHT} />
+          )}
         </CardActions>
       </StyledCard>
     </Tooltip>


### PR DESCRIPTION
Closes #861.

This pull request enhances the `ExportMethod` component by introducing a "Coming Soon" state for export options that are not yet available. The main changes include adding a `comingSoon` prop, updating the component's disabled logic, and displaying a `Chip` indicator when appropriate. Styling adjustments ensure the card reflects its disabled state visually.

**Feature: "Coming Soon" State for Export Methods**
- Added a `comingSoon` prop to `ExportMethodProps` and updated the component to display a "Coming Soon" `Chip` when this prop is set. This also disables the export method and updates the visual appearance accordingly. [[1]](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59R19-R23) [[2]](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59R33) [[3]](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59L38-R50) [[4]](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59R86-R90) [[5]](diffhunk://#diff-914d4a3b29d994ae0e6e4628ec39322960eab5cdc70f161b0f6796ab1c0bfe3dR1-R8)

**Styling Updates**
- Modified `StyledCard` in `exportMethod.styles.ts` to support a `disabled` prop, changing its background color when disabled and removing the previous `.Mui-disabled` CSS rule for better control. [[1]](diffhunk://#diff-be4ba75ae1a3c24c6529c63fb778e29dd024093b9b47875c5f2bccaa99ccd4f9L2-R13) [[2]](diffhunk://#diff-be4ba75ae1a3c24c6529c63fb778e29dd024093b9b47875c5f2bccaa99ccd4f9L17-L21) [[3]](diffhunk://#diff-be4ba75ae1a3c24c6529c63fb778e29dd024093b9b47875c5f2bccaa99ccd4f9L40-R42)

**Component Integration**
- Imported and used the shared `CHIP_PROPS` for consistent "Coming Soon" chip styling across the UI. [[1]](diffhunk://#diff-12229531e2d67dad99fb2faa665e34a924284bb6699973afdf2772e0d23d9f59R6) [[2]](diffhunk://#diff-914d4a3b29d994ae0e6e4628ec39322960eab5cdc70f161b0f6796ab1c0bfe3dR1-R8)

<img width="754" height="207" alt="image" src="https://github.com/user-attachments/assets/8c3f70c9-e55c-4ce1-8519-588f371304b2" />
