### PR TITLE
fix: restore early exit in buildNextEntities to preserve non-current entity queries (#894)

### DIFF
--- a/src/providers/exploreState/entities/state.ts
+++ b/src/providers/exploreState/entities/state.ts
@@ -24,13 +24,17 @@ export function buildNextEntities(
     // Grab the entity key for the entity.
     const entityKey = entity.entityKey;
 
+    if (entityKey !== key) {
+      // For entities that do not share the same key, leave the context unchanged.
+      entities[entityPath] = entity;
+      continue;
+    }
+
     // Clone the entity context.
     const entityContext = { ...entity };
 
     // Build the params object.
     // All entities share the same catalog and feature flag state.
-    // Filter state is default to an empty array and updated below,
-    // if the entity key matches the current entity key.
     const params: EntityState = {
       catalogState: state.catalogState,
       featureFlagState: state.featureFlagState,

--- a/tests/buildNextEntities.test.ts
+++ b/tests/buildNextEntities.test.ts
@@ -1,0 +1,151 @@
+import { SelectedFilter } from "../src/common/entities";
+import { ExploreState } from "../src/providers/exploreState";
+import { buildNextEntities } from "../src/providers/exploreState/entities/state";
+import { EntitiesContext } from "../src/providers/exploreState/entities/types";
+
+/**
+ * Creates a minimal ExploreState for testing buildNextEntities.
+ * @param root0 - State options.
+ * @param root0.catalogState - Catalog state.
+ * @param root0.entities - Entities context.
+ * @param root0.entityStateByCategoryGroupConfigKey - Entity state by category group config key.
+ * @param root0.featureFlagState - Feature flag state.
+ * @returns Minimal ExploreState.
+ */
+function makeState({
+  catalogState,
+  entities,
+  entityStateByCategoryGroupConfigKey,
+  featureFlagState,
+}: {
+  catalogState?: string;
+  entities: EntitiesContext;
+  entityStateByCategoryGroupConfigKey?: Map<string, unknown>;
+  featureFlagState?: string;
+}): ExploreState {
+  return {
+    catalogState,
+    entities,
+    entityStateByCategoryGroupConfigKey:
+      entityStateByCategoryGroupConfigKey ?? new Map(),
+    featureFlagState,
+  } as unknown as ExploreState;
+}
+
+const FILTER_SPECIES: SelectedFilter[] = [
+  { categoryKey: "species", value: ["dog"] },
+];
+
+const FILTER_STRAIN: SelectedFilter[] = [
+  { categoryKey: "strain", value: ["labrador"] },
+];
+
+const FILTER_RELEASE: SelectedFilter[] = [
+  { categoryKey: "release", value: ["2"] },
+];
+
+describe("buildNextEntities", () => {
+  it("applies next filter state to the current entity", () => {
+    const state = makeState({
+      entities: {
+        organisms: { entityKey: "organisms-key", query: {} },
+      },
+    });
+
+    const result = buildNextEntities(state, "organisms", {
+      filterState: FILTER_SPECIES,
+    });
+
+    expect(result.organisms.query).toEqual({
+      entityListType: "organisms",
+      filter: JSON.stringify(FILTER_SPECIES),
+    });
+  });
+
+  it("applies next filter state to entities sharing the same key", () => {
+    const state = makeState({
+      entities: {
+        organisms: { entityKey: "shared-key", query: {} },
+        species: { entityKey: "shared-key", query: {} },
+      },
+    });
+
+    const result = buildNextEntities(state, "organisms", {
+      filterState: FILTER_SPECIES,
+    });
+
+    expect(result.organisms.query).toEqual({
+      entityListType: "organisms",
+      filter: JSON.stringify(FILTER_SPECIES),
+    });
+    expect(result.species.query).toEqual({
+      entityListType: "species",
+      filter: JSON.stringify(FILTER_SPECIES),
+    });
+  });
+
+  it("does not touch non-current entity queries", () => {
+    const assembliesQuery = {
+      entityListType: "assemblies",
+      filter: JSON.stringify(FILTER_RELEASE),
+    };
+
+    const state = makeState({
+      entities: {
+        assemblies: { entityKey: "assemblies-key", query: assembliesQuery },
+        organisms: { entityKey: "organisms-key", query: {} },
+      },
+    });
+
+    const result = buildNextEntities(state, "organisms", {
+      filterState: FILTER_STRAIN,
+    });
+
+    expect(result.organisms.query).toEqual({
+      entityListType: "organisms",
+      filter: JSON.stringify(FILTER_STRAIN),
+    });
+
+    expect(result.assemblies.query).toBe(assembliesQuery);
+  });
+
+  it("does not wipe non-current entity filters when clearing current entity", () => {
+    const assembliesQuery = {
+      entityListType: "assemblies",
+      filter: JSON.stringify(FILTER_RELEASE),
+    };
+
+    const state = makeState({
+      entities: {
+        assemblies: { entityKey: "assemblies-key", query: assembliesQuery },
+        organisms: { entityKey: "organisms-key", query: {} },
+      },
+    });
+
+    const result = buildNextEntities(state, "organisms", {
+      filterState: [],
+    });
+
+    expect(result.organisms.query).toEqual({
+      entityListType: "organisms",
+    });
+
+    expect(result.assemblies.query).toBe(assembliesQuery);
+  });
+
+  it("clones entity context for matching entities only", () => {
+    const state = makeState({
+      entities: {
+        assemblies: { entityKey: "assemblies-key", query: { filter: "x" } },
+        organisms: { entityKey: "organisms-key", query: {} },
+      },
+    });
+
+    const result = buildNextEntities(state, "organisms", {
+      filterState: FILTER_SPECIES,
+    });
+
+    expect(result.organisms).not.toBe(state.entities.organisms);
+    expect(result.assemblies).toBe(state.entities.assemblies);
+  });
+});


### PR DESCRIPTION
## Summary

Restores the early-exit pattern for non-matching entities in `buildNextEntities`, which was removed in #521. The #521 refactor intended to ensure `catalogState` and `featureFlagState` were included in every entity's query, but inadvertently wiped `filterState` to `[]` for all non-current entities on every filter action.

### The bug

Every filter action (`UpdateFilter`, `ClearFilters`, `ApplySavedFilter`) calls `buildNextEntities`, which rebuilt the query for **every** entity — including non-current ones — with `filterState: []`. This wiped their persisted filter state from the query, causing the URL to lose filter params when navigating back to a previously-filtered tab.

### Reproduction

1. Filter on tab A (e.g. Organisms by species)
2. Navigate to tab B and apply a filter
3. Navigate back to tab A — filter chip is selected but URL has no filter params

Confirmed on production: https://brc-analytics.org

### The fix

Restore the original early-exit from #514 — non-matching entities are left unchanged (same reference, same query). Only entities sharing the current entity's `categoryGroupConfigKey` get their query rebuilt. The `params` + `Object.assign` pattern from #521 is preserved for matching entities.

### Why `catalogState`/`featureFlagState` don't need updating on non-matching entities

These are global state values set during init and changed only via URL params (`urlToState`), not by filter actions. When a filter action fires, they haven't changed — so non-matching entities' queries already have the correct values.

Closes #894

## Test plan
- [x] 371 tests pass (5 new `buildNextEntities` unit tests)
- [x] Filter on tab A, filter on tab B, navigate back to tab A — URL preserves filter params
- [x] Verify on BRC Analytics: filter Organisms by species, filter Assemblies by strain, navigate back — species filter preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)