### PR TITLE
fix: range filter min/max displays -infinity when actual minimum is 0 (#889)

### DIFF
--- a/src/common/categories/views/range/utils.ts
+++ b/src/common/categories/views/range/utils.ts
@@ -23,7 +23,8 @@ export function buildRangeCategoryView(
   );
   return {
     annotation: categoryConfig?.annotation,
-    isDisabled: !isFinite(category.min) && !isFinite(category.max),
+    isDisabled:
+      !Number.isFinite(category.min) && !Number.isFinite(category.max),
     key: category.key,
     label: categoryConfig?.label || category.key,
     max: category.max,

--- a/src/common/categories/views/range/utils.ts
+++ b/src/common/categories/views/range/utils.ts
@@ -23,7 +23,7 @@ export function buildRangeCategoryView(
   );
   return {
     annotation: categoryConfig?.annotation,
-    isDisabled: false,
+    isDisabled: !isFinite(category.min) && !isFinite(category.max),
     key: category.key,
     label: categoryConfig?.label || category.key,
     max: category.max,
@@ -32,4 +32,24 @@ export function buildRangeCategoryView(
     selectedMin,
     unit: categoryConfig?.unit,
   };
+}
+
+/**
+ * Returns the maximum value from a faceted min/max tuple, falling back to Infinity.
+ * Uses nullish coalescing to correctly handle a max of 0.
+ * @param minMax - Faceted min/max values, or undefined.
+ * @returns The maximum value.
+ */
+export function getRangeMax(minMax: [number, number] | undefined): number {
+  return minMax?.[1] ?? Infinity;
+}
+
+/**
+ * Returns the minimum value from a faceted min/max tuple, falling back to -Infinity.
+ * Uses nullish coalescing to correctly handle a min of 0.
+ * @param minMax - Faceted min/max values, or undefined.
+ * @returns The minimum value.
+ */
+export function getRangeMin(minMax: [number, number] | undefined): number {
+  return minMax?.[0] ?? -Infinity;
 }

--- a/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
+++ b/src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts
@@ -5,6 +5,10 @@ import {
   SelectCategoryConfig,
 } from "../../../../../../common/categories/config/types";
 import { RangeCategoryView } from "../../../../../../common/categories/views/range/types";
+import {
+  getRangeMax,
+  getRangeMin,
+} from "../../../../../../common/categories/views/range/utils";
 import { CategoryView } from "../../../../../../common/categories/views/types";
 import {
   SelectCategoryValueView,
@@ -184,8 +188,8 @@ function mapColumnToRangeCategoryView<T extends RowData>(
     isDisabled,
     key: column.id,
     label: getColumnHeader(column),
-    max: minMax?.[1] || Infinity,
-    min: minMax?.[0] || -Infinity,
+    max: getRangeMax(minMax),
+    min: getRangeMin(minMax),
     selectedMax: filterValue[1],
     selectedMin: filterValue[0],
     ...categoryConfig,

--- a/src/components/Table/common/utils.ts
+++ b/src/components/Table/common/utils.ts
@@ -10,6 +10,10 @@ import {
   Table,
 } from "@tanstack/react-table";
 import { Category } from "../../../common/categories/models/types";
+import {
+  getRangeMax,
+  getRangeMin,
+} from "../../../common/categories/views/range/utils";
 import { EXPLORE_MODE, ExploreMode } from "../../../hooks/useExploreMode/types";
 
 /**
@@ -52,8 +56,8 @@ export function buildCategoryViews<T extends RowData>(
         categoryViews.push({
           key,
           label,
-          max: minMax?.[1] || Infinity,
-          min: minMax?.[0] || -Infinity,
+          max: getRangeMax(minMax),
+          min: getRangeMin(minMax),
           selectedMax: null, // Selected state updated in reducer.
           selectedMin: null, // Selected state updated in reducer.
         });

--- a/tests/getRangeMinMax.test.ts
+++ b/tests/getRangeMinMax.test.ts
@@ -1,4 +1,6 @@
+import { RangeCategory } from "../src/common/categories/models/range/types";
 import {
+  buildRangeCategoryView,
   getRangeMax,
   getRangeMin,
 } from "../src/common/categories/views/range/utils";
@@ -36,5 +38,33 @@ describe("getRangeMax", () => {
 
   it("returns a negative max", () => {
     expect(getRangeMax([-50, -10])).toBe(-10);
+  });
+});
+
+describe("buildRangeCategoryView", () => {
+  const makeCategory = (min: number, max: number): RangeCategory => ({
+    key: "test",
+    max,
+    min,
+    selectedMax: null,
+    selectedMin: null,
+  });
+
+  it("disables the filter when min and max are both infinite", () => {
+    const result = buildRangeCategoryView(
+      makeCategory(-Infinity, Infinity),
+      [],
+    );
+    expect(result.isDisabled).toBe(true);
+  });
+
+  it("enables the filter when min and max are finite", () => {
+    const result = buildRangeCategoryView(makeCategory(0, 100), []);
+    expect(result.isDisabled).toBe(false);
+  });
+
+  it("enables the filter when min is 0 and max is finite", () => {
+    const result = buildRangeCategoryView(makeCategory(0, 61.31), []);
+    expect(result.isDisabled).toBe(false);
   });
 });

--- a/tests/getRangeMinMax.test.ts
+++ b/tests/getRangeMinMax.test.ts
@@ -1,0 +1,40 @@
+import {
+  getRangeMax,
+  getRangeMin,
+} from "../src/common/categories/views/range/utils";
+
+describe("getRangeMin", () => {
+  it("returns the min from a valid tuple", () => {
+    expect(getRangeMin([5, 100])).toBe(5);
+  });
+
+  it("returns 0 when the min is 0", () => {
+    expect(getRangeMin([0, 61.31])).toBe(0);
+  });
+
+  it("returns -Infinity when minMax is undefined", () => {
+    expect(getRangeMin(undefined)).toBe(-Infinity);
+  });
+
+  it("returns a negative min", () => {
+    expect(getRangeMin([-10, 50])).toBe(-10);
+  });
+});
+
+describe("getRangeMax", () => {
+  it("returns the max from a valid tuple", () => {
+    expect(getRangeMax([5, 100])).toBe(100);
+  });
+
+  it("returns 0 when the max is 0", () => {
+    expect(getRangeMax([-10, 0])).toBe(0);
+  });
+
+  it("returns Infinity when minMax is undefined", () => {
+    expect(getRangeMax(undefined)).toBe(Infinity);
+  });
+
+  it("returns a negative max", () => {
+    expect(getRangeMax([-50, -10])).toBe(-10);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes range filter displaying `Min allowed: -Infinity` when the actual minimum value is `0`, caused by `||` treating `0` as falsy
- Extracts `getRangeMin`/`getRangeMax` helper functions using `??` (nullish coalescing) instead of `||`
- Fixes `buildRangeCategoryView` to disable the range filter when all values are non-numeric (min/max are both infinite)

### Files changed
- `src/common/categories/views/range/utils.ts` — Added `getRangeMin`/`getRangeMax` helpers; `buildRangeCategoryView` now sets `isDisabled` when both min and max are infinite
- `src/components/Table/common/utils.ts` — Replaced inline `||` fallbacks with `getRangeMin`/`getRangeMax`
- `src/components/Filter/components/adapters/tanstack/ColumnFiltersAdapter/utils.ts` — Same replacement
- `tests/getRangeMinMax.test.ts` — 8 tests covering `0` edge cases and `undefined` fallbacks

Closes #889

## Test plan
- [x] All 363 existing tests pass
- [x] 8 new unit tests for `getRangeMin`/`getRangeMax`
- [x] Manually verified on HPRC Data Explorer: Coverage filter shows `Min allowed: 0` instead of `-Infinity`
- [x] Manually verified range filter disables when filtered results have only non-numeric values

🤖 Generated with [Claude Code](https://claude.com/claude-code)