### PR TITLE
fix: validate filter query params and surface errors inside error boundary (#898)

### DIFF
--- a/src/common/filters/typeGuards.ts
+++ b/src/common/filters/typeGuards.ts
@@ -13,13 +13,14 @@ export function isSelectedFilter(value: unknown): value is SelectedFilter {
 
 /**
  * Parses a filter parameter string into an array of SelectedFilter.
- * Returns an empty array if the string is not valid JSON or does not
- * contain valid SelectedFilter objects. This function must not throw,
- * as it is called from reducers above the ErrorBoundary. The
- * useValidateFilterParam hook in ExploreView handles surfacing
+ * Filters out invalid entries — a mixed array of valid and invalid
+ * objects returns only the valid ones. Returns an empty array if the
+ * string is not valid JSON or contains no valid entries. This function
+ * must not throw, as it is called from reducers above the ErrorBoundary.
+ * The useValidateFilterParam hook in ExploreView handles surfacing
  * invalid filter errors to the user from inside the ErrorBoundary.
  * @param paramValue - URL-decoded filter parameter string.
- * @returns parsed filters, or empty array if invalid.
+ * @returns valid filters from the parsed input, or empty array.
  */
 export function parseFilterParam(paramValue: string): SelectedFilter[] {
   try {

--- a/src/common/filters/typeGuards.ts
+++ b/src/common/filters/typeGuards.ts
@@ -1,0 +1,36 @@
+import { SelectedFilter } from "../entities";
+
+/**
+ * Returns true if the value is a valid SelectedFilter.
+ * @param value - Value to check.
+ * @returns true if the value has the expected shape.
+ */
+export function isSelectedFilter(value: unknown): value is SelectedFilter {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "categoryKey" in value &&
+    "value" in value &&
+    Array.isArray((value as SelectedFilter).value)
+  );
+}
+
+/**
+ * Parses a filter parameter string into an array of SelectedFilter.
+ * Returns an empty array if the string is not valid JSON or does not
+ * contain valid SelectedFilter objects. This function must not throw,
+ * as it is called from reducers above the ErrorBoundary. The
+ * useValidateFilterParam hook in ExploreView handles surfacing
+ * invalid filter errors to the user from inside the ErrorBoundary.
+ * @param paramValue - URL-decoded filter parameter string.
+ * @returns parsed filters, or empty array if invalid.
+ */
+export function parseFilterParam(paramValue: string): SelectedFilter[] {
+  try {
+    const parsed: unknown = JSON.parse(paramValue);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isSelectedFilter);
+  } catch {
+    return [];
+  }
+}

--- a/src/common/filters/typeGuards.ts
+++ b/src/common/filters/typeGuards.ts
@@ -6,13 +6,9 @@ import { SelectedFilter } from "../entities";
  * @returns true if the value has the expected shape.
  */
 export function isSelectedFilter(value: unknown): value is SelectedFilter {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "categoryKey" in value &&
-    "value" in value &&
-    Array.isArray((value as SelectedFilter).value)
-  );
+  if (typeof value !== "object" || value === null) return false;
+  const filter = value as Record<string, unknown>;
+  return typeof filter.categoryKey === "string" && Array.isArray(filter.value);
 }
 
 /**

--- a/src/components/ErrorBoundary/errorBoundary.tsx
+++ b/src/components/ErrorBoundary/errorBoundary.tsx
@@ -37,7 +37,7 @@ export class ErrorBoundary extends Component<
 
   render(): React.ReactNode {
     if (this.state.error) {
-      const fallbackProps = { error: this.state.error, reset: this.render };
+      const fallbackProps = { error: this.state.error, reset: this.reset };
       return this.props.fallbackRender(fallbackProps);
     }
 

--- a/src/components/Links/components/Link/components/ExploreViewLink/exploreViewLink.tsx
+++ b/src/components/Links/components/Link/components/ExploreViewLink/exploreViewLink.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { JSX } from "react";
 import { UrlObject } from "url";
 import { SelectedFilter } from "../../../../../../common/entities";
+import { isSelectedFilter } from "../../../../../../common/filters/typeGuards";
 import { useExploreState } from "../../../../../../hooks/useExploreState";
 import {
   ExploreActionKind,
@@ -109,20 +110,6 @@ function getSorting(
   const decodedQuery = decodeURIComponent(query);
   const parsedQuery = JSON.parse(decodedQuery);
   return parsedQuery[PARAM_SORTING];
-}
-
-/**
- * Returns true if the given value is a SelectedFilter.
- * @param value - Value.
- * @returns true if the given value is a SelectedFilter.
- */
-function isSelectedFilter(value: unknown): value is SelectedFilter {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "categoryKey" in value &&
-    "value" in value
-  );
 }
 
 /**

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -43,7 +43,7 @@ export const useAsync = <T>(state: State<T> = { status: "idle" }) => {
           `The argument passed to useAsync().run must be a promise.`,
         );
       }
-      safeSetState({ status: "pending" });
+      safeSetState({ error: undefined, status: "pending" });
       return promise.then(
         (data: T) => {
           setData(data);

--- a/src/providers/exploreState/actions/urlToState/utils.ts
+++ b/src/providers/exploreState/actions/urlToState/utils.ts
@@ -11,7 +11,11 @@ export function decodeFilterParamValue(
   paramValue: string | string[] | undefined,
 ): SelectedFilter[] {
   if (typeof paramValue === "string") {
-    return parseFilterParam(decodeURIComponent(paramValue));
+    try {
+      return parseFilterParam(decodeURIComponent(paramValue));
+    } catch {
+      return [];
+    }
   }
   return [];
 }

--- a/src/providers/exploreState/actions/urlToState/utils.ts
+++ b/src/providers/exploreState/actions/urlToState/utils.ts
@@ -1,18 +1,17 @@
 import { SelectedFilter } from "../../../../common/entities";
+import { parseFilterParam } from "../../../../common/filters/typeGuards";
 
 /**
  * Returns the selected filters from the filter parameter value.
  * @param paramValue - The filter parameter value.
  * @returns The selected filters or an empty array.
+ * @see parseFilterParam for validation details and ErrorBoundary constraints.
  */
 export function decodeFilterParamValue(
   paramValue: string | string[] | undefined,
 ): SelectedFilter[] {
   if (typeof paramValue === "string") {
-    // Return decoded filter param value if it is a string.
-    return JSON.parse(decodeURIComponent(paramValue));
+    return parseFilterParam(decodeURIComponent(paramValue));
   }
-
-  // Default to an empty array.
   return [];
 }

--- a/src/providers/exploreState/initializer/utils.ts
+++ b/src/providers/exploreState/initializer/utils.ts
@@ -7,6 +7,7 @@ import {
 import { CategoryConfig } from "../../../common/categories/config/types";
 import { SelectCategory, SelectedFilter } from "../../../common/entities";
 import { getFilterSortType } from "../../../common/filters/sort/config/utils";
+import { parseFilterParam } from "../../../common/filters/typeGuards";
 import { getInitialColumnVisibilityState } from "../../../components/TableCreator/options/initialState/columnVisibility";
 import {
   CategoryGroup,
@@ -303,16 +304,11 @@ function initEntityStateByCategoryGroupConfigKey(
 /**
  * Initializes filter state from URL "filter" parameter.
  * @param decodedFilterParam - Decoded filter parameter.
- * @returns filter state.
+ * @returns filter state, or empty array if invalid.
+ * @see parseFilterParam for validation details and ErrorBoundary constraints.
  */
 function initFilterState(decodedFilterParam: string): SelectedFilter[] {
-  let filterState: SelectedFilter[] = [];
-  try {
-    filterState = JSON.parse(decodedFilterParam);
-  } catch {
-    // do nothing
-  }
-  return filterState;
+  return parseFilterParam(decodedFilterParam);
 }
 
 /**

--- a/src/views/ExploreView/exploreView.tsx
+++ b/src/views/ExploreView/exploreView.tsx
@@ -32,6 +32,7 @@ import { TEST_IDS } from "../../tests/testIds";
 import { ToggleButtonGroup } from "./entityList/filters/components/ToggleButtonGroup/toggleButtonGroup";
 import { StyledGrid, StyledStack } from "./entityList/filters/filters.styles";
 import { useUpdateFilterSort } from "./hooks/UseUpdateFilterSort/hook";
+import { useValidateFilterParam } from "./hooks/UseValidateFilterParam/hook";
 import { buildStateSyncManagerContext } from "./utils";
 
 export interface ExploreViewProps extends AzulEntitiesStaticResponse {
@@ -45,6 +46,7 @@ export const ExploreView = (props: ExploreViewProps): JSX.Element => {
   const { trackingConfig } = config;
   const { label } = entityConfig;
   const { categoryGroups, categoryViews, loading } = exploreState;
+  useValidateFilterParam();
   useEntityList(props); // Fetch entities.
   const { entityListType } = props;
   const categoryFilters = useMemo(

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
@@ -1,0 +1,29 @@
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+import { parseFilterParam } from "../../../../common/filters/typeGuards";
+import { EXPLORE_URL_PARAMS } from "../../../../providers/exploreState/constants";
+import { DataExplorerError } from "../../../../types/error";
+
+/**
+ * Validates the filter query parameter from the URL.
+ * Throws a DataExplorerError during render if the filter param is present
+ * but contains malformed JSON or an invalid filter shape, allowing the
+ * ErrorBoundary to catch and display the error page.
+ */
+export function useValidateFilterParam(): void {
+  const { query } = useRouter();
+  const filterParam = query[EXPLORE_URL_PARAMS.FILTER];
+
+  useMemo(() => {
+    if (typeof filterParam !== "string") return;
+    const decoded = decodeURIComponent(filterParam);
+    // An empty array "[]" is a valid filter param (no filters selected).
+    if (decoded === "[]") return;
+    const filters = parseFilterParam(decoded);
+    if (filters.length === 0) {
+      throw new DataExplorerError({
+        message: "Invalid filter parameter in URL",
+      });
+    }
+  }, [filterParam]);
+}

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
@@ -4,6 +4,8 @@ import { parseFilterParam } from "../../../../common/filters/typeGuards";
 import { EXPLORE_URL_PARAMS } from "../../../../providers/exploreState/constants";
 import { DataExplorerError } from "../../../../types/error";
 
+const INVALID_FILTER_PARAM_ERROR = "Invalid filter parameter in URL";
+
 /**
  * Validates the filter query parameter from the URL.
  * Throws a DataExplorerError during render if the filter param is present
@@ -15,15 +17,21 @@ export function useValidateFilterParam(): void {
   const filterParam = query[EXPLORE_URL_PARAMS.FILTER];
 
   useMemo(() => {
-    if (typeof filterParam !== "string") return;
-    const decoded = decodeURIComponent(filterParam);
+    if (filterParam === undefined) return;
+    if (typeof filterParam !== "string") {
+      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+    }
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(filterParam);
+    } catch {
+      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+    }
     // An empty array "[]" is a valid filter param (no filters selected).
     if (decoded === "[]") return;
     const filters = parseFilterParam(decoded);
     if (filters.length === 0) {
-      throw new DataExplorerError({
-        message: "Invalid filter parameter in URL",
-      });
+      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
     }
   }, [filterParam]);
 }

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
@@ -11,27 +11,49 @@ const INVALID_FILTER_PARAM_ERROR = "Invalid filter parameter in URL";
  * Throws a DataExplorerError during render if the filter param is present
  * but contains malformed JSON or an invalid filter shape, allowing the
  * ErrorBoundary to catch and display the error page.
+ * @returns Nothing; this hook performs validation and throws on invalid input.
  */
 export function useValidateFilterParam(): void {
   const { query } = useRouter();
   const filterParam = query[EXPLORE_URL_PARAMS.FILTER];
 
-  useMemo(() => {
-    if (filterParam === undefined) return;
+  const validationError = useMemo((): DataExplorerError | undefined => {
+    if (filterParam === undefined) return undefined;
+
     if (typeof filterParam !== "string") {
-      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
     }
+
     let decoded: string;
+
     try {
       decoded = decodeURIComponent(filterParam);
     } catch {
-      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
     }
-    // An empty array "[]" is a valid filter param (no filters selected).
-    if (decoded === "[]") return;
+
+    // Parse and validate the filter param.
+    // An empty array (e.g. "[]") is valid — it means no filters selected.
+    // A non-empty array with no valid entries is invalid.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decoded);
+    } catch {
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+    }
+    if (!Array.isArray(parsed)) {
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+    }
+    if (parsed.length === 0) return undefined;
     const filters = parseFilterParam(decoded);
     if (filters.length === 0) {
-      throw new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
     }
+
+    return undefined;
   }, [filterParam]);
+
+  if (validationError) {
+    throw validationError;
+  }
 }

--- a/tests/filterTypeGuards.test.ts
+++ b/tests/filterTypeGuards.test.ts
@@ -1,0 +1,94 @@
+import {
+  isSelectedFilter,
+  parseFilterParam,
+} from "../src/common/filters/typeGuards";
+
+describe("isSelectedFilter", () => {
+  it("returns true for a valid SelectedFilter", () => {
+    expect(isSelectedFilter({ categoryKey: "species", value: ["human"] })).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a SelectedFilter with empty value array", () => {
+    expect(isSelectedFilter({ categoryKey: "species", value: [] })).toBe(true);
+  });
+
+  it("returns false when categoryKey is missing", () => {
+    expect(isSelectedFilter({ value: ["human"] })).toBe(false);
+  });
+
+  it("returns false when value is missing", () => {
+    expect(isSelectedFilter({ categoryKey: "species" })).toBe(false);
+  });
+
+  it("returns false when value is not an array", () => {
+    expect(isSelectedFilter({ categoryKey: "species", value: "human" })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for wrong shape (facetName/terms)", () => {
+    expect(isSelectedFilter({ facetName: "bogus", terms: ["invalid"] })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for null", () => {
+    expect(isSelectedFilter(null)).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isSelectedFilter("not a filter")).toBe(false);
+  });
+});
+
+describe("parseFilterParam", () => {
+  it("parses a valid filter param", () => {
+    const input = JSON.stringify([
+      { categoryKey: "species", value: ["human"] },
+    ]);
+    expect(parseFilterParam(input)).toEqual([
+      { categoryKey: "species", value: ["human"] },
+    ]);
+  });
+
+  it("parses multiple valid filters", () => {
+    const input = JSON.stringify([
+      { categoryKey: "species", value: ["human"] },
+      { categoryKey: "organ", value: ["brain", "heart"] },
+    ]);
+    expect(parseFilterParam(input)).toHaveLength(2);
+  });
+
+  it("returns empty array for malformed JSON", () => {
+    expect(parseFilterParam('{"truncated')).toEqual([]);
+  });
+
+  it("returns empty array for non-array JSON", () => {
+    expect(parseFilterParam('{"categoryKey":"species"}')).toEqual([]);
+  });
+
+  it("returns empty array for wrong-shape objects", () => {
+    const input = JSON.stringify([{ facetName: "bogus", terms: ["invalid"] }]);
+    expect(parseFilterParam(input)).toEqual([]);
+  });
+
+  it("filters out invalid entries and keeps valid ones", () => {
+    const input = JSON.stringify([
+      { categoryKey: "species", value: ["human"] },
+      { facetName: "bogus", terms: ["invalid"] },
+    ]);
+    expect(parseFilterParam(input)).toEqual([
+      { categoryKey: "species", value: ["human"] },
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseFilterParam("")).toEqual([]);
+  });
+
+  it("returns empty array for valid empty array", () => {
+    expect(parseFilterParam("[]")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the infinite re-render loop when the URL contains an invalid `filter` query parameter (#898, DataBiosphere/data-browser#4776).

### Root Cause

`decodeFilterParamValue` and `initFilterState` parse filter params from the URL without validation. Malformed JSON crashes via `SyntaxError`, wrong-shape objects (e.g. `{facetName, terms}` instead of `{categoryKey, value}`) crash via `TypeError` when downstream code accesses missing properties. These functions run inside `ExploreStateProvider`'s reducer, which sits above the `ErrorBoundary` in consumer apps — so the crashes bypass error handling and trigger an infinite re-render loop as Next.js attempts recovery.

### Fix

**Defensive parsing** — `parseFilterParam` (new shared function) wraps `JSON.parse` in a try-catch and validates each entry with `isSelectedFilter`. It must not throw, as it is called from reducers above the ErrorBoundary. `decodeFilterParamValue` and `initFilterState` now delegate to it.

**Error surfacing** — `useValidateFilterParam` (new hook in ExploreView) validates the URL filter param directly and throws `DataExplorerError` inside the ErrorBoundary, rendering the error page for:
- Malformed/truncated JSON
- Wrong-shape filter objects
- (Valid-shape filters with invalid values are caught by the API returning 400, handled by existing `useAsync` error path)

The hook is memoized on the filter param to avoid re-parsing on unrelated renders.

### Additional fixes

- **ErrorBoundary**: `reset: this.render` → `reset: this.reset` — the error fallback's reset button was calling the render method instead of clearing the error state.
- **useAsync.run()**: now clears the `error` field (`{ error: undefined, status: "pending" }`) when starting a new request. Without this, if a dependency change triggers the fetch effect while a previous error exists, the stale error throws immediately on the next render before the new request can complete.
- **isSelectedFilter**: consolidated duplicate from ExploreViewLink into shared `common/filters/typeGuards.ts`. The shared version adds an `Array.isArray` check on the `value` field for stricter validation.

Closes #898

## Test plan
- [x] All existing tests pass (387/387)
- [x] New tests for `isSelectedFilter` and `parseFilterParam` (16 tests)
- [x] Manual testing: malformed JSON → error page, no loop
- [x] Manual testing: wrong shape (`facetName`/`terms`) → error page, no loop
- [x] Manual testing: valid shape, invalid values (`categoryKey`/`value`) → API 400 error page, no loop
- [x] Manual testing: valid filters work normally
- [x] Manual testing: `?filter=[]` does not false-positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1610" height="1289" alt="image" src="https://github.com/user-attachments/assets/1ba8ae7b-4add-4a0c-a6b7-2b739cb7a0cb" />

<img width="1611" height="1105" alt="image" src="https://github.com/user-attachments/assets/f0254c5e-47d6-47fb-bc3b-62ce1376822c" />

<img width="1610" height="1096" alt="image" src="https://github.com/user-attachments/assets/2540b59d-4c8d-4b09-b99c-d5fc3b880f29" />
