### PR TITLE
feat: render error for invalid categorykey in filter url param (cs filtering) (#901)

### DIFF
--- a/src/common/filters/adapters/tanstack/typeGuards.ts
+++ b/src/common/filters/adapters/tanstack/typeGuards.ts
@@ -1,0 +1,12 @@
+import type { ColumnFilter } from "@tanstack/react-table";
+
+/**
+ * Returns true if the value is a valid TanStack ColumnFilter shape.
+ * @param value - Value to check.
+ * @returns true if the value has the expected shape.
+ */
+export function isColumnFilter(value: unknown): value is ColumnFilter {
+  if (typeof value !== "object" || value === null) return false;
+  const filter = value as Record<string, unknown>;
+  return typeof filter.id === "string" && "value" in filter;
+}

--- a/src/common/filters/hooks/UseValidateFilterKeys/hook.ts
+++ b/src/common/filters/hooks/UseValidateFilterKeys/hook.ts
@@ -1,0 +1,34 @@
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+import { validateFilterParam } from "./utils";
+
+/**
+ * Generic hook that validates filter URL param keys against a provided set of
+ * valid keys. Throws a DataExplorerError during render if the filter param is
+ * present but contains malformed JSON, an invalid entry shape, or a key that
+ * is not in the valid set, allowing the ErrorBoundary to catch and display the
+ * error page.
+ * @param queryParamKey - URL query parameter key to read (e.g. "filter").
+ * @param validKeys - Set of valid keys, or undefined to skip key validation.
+ * @param entryValidator - Type guard that validates each parsed entry's shape.
+ * @param keyExtractor - Extracts the key string from a validated entry. Required when validKeys is provided.
+ */
+export function useValidateFilterKeys(
+  queryParamKey: string,
+  validKeys: Set<string> | undefined,
+  entryValidator: (value: unknown) => boolean,
+  keyExtractor?: (entry: unknown) => string,
+): void {
+  const { query } = useRouter();
+  const filterParam = query[queryParamKey];
+
+  const validationError = useMemo(
+    () =>
+      validateFilterParam(filterParam, validKeys, entryValidator, keyExtractor),
+    [entryValidator, filterParam, keyExtractor, validKeys],
+  );
+
+  if (validationError) {
+    throw validationError;
+  }
+}

--- a/src/common/filters/hooks/UseValidateFilterKeys/hook.ts
+++ b/src/common/filters/hooks/UseValidateFilterKeys/hook.ts
@@ -3,16 +3,51 @@ import { useMemo } from "react";
 import { validateFilterParam } from "./utils";
 
 /**
- * Generic hook that validates filter URL param keys against a provided set of
- * valid keys. Throws a DataExplorerError during render if the filter param is
- * present but contains malformed JSON, an invalid entry shape, or a key that
- * is not in the valid set, allowing the ErrorBoundary to catch and display the
- * error page.
+ * Validates the filter query parameter shape only (no key validation).
+ * Throws a DataExplorerError during render if the filter param is present
+ * but contains malformed JSON or an invalid entry shape.
+ * @param queryParamKey - URL query parameter key to read (e.g. "filter").
+ * @param validKeys - Must be undefined to use this overload.
+ * @param entryValidator - Type guard that validates each parsed entry's shape.
+ * @returns void; throws DataExplorerError on invalid input.
+ */
+export function useValidateFilterKeys(
+  queryParamKey: string,
+  validKeys: undefined,
+  entryValidator: (value: unknown) => boolean,
+): void;
+/**
+ * Validates the filter query parameter shape and keys against a valid set.
+ * Throws a DataExplorerError during render if the filter param is present
+ * but contains malformed JSON, an invalid entry shape, or a key that
+ * is not in the valid set.
+ * @param queryParamKey - URL query parameter key to read (e.g. "filter").
+ * @param validKeys - Set of valid keys.
+ * @param entryValidator - Type guard that validates each parsed entry's shape.
+ * @param keyExtractor - Extracts the key string from a validated entry.
+ * @returns void; throws DataExplorerError on invalid input.
+ */
+export function useValidateFilterKeys(
+  queryParamKey: string,
+  validKeys: Set<string>,
+  entryValidator: (value: unknown) => boolean,
+  keyExtractor: (entry: unknown) => string,
+): void;
+/**
+ * Validates the filter query parameter shape and, when validKeys is defined,
+ * keys against the valid set. Use when validKeys is dynamically determined.
  * @param queryParamKey - URL query parameter key to read (e.g. "filter").
  * @param validKeys - Set of valid keys, or undefined to skip key validation.
  * @param entryValidator - Type guard that validates each parsed entry's shape.
- * @param keyExtractor - Extracts the key string from a validated entry. Required when validKeys is provided.
+ * @param keyExtractor - Extracts the key string from a validated entry.
+ * @returns void; throws DataExplorerError on invalid input.
  */
+export function useValidateFilterKeys(
+  queryParamKey: string,
+  validKeys: Set<string> | undefined,
+  entryValidator: (value: unknown) => boolean,
+  keyExtractor: (entry: unknown) => string,
+): void;
 export function useValidateFilterKeys(
   queryParamKey: string,
   validKeys: Set<string> | undefined,
@@ -22,11 +57,17 @@ export function useValidateFilterKeys(
   const { query } = useRouter();
   const filterParam = query[queryParamKey];
 
-  const validationError = useMemo(
-    () =>
-      validateFilterParam(filterParam, validKeys, entryValidator, keyExtractor),
-    [entryValidator, filterParam, keyExtractor, validKeys],
-  );
+  const validationError = useMemo(() => {
+    if (validKeys && keyExtractor) {
+      return validateFilterParam(
+        filterParam,
+        validKeys,
+        entryValidator,
+        keyExtractor,
+      );
+    }
+    return validateFilterParam(filterParam, undefined, entryValidator);
+  }, [entryValidator, filterParam, keyExtractor, validKeys]);
 
   if (validationError) {
     throw validationError;

--- a/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
+++ b/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
@@ -1,0 +1,69 @@
+import { DataExplorerError } from "../../../../types/error";
+
+const INVALID_FILTER_PARAM = "Invalid filter parameter in URL";
+const INVALID_FILTER_SHAPE = "Invalid filter entry shape in URL";
+const UNKNOWN_FILTER_KEY = "Unknown filter key in URL";
+
+/**
+ * Validates a filter query parameter value against a set of valid keys.
+ * Returns a DataExplorerError if the param is malformed, has an invalid
+ * entry shape, or contains a key not in the valid set.
+ * @param filterParam - Raw URL query param value.
+ * @param validKeys - Set of valid keys, or undefined to skip key validation.
+ * @param entryValidator - Type guard that validates each parsed entry's shape.
+ * @param keyExtractor - Extracts the key string from a validated entry. Required when validKeys is provided.
+ * @returns DataExplorerError if invalid, undefined if valid.
+ */
+export function validateFilterParam(
+  filterParam: string | string[] | undefined,
+  validKeys: Set<string> | undefined,
+  entryValidator: (value: unknown) => boolean,
+  keyExtractor?: (entry: unknown) => string,
+): DataExplorerError | undefined {
+  if (filterParam === undefined) return undefined;
+
+  if (typeof filterParam !== "string") {
+    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+  }
+
+  let decoded: string;
+
+  try {
+    decoded = decodeURIComponent(filterParam);
+  } catch {
+    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+  }
+
+  if (!Array.isArray(parsed)) {
+    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+  }
+
+  // An empty array (e.g. "[]") is valid — it means no filters selected.
+  if (parsed.length === 0) return undefined;
+
+  // Validate shape: every entry must match the expected shape.
+  if (!parsed.every(entryValidator)) {
+    return new DataExplorerError({ message: INVALID_FILTER_SHAPE });
+  }
+
+  // Validate keys: every extracted key must be in the valid set.
+  if (validKeys && keyExtractor) {
+    const invalidKey = parsed
+      .map(keyExtractor)
+      .find((key) => !validKeys.has(key));
+    if (invalidKey !== undefined) {
+      return new DataExplorerError({
+        message: `${UNKNOWN_FILTER_KEY}: ${invalidKey}`,
+      });
+    }
+  }
+
+  return undefined;
+}

--- a/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
+++ b/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
@@ -42,19 +42,17 @@ export function validateFilterParam(
     return new DataExplorerError({ message: INVALID_FILTER_PARAM });
   }
 
-  let decoded: string;
-
-  try {
-    decoded = decodeURIComponent(filterParam);
-  } catch {
-    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
-  }
-
+  // Try JSON.parse directly first (Next.js router.query already decodes),
+  // then fall back to decodeURIComponent + JSON.parse for encoded values.
   let parsed: unknown;
   try {
-    parsed = JSON.parse(decoded);
+    parsed = JSON.parse(filterParam);
   } catch {
-    return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+    try {
+      parsed = JSON.parse(decodeURIComponent(filterParam));
+    } catch {
+      return new DataExplorerError({ message: INVALID_FILTER_PARAM });
+    }
   }
 
   if (!Array.isArray(parsed)) {

--- a/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
+++ b/src/common/filters/hooks/UseValidateFilterKeys/utils.ts
@@ -5,15 +5,31 @@ const INVALID_FILTER_SHAPE = "Invalid filter entry shape in URL";
 const UNKNOWN_FILTER_KEY = "Unknown filter key in URL";
 
 /**
- * Validates a filter query parameter value against a set of valid keys.
- * Returns a DataExplorerError if the param is malformed, has an invalid
- * entry shape, or contains a key not in the valid set.
+ * Validates a filter query parameter value (shape only, no key validation).
  * @param filterParam - Raw URL query param value.
- * @param validKeys - Set of valid keys, or undefined to skip key validation.
+ * @param validKeys - Must be undefined to use this overload.
  * @param entryValidator - Type guard that validates each parsed entry's shape.
- * @param keyExtractor - Extracts the key string from a validated entry. Required when validKeys is provided.
  * @returns DataExplorerError if invalid, undefined if valid.
  */
+export function validateFilterParam(
+  filterParam: string | string[] | undefined,
+  validKeys: undefined,
+  entryValidator: (value: unknown) => boolean,
+): DataExplorerError | undefined;
+/**
+ * Validates a filter query parameter value against a set of valid keys.
+ * @param filterParam - Raw URL query param value.
+ * @param validKeys - Set of valid keys.
+ * @param entryValidator - Type guard that validates each parsed entry's shape.
+ * @param keyExtractor - Extracts the key string from a validated entry.
+ * @returns DataExplorerError if invalid, undefined if valid.
+ */
+export function validateFilterParam(
+  filterParam: string | string[] | undefined,
+  validKeys: Set<string>,
+  entryValidator: (value: unknown) => boolean,
+  keyExtractor: (entry: unknown) => string,
+): DataExplorerError | undefined;
 export function validateFilterParam(
   filterParam: string | string[] | undefined,
   validKeys: Set<string> | undefined,

--- a/src/common/filters/typeGuards.ts
+++ b/src/common/filters/typeGuards.ts
@@ -1,4 +1,4 @@
-import { SelectedFilter } from "../entities";
+import type { SelectedFilter } from "../entities";
 
 /**
  * Returns true if the value is a valid SelectedFilter.

--- a/src/components/DataDictionary/dataDictionary.tsx
+++ b/src/components/DataDictionary/dataDictionary.tsx
@@ -1,10 +1,13 @@
 import { Fade } from "@mui/material";
 import { RowData } from "@tanstack/react-table";
-import { JSX } from "react";
+import { JSX, useMemo } from "react";
 import { Attribute } from "../../common/entities";
+import { isColumnFilter } from "../../common/filters/adapters/tanstack/typeGuards";
+import { useValidateFilterKeys } from "../../common/filters/hooks/UseValidateFilterKeys/hook";
 import { PROPERTY } from "../../hooks/useHtmlStyle/constants";
 import { useHtmlStyle } from "../../hooks/useHtmlStyle/hook";
 import { useLayoutSpacing } from "../../hooks/UseLayoutSpacing/hook";
+import { DATA_DICTIONARY_URL_PARAMS } from "../../providers/dataDictionaryState/dictionaries/constants";
 import { Description } from "./components/Description/description";
 import { Entities } from "./components/Entities/entities";
 import { ColumnFilterTags } from "./components/Filters/components/ColumnFilterTags/columnFilterTags";
@@ -21,6 +24,7 @@ import { View } from "./dataDictionary.styles";
 import { useDataDictionaryConfig } from "./hooks/UseDataDictionaryConfig/hook";
 import { useMeasureFilters } from "./hooks/UseMeasureFilters/hook";
 import { DataDictionaryProps } from "./types";
+import { extractColumnId, getValidColumnIds } from "./utils";
 
 export const DataDictionary = <T extends RowData = Attribute>({
   className,
@@ -46,6 +50,16 @@ export const DataDictionary = <T extends RowData = Attribute>({
 
   // Table instance.
   const table = useTable<T>(dictionary, classes, tableOptions);
+
+  // Validate filter URL param keys against the table's column IDs.
+  const validColumnIds = useMemo(() => getValidColumnIds(table), [table]);
+
+  useValidateFilterKeys(
+    DATA_DICTIONARY_URL_PARAMS.COLUMN_FILTERS,
+    validColumnIds,
+    isColumnFilter,
+    extractColumnId,
+  );
 
   // Dictionary outline.
   const outline = buildClassesOutline<T>(table);

--- a/src/components/DataDictionary/utils.ts
+++ b/src/components/DataDictionary/utils.ts
@@ -1,0 +1,21 @@
+import type { ColumnFilter, RowData, Table } from "@tanstack/react-table";
+
+/**
+ * Extracts the column ID from a validated ColumnFilter entry.
+ * @param entry - Validated entry.
+ * @returns column ID.
+ */
+export function extractColumnId(entry: unknown): string {
+  return (entry as ColumnFilter).id;
+}
+
+/**
+ * Returns the set of valid column IDs from a TanStack table instance.
+ * @param table - TanStack table instance.
+ * @returns set of valid column IDs.
+ */
+export function getValidColumnIds<T extends RowData>(
+  table: Table<T>,
+): Set<string> {
+  return new Set(table.getAllColumns().map((column) => column.id));
+}

--- a/src/providers/exploreState/initializer/utils.ts
+++ b/src/providers/exploreState/initializer/utils.ts
@@ -120,7 +120,7 @@ function columnFiltersToSelectedFilters(
  * @param entityConfig - Entity config.
  * @returns entity related category group config.
  */
-function getEntityCategoryGroupConfig(
+export function getEntityCategoryGroupConfig(
   siteConfig: SiteConfig,
   entityConfig: EntityConfig,
 ): CategoryGroupConfig | undefined {

--- a/src/views/DataDictionaryView/dataDictionaryView.tsx
+++ b/src/views/DataDictionaryView/dataDictionaryView.tsx
@@ -1,10 +1,13 @@
 import { JSX } from "react";
+import { isColumnFilter } from "../../common/filters/adapters/tanstack/typeGuards";
+import { useValidateFilterKeys } from "../../common/filters/hooks/UseValidateFilterKeys/hook";
 import { DataDictionary } from "../../components/DataDictionary/dataDictionary";
 import { useStateSyncManager } from "../../hooks/stateSyncManager/hook";
 import { DataDictionaryContext } from "../../providers/dataDictionary/context";
 import { clearMeta } from "../../providers/dataDictionaryState/actions/clearMeta/dispatch";
 import { stateToUrl } from "../../providers/dataDictionaryState/actions/stateToUrl/dispatch";
 import { urlToState } from "../../providers/dataDictionaryState/actions/urlToState/dispatch";
+import { DATA_DICTIONARY_URL_PARAMS } from "../../providers/dataDictionaryState/dictionaries/constants";
 import { useDataDictionaryState } from "../../providers/dataDictionaryState/hooks/UseDataDictionaryState/hook";
 import { DataDictionaryViewProps } from "./types";
 import { buildStateSyncManagerContext } from "./utils";
@@ -15,6 +18,14 @@ export const DataDictionaryView = ({
 }: DataDictionaryViewProps): JSX.Element => {
   const { dataDictionaryDispatch, dataDictionaryState } =
     useDataDictionaryState();
+
+  // Shape-only validation (no key check) — must run before useStateSyncManager
+  // to prevent malformed entries from being dispatched into state.
+  useValidateFilterKeys(
+    DATA_DICTIONARY_URL_PARAMS.COLUMN_FILTERS,
+    undefined,
+    isColumnFilter,
+  );
 
   useStateSyncManager({
     actions: { clearMeta, stateToUrl, urlToState },

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
@@ -1,59 +1,28 @@
-import { useRouter } from "next/router";
 import { useMemo } from "react";
-import { parseFilterParam } from "../../../../common/filters/typeGuards";
+import { useValidateFilterKeys } from "../../../../common/filters/hooks/UseValidateFilterKeys/hook";
+import { isSelectedFilter } from "../../../../common/filters/typeGuards";
+import { useConfig } from "../../../../hooks/useConfig";
 import { EXPLORE_URL_PARAMS } from "../../../../providers/exploreState/constants";
-import { DataExplorerError } from "../../../../types/error";
-
-const INVALID_FILTER_PARAM_ERROR = "Invalid filter parameter in URL";
+import { extractCategoryKey, getValidCategoryKeys } from "./utils";
 
 /**
- * Validates the filter query parameter from the URL.
+ * Validates the filter query parameter from the URL for the ExploreView.
  * Throws a DataExplorerError during render if the filter param is present
- * but contains malformed JSON or an invalid filter shape, allowing the
+ * but contains malformed JSON, an invalid filter shape, or a categoryKey
+ * that does not exist in the configured categories, allowing the
  * ErrorBoundary to catch and display the error page.
- * @returns Nothing; this hook performs validation and throws on invalid input.
  */
 export function useValidateFilterParam(): void {
-  const { query } = useRouter();
-  const filterParam = query[EXPLORE_URL_PARAMS.FILTER];
+  const { config, entityConfig } = useConfig();
+  const validKeys = useMemo(
+    () => getValidCategoryKeys(config, entityConfig),
+    [config, entityConfig],
+  );
 
-  const validationError = useMemo((): DataExplorerError | undefined => {
-    if (filterParam === undefined) return undefined;
-
-    if (typeof filterParam !== "string") {
-      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
-    }
-
-    let decoded: string;
-
-    try {
-      decoded = decodeURIComponent(filterParam);
-    } catch {
-      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
-    }
-
-    // Parse and validate the filter param.
-    // An empty array (e.g. "[]") is valid — it means no filters selected.
-    // A non-empty array with no valid entries is invalid.
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(decoded);
-    } catch {
-      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
-    }
-    if (!Array.isArray(parsed)) {
-      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
-    }
-    if (parsed.length === 0) return undefined;
-    const filters = parseFilterParam(decoded);
-    if (filters.length === 0) {
-      return new DataExplorerError({ message: INVALID_FILTER_PARAM_ERROR });
-    }
-
-    return undefined;
-  }, [filterParam]);
-
-  if (validationError) {
-    throw validationError;
-  }
+  useValidateFilterKeys(
+    EXPLORE_URL_PARAMS.FILTER,
+    validKeys,
+    isSelectedFilter,
+    extractCategoryKey,
+  );
 }

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/hook.ts
@@ -11,6 +11,7 @@ import { extractCategoryKey, getValidCategoryKeys } from "./utils";
  * but contains malformed JSON, an invalid filter shape, or a categoryKey
  * that does not exist in the configured categories, allowing the
  * ErrorBoundary to catch and display the error page.
+ * @returns void; throws DataExplorerError on invalid input.
  */
 export function useValidateFilterParam(): void {
   const { config, entityConfig } = useConfig();

--- a/src/views/ExploreView/hooks/UseValidateFilterParam/utils.ts
+++ b/src/views/ExploreView/hooks/UseValidateFilterParam/utils.ts
@@ -1,0 +1,38 @@
+import type { SelectedFilter } from "../../../../common/entities";
+import type { EntityConfig, SiteConfig } from "../../../../config/entities";
+import { getEntityCategoryGroupConfig } from "../../../../providers/exploreState/initializer/utils";
+
+/**
+ * Extracts the categoryKey from a validated SelectedFilter entry.
+ * @param entry - Validated entry.
+ * @returns category key.
+ */
+export function extractCategoryKey(entry: unknown): string {
+  return (entry as SelectedFilter).categoryKey;
+}
+
+/**
+ * Returns the set of valid category keys for the given entity, derived from
+ * the entity's category group config. Returns undefined if no category group
+ * config is available (skipping key validation).
+ * @param config - Site config.
+ * @param entityConfig - Entity config.
+ * @returns set of valid category keys, or undefined.
+ */
+export function getValidCategoryKeys(
+  config: SiteConfig,
+  entityConfig: EntityConfig,
+): Set<string> | undefined {
+  const categoryGroupConfig = getEntityCategoryGroupConfig(
+    config,
+    entityConfig,
+  );
+  if (!categoryGroupConfig) return undefined;
+  const keys = new Set<string>();
+  for (const group of categoryGroupConfig.categoryGroups) {
+    for (const categoryConfig of group.categoryConfigs) {
+      keys.add(categoryConfig.key);
+    }
+  }
+  return keys;
+}

--- a/tests/validateFilterKeys.test.ts
+++ b/tests/validateFilterKeys.test.ts
@@ -1,0 +1,244 @@
+import type { RowData, Table } from "@tanstack/react-table";
+import { isColumnFilter } from "../src/common/filters/adapters/tanstack/typeGuards";
+import { validateFilterParam } from "../src/common/filters/hooks/UseValidateFilterKeys/utils";
+import { getValidColumnIds } from "../src/components/DataDictionary/utils";
+import type {
+  CategoryGroupConfig,
+  EntityConfig,
+  SiteConfig,
+} from "../src/config/entities";
+import { DataExplorerError } from "../src/types/error";
+import { getValidCategoryKeys } from "../src/views/ExploreView/hooks/UseValidateFilterParam/utils";
+
+// Simple validator/extractor for testing validateFilterParam.
+const isEntry = (v: unknown): boolean =>
+  typeof v === "object" && v !== null && "key" in v;
+const extractKey = (v: unknown): string => (v as { key: string }).key;
+
+describe("validateFilterParam", () => {
+  it("returns undefined for undefined param", () => {
+    expect(
+      validateFilterParam(undefined, new Set(["a"]), isEntry, extractKey),
+    ).toBeUndefined();
+  });
+
+  it("returns error for non-string param (string array)", () => {
+    const result = validateFilterParam(
+      ["a", "b"],
+      undefined,
+      isEntry,
+      extractKey,
+    );
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Invalid filter parameter in URL");
+  });
+
+  it("returns error for malformed URI encoding", () => {
+    const result = validateFilterParam(
+      "%E0%A4%A",
+      undefined,
+      isEntry,
+      extractKey,
+    );
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Invalid filter parameter in URL");
+  });
+
+  it("returns error for invalid JSON", () => {
+    const result = validateFilterParam(
+      '{"truncated',
+      undefined,
+      isEntry,
+      extractKey,
+    );
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Invalid filter parameter in URL");
+  });
+
+  it("returns error for non-array JSON", () => {
+    const result = validateFilterParam(
+      '{"key":"a"}',
+      undefined,
+      isEntry,
+      extractKey,
+    );
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Invalid filter parameter in URL");
+  });
+
+  it("returns undefined for empty array", () => {
+    expect(
+      validateFilterParam("[]", new Set(["a"]), isEntry, extractKey),
+    ).toBeUndefined();
+  });
+
+  it("returns error when entries fail shape validation", () => {
+    const param = JSON.stringify(["not an object"]);
+    const result = validateFilterParam(param, undefined, isEntry, extractKey);
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Invalid filter entry shape in URL");
+  });
+
+  it("returns undefined when entries pass shape validation and no valid keys", () => {
+    const param = JSON.stringify([{ key: "a" }]);
+    expect(
+      validateFilterParam(param, undefined, isEntry, extractKey),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when all keys are valid", () => {
+    const param = JSON.stringify([{ key: "a" }, { key: "b" }]);
+    expect(
+      validateFilterParam(param, new Set(["a", "b", "c"]), isEntry, extractKey),
+    ).toBeUndefined();
+  });
+
+  it("returns error with offending key when a key is not in the valid set", () => {
+    const param = JSON.stringify([{ key: "a" }, { key: "bogus" }]);
+    const result = validateFilterParam(
+      param,
+      new Set(["a", "b"]),
+      isEntry,
+      extractKey,
+    );
+    expect(result).toBeInstanceOf(DataExplorerError);
+    expect(result?.message).toBe("Unknown filter key in URL: bogus");
+  });
+
+  it("skips key validation when validKeys is undefined", () => {
+    const param = JSON.stringify([{ key: "anything" }]);
+    expect(
+      validateFilterParam(param, undefined, isEntry, extractKey),
+    ).toBeUndefined();
+  });
+
+  it("handles URI-encoded param", () => {
+    const raw = JSON.stringify([{ key: "a" }]);
+    const encoded = encodeURIComponent(raw);
+    expect(
+      validateFilterParam(encoded, new Set(["a"]), isEntry, extractKey),
+    ).toBeUndefined();
+  });
+});
+
+describe("isColumnFilter", () => {
+  it("returns true for a valid ColumnFilter", () => {
+    expect(isColumnFilter({ id: "name", value: "test" })).toBe(true);
+  });
+
+  it("returns true for a ColumnFilter with array value", () => {
+    expect(isColumnFilter({ id: "status", value: ["active", "pending"] })).toBe(
+      true,
+    );
+  });
+
+  it("returns true for a ColumnFilter with null value", () => {
+    expect(isColumnFilter({ id: "name", value: null })).toBe(true);
+  });
+
+  it("returns false when id is missing", () => {
+    expect(isColumnFilter({ value: "test" })).toBe(false);
+  });
+
+  it("returns false when value is missing", () => {
+    expect(isColumnFilter({ id: "name" })).toBe(false);
+  });
+
+  it("returns false when id is not a string", () => {
+    expect(isColumnFilter({ id: 123, value: "test" })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isColumnFilter(null)).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isColumnFilter("not a filter")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isColumnFilter(undefined)).toBe(false);
+  });
+});
+
+describe("getValidCategoryKeys", () => {
+  const buildConfig = (
+    entityCategoryGroupConfig?: CategoryGroupConfig,
+    siteCategoryGroupConfig?: CategoryGroupConfig,
+  ): { config: SiteConfig; entityConfig: EntityConfig } => {
+    const entityConfig = {
+      categoryGroupConfig: entityCategoryGroupConfig,
+    } as EntityConfig;
+    const config = {
+      categoryGroupConfig: siteCategoryGroupConfig,
+    } as SiteConfig;
+    return { config, entityConfig };
+  };
+
+  it("returns keys from entity category group config", () => {
+    const { config, entityConfig } = buildConfig({
+      categoryGroups: [
+        {
+          categoryConfigs: [
+            { key: "species", label: "Species" },
+            { key: "organ", label: "Organ" },
+          ],
+        },
+        {
+          categoryConfigs: [{ key: "library", label: "Library" }],
+        },
+      ],
+      key: "test",
+    });
+    const result = getValidCategoryKeys(config, entityConfig);
+    expect(result).toEqual(new Set(["species", "organ", "library"]));
+  });
+
+  it("falls back to site category group config when entity has none", () => {
+    const { config, entityConfig } = buildConfig(undefined, {
+      categoryGroups: [
+        {
+          categoryConfigs: [{ key: "project", label: "Project" }],
+        },
+      ],
+      key: "site",
+    });
+    const result = getValidCategoryKeys(config, entityConfig);
+    expect(result).toEqual(new Set(["project"]));
+  });
+
+  it("returns undefined when no category group config exists", () => {
+    const { config, entityConfig } = buildConfig(undefined, undefined);
+    const result = getValidCategoryKeys(config, entityConfig);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns empty set when category groups have no configs", () => {
+    const { config, entityConfig } = buildConfig({
+      categoryGroups: [{ categoryConfigs: [] }],
+      key: "empty",
+    });
+    const result = getValidCategoryKeys(config, entityConfig);
+    expect(result).toEqual(new Set());
+  });
+});
+
+describe("getValidColumnIds", () => {
+  const buildTable = (columnIds: string[]): Table<RowData> => {
+    return {
+      getAllColumns: () => columnIds.map((id) => ({ id })),
+    } as unknown as Table<RowData>;
+  };
+
+  it("returns column IDs from table instance", () => {
+    const table = buildTable(["name", "type", "description"]);
+    expect(getValidColumnIds(table)).toEqual(
+      new Set(["name", "type", "description"]),
+    );
+  });
+
+  it("returns empty set when table has no columns", () => {
+    const table = buildTable([]);
+    expect(getValidColumnIds(table)).toEqual(new Set());
+  });
+});


### PR DESCRIPTION
## Summary

- Adds shared `useValidateFilterKeys` hook that validates filter URL param keys against a set of valid keys, throwing `DataExplorerError` for the ErrorBoundary
- Refactors ExploreView's `useValidateFilterParam` to delegate to the shared hook, adding categoryKey validation against configured categories
- Adds two-tier validation for DataDictionary: shape-only check in the view (before state sync), key validation in the component (after table creation using the table instance)
- Moves `isColumnFilter` type guard to `common/filters/adapters/tanstack/typeGuards.ts` for reuse across TanStack adapter tables
- Differentiated error messages: malformed param, invalid shape, unknown key (includes the offending key name)
- Exports `getEntityCategoryGroupConfig` for reuse by the ExploreView adapter

Closes #901

## Test plan

- [x] `npx tsc --noEmit` compiles clean
- [x] `npm test` — 414/414 tests pass (27 new tests for `validateFilterParam`, `isColumnFilter`, `getValidCategoryKeys`, `getValidColumnIds`)
- [x] Manual: ExploreView with `?filter=[{"categoryKey":"bogus","value":["x"]}]` → error page
- [x] Manual: DataDictionary with `?filter=[{"id":"bogus","value":["x"]}]` → error page
- [x] Manual: valid filters still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1003" height="816" alt="image" src="https://github.com/user-attachments/assets/09c27f83-9d4a-4f9b-85fd-992af65cbb51" />

<img width="550" height="448" alt="image" src="https://github.com/user-attachments/assets/0d2a8039-231b-4514-b163-399e97b83822" />

<img width="820" height="670" alt="image" src="https://github.com/user-attachments/assets/9eccb69b-eb25-4990-8b5e-224ab0a7d2fc" />

<img width="821" height="671" alt="image" src="https://github.com/user-attachments/assets/88d59e1b-58cb-4aba-8719-60a8ba1c9966" />

<img width="734" height="597" alt="image" src="https://github.com/user-attachments/assets/627d3754-8ac7-41a0-9547-a22503d1b1d5" />
