### PR TITLE
feat: update attribute required prop to support strongly recommended (#875)

### DIFF
--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -14,7 +14,7 @@ export interface Attribute {
   name: string; // Programmatic slot name or key (e.g. batch_condition, biosamples.anatomical_site)
   range: string; // Type of attribute value e.g. "string"
   rationale?: string; // Free text rationale for attribute
-  required: boolean;
+  required: boolean | "strongly recommended";
   title: string; // Display name
   values?: string; // Free text description of attribute values
 }

--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -14,7 +14,7 @@ export interface Attribute {
   name: string; // Programmatic slot name or key (e.g. batch_condition, biosamples.anatomical_site)
   range: string; // Type of attribute value e.g. "string"
   rationale?: string; // Free text rationale for attribute
-  required: boolean | "strongly recommended";
+  required: RequirementLevel;
   title: string; // Display name
   values?: string; // Free text description of attribute values
 }
@@ -118,6 +118,20 @@ export interface Pagination {
  * Possible pagination direction values.
  */
 export type PaginationDirectionType = "next" | "prev";
+
+/**
+ * Requirement level for an attribute.
+ */
+export const REQUIREMENT_LEVEL = {
+  STRONGLY_RECOMMENDED: "strongly recommended",
+} as const;
+
+/**
+ * Requirement level type.
+ */
+export type RequirementLevel =
+  | boolean
+  | (typeof REQUIREMENT_LEVEL)[keyof typeof REQUIREMENT_LEVEL];
 
 /**
  * Internal filter model of a multiselect category (e.g. library construction approach).


### PR DESCRIPTION
## Summary
- Update `Attribute.required` type from `boolean` to `boolean | "strongly recommended"`
- Backwards-compatible — existing `true`/`false` usage is unaffected
- `"strongly recommended"` is truthy, so existing `if (required)` checks still work

Closes #875

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Downstream consumers using `required: true` or `required: false` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)