### PR TITLE
fix: update type declarations to import from lib/ instead of src/ (#865)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "main": "lib/index.js",
   "files": [
     "lib",
-    "src",
     "types"
   ],
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "baseUrl": "./src",
+    "paths": {
+      "@databiosphere/findable-ui/lib/*": ["*"]
+    },
     "rootDir": "./src",
     "outDir": "lib",
     "declaration": true,

--- a/types/data-explorer-ui.d.ts
+++ b/types/data-explorer-ui.d.ts
@@ -17,11 +17,10 @@ import type {} from "@mui/material/Tabs";
 import type {} from "@mui/material/themeCssVarsAugmentation";
 import type {} from "@mui/material/Toolbar";
 import type {} from "@mui/material/Typography";
-import type {} from "@tanstack/react-table";
-import { RowData } from "@tanstack/react-table";
+import type { RowData } from "@tanstack/react-table";
 import { Components } from "rehype-react";
-import { DataLayer } from "../src/common/analytics/entities";
-import { DataDictionaryAnnotation } from "../src/common/entities";
+import { DataLayer } from "@databiosphere/findable-ui/lib/common/analytics/entities";
+import { DataDictionaryAnnotation } from "@databiosphere/findable-ui/lib/common/entities";
 import {
   CustomFeatureColumn,
   CustomFeatureInitialTableState,
@@ -29,9 +28,9 @@ import {
   CustomFeatureOptions,
   CustomFeatureRow,
   CustomFeatureTableState,
-} from "../src/components/Table/features/entities";
-import { GridTrackSize } from "../src/config/entities";
-import { SIZE } from "../src/styles/common/constants/size";
+} from "@databiosphere/findable-ui/lib/components/Table/features/entities";
+import { GridTrackSize } from "@databiosphere/findable-ui/lib/config/entities";
+import { SIZE } from "@databiosphere/findable-ui/lib/styles/common/constants/size";
 
 declare module "@mui/material/Alert" {
   interface AlertProps {


### PR DESCRIPTION
Closes #865

## Summary

- Updated 5 imports in `types/data-explorer-ui.d.ts` from relative `../src/...` paths to package-scoped `@databiosphere/findable-ui/lib/...` paths
- Added a `paths` mapping in `tsconfig.json` so TypeScript resolves these imports back to `src/` during local development
- Removed `src` from the `files` field in `package.json`, reducing the published package size by ~5.7 MB

### Why the full package name?

The imports in `types/data-explorer-ui.d.ts` must resolve in two contexts:

1. **Locally** (during `tsc`): the `paths` mapping in `tsconfig.json` redirects `@databiosphere/findable-ui/lib/*` → `src/*`, avoiding the TS5055 error where `lib/` would be both input and output
2. **For consumers** (after `npm install`): TypeScript resolves the same specifier via `node_modules` to the compiled `lib/` directory

A relative `../lib/...` import causes TS5055 because it pulls `lib/` files in as compilation inputs while `lib/` is the output directory. The package-scoped import with the `paths` mapping solves both cases cleanly.

## Test plan

- [x] `npx tsc` — compiles without TS5055 errors
- [x] `npm run test-compile` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 327 tests passing
- [x] Install tarball in a consumer app and verify type resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)