### PR TITLE
fix: move token-change reset from explorestateprovider to useentitylist (#310)

### DIFF
--- a/src/hooks/useEntityList.ts
+++ b/src/hooks/useEntityList.ts
@@ -55,6 +55,19 @@ export const useEntityList = (
   );
   const isFetching = isIdle || isLoading;
 
+  // Reset explore response when token changes - server-side fetched modes only.
+  useEffect(() => {
+    if (
+      exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING ||
+      exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING
+    ) {
+      exploreDispatch({
+        payload: undefined,
+        type: ExploreActionKind.ResetExploreResponse,
+      });
+    }
+  }, [exploreDispatch, exploreMode, token]);
+
   // Fetch entities - on change of filter state - server-side fetching and server-side filtering.
   useEffect(() => {
     if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING) {

--- a/src/providers/exploreState.tsx
+++ b/src/providers/exploreState.tsx
@@ -4,7 +4,6 @@ import {
   Dispatch,
   JSX,
   ReactNode,
-  useEffect,
   useMemo,
   useReducer,
   useState,
@@ -15,7 +14,6 @@ import { SelectedFilter } from "../common/entities";
 import { FILTER_SORT } from "../common/filters/sort/config/types";
 import { RowPreviewState } from "../components/Table/features/RowPreview/entities";
 import { CategoryGroup, SiteConfig } from "../config/entities";
-import { useToken } from "../hooks/authentication/token/useToken";
 import { META_COMMAND } from "../hooks/stateSyncManager/hooks/UseMetaCommands/types";
 import {
   buildCategoryViews,
@@ -189,7 +187,6 @@ export function ExploreStateProvider({
   const { config, defaultEntityListType } = useConfig();
   const { decodedCatalogParam, decodedFeatureFlagParam, decodedFilterParam } =
     useURLFilterParams();
-  const { token } = useToken();
   const entityList = entityListType || defaultEntityListType;
   const [initializerArg] = useState(() =>
     initReducerArguments(
@@ -214,14 +211,6 @@ export function ExploreStateProvider({
   const exploreContextValue = useMemo(() => {
     return { exploreDispatch, exploreState };
   }, [exploreDispatch, exploreState]);
-
-  // Reset explore response when token changes.
-  useEffect(() => {
-    exploreDispatch({
-      payload: undefined,
-      type: ExploreActionKind.ResetExploreResponse,
-    });
-  }, [exploreDispatch, token]);
 
   return (
     <ExploreStateContext.Provider value={exploreContextValue}>


### PR DESCRIPTION
## Summary
- Moves the `ResetExploreResponse` effect from `ExploreStateProvider` to `useEntityList`, scoped to SS_FETCH modes only
- Removes `useToken()` dependency from `ExploreStateProvider`

### Root cause
`ExploreStateProvider` dispatched `ResetExploreResponse` (setting `loading: true`) in a `useEffect` dependent on `token`. This effect fired as a parent effect — **after** the child `useEntityList` had already dispatched `ProcessExploreResponse` (setting `loading: false`). The parent reset overwrote the child's response, and since `useEntityList`'s dependencies hadn't changed, it never re-fired. Result: `loading` stuck at `true`.

Without `GoogleSignInAuthenticationProvider` in the tree, there was no `CredentialsContext.Provider`, so the token came from the default context — but the effect ordering issue was the same.

### Fix
The reset now lives in `useEntityList` alongside the fetch effects, scoped to `SS_FETCH_SS_FILTERING` and `SS_FETCH_CS_FILTERING` only. This ensures:
- **CS_FETCH_CS_FILTERING** (e.g. BRC Analytics) — no reset fires, no stuck loading
- **SS_FETCH_SS_FILTERING** (e.g. AnVIL CMG) — reset fires on token change, triggering refetch with new auth
- **SS_FETCH_CS_FILTERING** (e.g. HCA Atlas Tracker) — reset fires on token change, triggering refetch

Fixes #310

## Test plan
Verified across all three explore modes:
- [x] BRC Analytics (CS_FETCH_CS_FILTERING) — entity list loads without `GoogleSignInAuthenticationProvider`
- [x] AnVIL CMG (SS_FETCH_SS_FILTERING) — initial load works, login triggers data refetch
- [x] HCA Atlas Tracker (SS_FETCH_CS_FILTERING) — initial load works

🤖 Generated with [Claude Code](https://claude.com/claude-code)