### PR TITLE
feat!: support oauth authorization code flow (#906)

### DIFF
--- a/src/config/entities.ts
+++ b/src/config/entities.ts
@@ -285,6 +285,7 @@ export interface ListViewConfig {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
 export interface OAuthProvider<P = any> {
   authorization: { params: { scope: string } };
+  authorize?: string; // Backend authorize endpoint that exchanges an OAuth authorization code for a token set. When set, the authorization code flow is used; otherwise the implicit token flow is used.
   clientId: string;
   icon: ReactNode;
   id: ProviderId;

--- a/src/config/entities.ts
+++ b/src/config/entities.ts
@@ -282,10 +282,14 @@ export interface ListViewConfig {
   rowSelectionView?: ComponentsConfig;
 }
 
+export enum OAUTH_FLOW {
+  AUTHORIZATION_CODE = "AUTHORIZATION_CODE",
+  IMPLICIT = "IMPLICIT",
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
-export interface OAuthProvider<P = any> {
+interface OAuthProviderBase<P = any> {
   authorization: { params: { scope: string } };
-  authorize?: string; // Backend authorize endpoint that exchanges an OAuth authorization code for a token set. When set, the authorization code flow is used; otherwise the implicit token flow is used.
   clientId: string;
   icon: ReactNode;
   id: ProviderId;
@@ -293,6 +297,24 @@ export interface OAuthProvider<P = any> {
   profile: (profile: P) => UserProfile;
   userinfo: string;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
+export interface ImplicitFlowProvider<P = any> extends OAuthProviderBase<P> {
+  flow: OAUTH_FLOW.IMPLICIT;
+}
+
+export interface AuthorizationCodeFlowProvider<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
+  P = any,
+> extends OAuthProviderBase<P> {
+  authorize: string; // Backend endpoint that exchanges an OAuth authorization code for a token set.
+  flow: OAUTH_FLOW.AUTHORIZATION_CODE;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
+export type OAuthProvider<P = any> =
+  | ImplicitFlowProvider<P>
+  | AuthorizationCodeFlowProvider<P>;
 
 /**
  * Option Method.

--- a/src/google/service.ts
+++ b/src/google/service.ts
@@ -36,21 +36,22 @@ export const service = {
     >,
   ): void => {
     const { authorize, id, profile, userinfo } = provider;
+    const resetSession = (): void => {
+      dispatch.authDispatch?.(resetAuthState());
+      dispatch.authenticationDispatch?.(
+        updateAuthentication({
+          profile: undefined,
+          status: AUTHENTICATION_STATUS.SETTLED,
+        }),
+      );
+      dispatch.tokenDispatch?.(resetTokenState());
+    };
     const onAccessToken = (token: string): void => {
       dispatch.authDispatch?.(requestAuth());
       dispatch.authenticationDispatch?.(requestAuthentication());
       dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
       fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
-        onError: () => {
-          dispatch.authDispatch?.(resetAuthState());
-          dispatch.authenticationDispatch?.(
-            updateAuthentication({
-              profile: undefined,
-              status: AUTHENTICATION_STATUS.SETTLED,
-            }),
-          );
-          dispatch.tokenDispatch?.(resetTokenState());
-        },
+        onError: resetSession,
         onSuccess: (r: GoogleProfile) =>
           dispatch.authenticationDispatch?.(
             updateAuthentication({
@@ -68,10 +69,19 @@ export const service = {
             headers: { "Content-Type": "application/json" },
             method: "POST",
           })
-            .then((r) => r.json())
-            .then((tokens: TokenSetParameters) =>
-              onAccessToken(tokens.access_token),
-            );
+            .then((r) => {
+              if (!r.ok) {
+                throw new Error(`authorize request failed (${r.status})`);
+              }
+              return r.json();
+            })
+            .then((tokens: TokenSetParameters) => {
+              if (!tokens?.access_token) {
+                throw new Error("authorize response missing access_token");
+              }
+              onAccessToken(tokens.access_token);
+            })
+            .catch(resetSession);
         },
         client_id: provider.clientId,
         scope: provider.authorization.params.scope,

--- a/src/google/service.ts
+++ b/src/google/service.ts
@@ -35,45 +35,57 @@ export const service = {
       "authDispatch" | "authenticationDispatch" | "tokenDispatch"
     >,
   ): void => {
-    const client = google.accounts.oauth2.initCodeClient({
-      callback: (response: CodeResponse) => {
-        const { id, profile, userinfo } = provider;
-        fetch("https://service.hannes2.anvil.gi.ucsc.edu/user/authorize", {
-          body: JSON.stringify(response),
-          headers: { "Content-Type": "application/json" },
-          method: "POST",
-        })
-          .then((r) => r.json())
-          .then((tokens: TokenSetParameters) => {
-            const { access_token: token } = tokens;
-            dispatch.authDispatch?.(requestAuth());
-            dispatch.authenticationDispatch?.(requestAuthentication());
-            dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
-            fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
-              onError: () => {
-                dispatch.authDispatch?.(resetAuthState());
-                dispatch.authenticationDispatch?.(
-                  updateAuthentication({
-                    profile: undefined,
-                    status: AUTHENTICATION_STATUS.SETTLED,
-                  }),
-                );
-                dispatch.tokenDispatch?.(resetTokenState());
-              },
-              onSuccess: (r: GoogleProfile) =>
-                dispatch.authenticationDispatch?.(
-                  updateAuthentication({
-                    profile: profile(r),
-                    status: AUTHENTICATION_STATUS.PENDING, // Authentication is pending until session controller is resolved.
-                  }),
-                ),
-            });
-          });
-      },
-      client_id: provider.clientId,
-      scope: provider.authorization.params.scope,
-    });
-    client.requestCode();
+    const { authorize, id, profile, userinfo } = provider;
+    const onAccessToken = (token: string): void => {
+      dispatch.authDispatch?.(requestAuth());
+      dispatch.authenticationDispatch?.(requestAuthentication());
+      dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
+      fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
+        onError: () => {
+          dispatch.authDispatch?.(resetAuthState());
+          dispatch.authenticationDispatch?.(
+            updateAuthentication({
+              profile: undefined,
+              status: AUTHENTICATION_STATUS.SETTLED,
+            }),
+          );
+          dispatch.tokenDispatch?.(resetTokenState());
+        },
+        onSuccess: (r: GoogleProfile) =>
+          dispatch.authenticationDispatch?.(
+            updateAuthentication({
+              profile: profile(r),
+              status: AUTHENTICATION_STATUS.PENDING, // Authentication is pending until session controller is resolved.
+            }),
+          ),
+      });
+    };
+    if (authorize) {
+      const client = google.accounts.oauth2.initCodeClient({
+        callback: (response: CodeResponse) => {
+          fetch(authorize, {
+            body: JSON.stringify(response),
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+          })
+            .then((r) => r.json())
+            .then((tokens: TokenSetParameters) =>
+              onAccessToken(tokens.access_token),
+            );
+        },
+        client_id: provider.clientId,
+        scope: provider.authorization.params.scope,
+      });
+      client.requestCode();
+    } else {
+      const client = google.accounts.oauth2.initTokenClient({
+        callback: (response: TokenSetParameters) =>
+          onAccessToken(response.access_token),
+        client_id: provider.clientId,
+        scope: provider.authorization.params.scope,
+      });
+      client.requestAccessToken();
+    }
   },
   /**
    * Logout and clear all auth state.

--- a/src/google/service.ts
+++ b/src/google/service.ts
@@ -1,23 +1,8 @@
-import { requestAuth, resetAuthState } from "../auth/dispatch/auth";
-import {
-  requestAuthentication,
-  resetAuthenticationState,
-  updateAuthentication,
-} from "../auth/dispatch/authentication";
-import { resetCredentialsState } from "../auth/dispatch/credentials";
-import { resetTokenState, updateToken } from "../auth/dispatch/token";
-import { AUTHENTICATION_STATUS } from "../auth/types/authentication";
-import { OAuthProvider } from "../config/entities";
-import type {
-  CodeResponse,
-  GoogleProfile,
-  SessionDispatch,
-  TokenSetParameters,
-} from "./types";
-import { fetchProfile, getAuthenticationRequestOptions } from "./utils/auth";
-
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any -- TODO see https://github.com/clevercanary/data-browser/issues/544.
-declare const google: any;
+import type { OAuthProvider } from "../config/entities";
+import { login as authorizationCodeFlowLogin } from "./services/authorizationCodeFlow";
+import { logout, type LoginDispatch } from "./services/common";
+import { login as implicitFlowLogin } from "./services/implicitFlow";
+import type { SessionDispatch } from "./types";
 
 /**
  * Google Sign-In service.
@@ -25,76 +10,15 @@ declare const google: any;
 export const service = {
   /**
    * Login with Google OAuth.
+   * Selects the authorization code flow or implicit flow based on provider configuration.
    * @param provider - OAuth provider configuration.
    * @param dispatch - Dispatch functions for auth state.
    */
-  login: (
-    provider: OAuthProvider,
-    dispatch: Pick<
-      SessionDispatch,
-      "authDispatch" | "authenticationDispatch" | "tokenDispatch"
-    >,
-  ): void => {
-    const { authorize, id, profile, userinfo } = provider;
-    const resetSession = (): void => {
-      dispatch.authDispatch?.(resetAuthState());
-      dispatch.authenticationDispatch?.(
-        updateAuthentication({
-          profile: undefined,
-          status: AUTHENTICATION_STATUS.SETTLED,
-        }),
-      );
-      dispatch.tokenDispatch?.(resetTokenState());
-    };
-    const onAccessToken = (token: string): void => {
-      dispatch.authDispatch?.(requestAuth());
-      dispatch.authenticationDispatch?.(requestAuthentication());
-      dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
-      fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
-        onError: resetSession,
-        onSuccess: (r: GoogleProfile) =>
-          dispatch.authenticationDispatch?.(
-            updateAuthentication({
-              profile: profile(r),
-              status: AUTHENTICATION_STATUS.PENDING, // Authentication is pending until session controller is resolved.
-            }),
-          ),
-      });
-    };
-    if (authorize) {
-      const client = google.accounts.oauth2.initCodeClient({
-        callback: (response: CodeResponse) => {
-          fetch(authorize, {
-            body: JSON.stringify(response),
-            headers: { "Content-Type": "application/json" },
-            method: "POST",
-          })
-            .then((r) => {
-              if (!r.ok) {
-                throw new Error(`authorize request failed (${r.status})`);
-              }
-              return r.json();
-            })
-            .then((tokens: TokenSetParameters) => {
-              if (!tokens?.access_token) {
-                throw new Error("authorize response missing access_token");
-              }
-              onAccessToken(tokens.access_token);
-            })
-            .catch(resetSession);
-        },
-        client_id: provider.clientId,
-        scope: provider.authorization.params.scope,
-      });
-      client.requestCode();
+  login: (provider: OAuthProvider, dispatch: LoginDispatch): void => {
+    if (provider.authorize) {
+      authorizationCodeFlowLogin(provider, dispatch);
     } else {
-      const client = google.accounts.oauth2.initTokenClient({
-        callback: (response: TokenSetParameters) =>
-          onAccessToken(response.access_token),
-        client_id: provider.clientId,
-        scope: provider.authorization.params.scope,
-      });
-      client.requestAccessToken();
+      implicitFlowLogin(provider, dispatch);
     }
   },
   /**
@@ -102,9 +26,6 @@ export const service = {
    * @param dispatch - Dispatch functions for auth state.
    */
   logout: (dispatch: SessionDispatch): void => {
-    dispatch.authDispatch?.(resetAuthState());
-    dispatch.authenticationDispatch?.(resetAuthenticationState());
-    dispatch.credentialsDispatch?.(resetCredentialsState());
-    dispatch.tokenDispatch?.(resetTokenState());
+    logout(dispatch);
   },
 };

--- a/src/google/service.ts
+++ b/src/google/service.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvider } from "../config/entities";
+import { OAUTH_FLOW, type OAuthProvider } from "../config/entities";
 import { login as authorizationCodeFlowLogin } from "./services/authorizationCodeFlow";
 import { logout, type LoginDispatch } from "./services/common";
 import { login as implicitFlowLogin } from "./services/implicitFlow";
@@ -10,12 +10,12 @@ import type { SessionDispatch } from "./types";
 export const service = {
   /**
    * Login with Google OAuth.
-   * Selects the authorization code flow or implicit flow based on provider configuration.
+   * Dispatches to the configured flow based on `provider.flow`.
    * @param provider - OAuth provider configuration.
    * @param dispatch - Dispatch functions for auth state.
    */
   login: (provider: OAuthProvider, dispatch: LoginDispatch): void => {
-    if (provider.authorize) {
+    if (provider.flow === OAUTH_FLOW.AUTHORIZATION_CODE) {
       authorizationCodeFlowLogin(provider, dispatch);
     } else {
       implicitFlowLogin(provider, dispatch);

--- a/src/google/service.ts
+++ b/src/google/service.ts
@@ -8,7 +8,12 @@ import { resetCredentialsState } from "../auth/dispatch/credentials";
 import { resetTokenState, updateToken } from "../auth/dispatch/token";
 import { AUTHENTICATION_STATUS } from "../auth/types/authentication";
 import { OAuthProvider } from "../config/entities";
-import { GoogleProfile, SessionDispatch, TokenSetParameters } from "./types";
+import type {
+  CodeResponse,
+  GoogleProfile,
+  SessionDispatch,
+  TokenSetParameters,
+} from "./types";
 import { fetchProfile, getAuthenticationRequestOptions } from "./utils/auth";
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any -- TODO see https://github.com/clevercanary/data-browser/issues/544.
@@ -30,37 +35,45 @@ export const service = {
       "authDispatch" | "authenticationDispatch" | "tokenDispatch"
     >,
   ): void => {
-    const client = google.accounts.oauth2.initTokenClient({
-      callback: (response: TokenSetParameters) => {
+    const client = google.accounts.oauth2.initCodeClient({
+      callback: (response: CodeResponse) => {
         const { id, profile, userinfo } = provider;
-        const { access_token: token } = response;
-        dispatch.authDispatch?.(requestAuth());
-        dispatch.authenticationDispatch?.(requestAuthentication());
-        dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
-        fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
-          onError: () => {
-            dispatch.authDispatch?.(resetAuthState());
-            dispatch.authenticationDispatch?.(
-              updateAuthentication({
-                profile: undefined,
-                status: AUTHENTICATION_STATUS.SETTLED,
-              }),
-            );
-            dispatch.tokenDispatch?.(resetTokenState());
-          },
-          onSuccess: (r: GoogleProfile) =>
-            dispatch.authenticationDispatch?.(
-              updateAuthentication({
-                profile: profile(r),
-                status: AUTHENTICATION_STATUS.PENDING, // Authentication is pending until session controller is resolved.
-              }),
-            ),
-        });
+        fetch("https://service.hannes2.anvil.gi.ucsc.edu/user/authorize", {
+          body: JSON.stringify(response),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+          .then((r) => r.json())
+          .then((tokens: TokenSetParameters) => {
+            const { access_token: token } = tokens;
+            dispatch.authDispatch?.(requestAuth());
+            dispatch.authenticationDispatch?.(requestAuthentication());
+            dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
+            fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
+              onError: () => {
+                dispatch.authDispatch?.(resetAuthState());
+                dispatch.authenticationDispatch?.(
+                  updateAuthentication({
+                    profile: undefined,
+                    status: AUTHENTICATION_STATUS.SETTLED,
+                  }),
+                );
+                dispatch.tokenDispatch?.(resetTokenState());
+              },
+              onSuccess: (r: GoogleProfile) =>
+                dispatch.authenticationDispatch?.(
+                  updateAuthentication({
+                    profile: profile(r),
+                    status: AUTHENTICATION_STATUS.PENDING, // Authentication is pending until session controller is resolved.
+                  }),
+                ),
+            });
+          });
       },
       client_id: provider.clientId,
       scope: provider.authorization.params.scope,
     });
-    client.requestAccessToken();
+    client.requestCode();
   },
   /**
    * Logout and clear all auth state.

--- a/src/google/services/authorizationCodeFlow.ts
+++ b/src/google/services/authorizationCodeFlow.ts
@@ -1,0 +1,48 @@
+import type { OAuthProvider } from "../../config/entities";
+import type { CodeResponse, TokenSetParameters } from "../types";
+import {
+  createOnAccessToken,
+  createResetSession,
+  type LoginDispatch,
+} from "./common";
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any -- TODO see https://github.com/clevercanary/data-browser/issues/544.
+declare const google: any;
+
+/**
+ * Login using the OAuth 2.0 authorization code flow.
+ * Uses Google's initCodeClient to request an authorization code,
+ * then exchanges it for an access token via the configured authorize endpoint.
+ * @param provider - OAuth provider configuration (must have authorize set).
+ * @param dispatch - Dispatch functions for auth state.
+ */
+export function login(provider: OAuthProvider, dispatch: LoginDispatch): void {
+  const { authorize } = provider;
+  const resetSession = createResetSession(dispatch);
+  const onAccessToken = createOnAccessToken(provider, dispatch, resetSession);
+  const client = google.accounts.oauth2.initCodeClient({
+    callback: (response: CodeResponse) => {
+      fetch(authorize as string, {
+        body: JSON.stringify(response),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+        .then((r) => {
+          if (!r.ok) {
+            throw new Error(`authorize request failed (${r.status})`);
+          }
+          return r.json();
+        })
+        .then((tokens: TokenSetParameters) => {
+          if (!tokens?.access_token) {
+            throw new Error("authorize response missing access_token");
+          }
+          onAccessToken(tokens.access_token);
+        })
+        .catch(resetSession);
+    },
+    client_id: provider.clientId,
+    scope: provider.authorization.params.scope,
+  });
+  client.requestCode();
+}

--- a/src/google/services/authorizationCodeFlow.ts
+++ b/src/google/services/authorizationCodeFlow.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvider } from "../../config/entities";
+import type { AuthorizationCodeFlowProvider } from "../../config/entities";
 import type { CodeResponse, TokenSetParameters } from "../types";
 import {
   createOnAccessToken,
@@ -13,16 +13,19 @@ declare const google: any;
  * Login using the OAuth 2.0 authorization code flow.
  * Uses Google's initCodeClient to request an authorization code,
  * then exchanges it for an access token via the configured authorize endpoint.
- * @param provider - OAuth provider configuration (must have authorize set).
+ * @param provider - OAuth provider configuration.
  * @param dispatch - Dispatch functions for auth state.
  */
-export function login(provider: OAuthProvider, dispatch: LoginDispatch): void {
+export function login(
+  provider: AuthorizationCodeFlowProvider,
+  dispatch: LoginDispatch,
+): void {
   const { authorize } = provider;
   const resetSession = createResetSession(dispatch);
   const onAccessToken = createOnAccessToken(provider, dispatch, resetSession);
   const client = google.accounts.oauth2.initCodeClient({
     callback: (response: CodeResponse) => {
-      fetch(authorize as string, {
+      fetch(authorize, {
         body: JSON.stringify(response),
         headers: { "Content-Type": "application/json" },
         method: "POST",

--- a/src/google/services/common.ts
+++ b/src/google/services/common.ts
@@ -1,0 +1,77 @@
+import { requestAuth, resetAuthState } from "../../auth/dispatch/auth";
+import {
+  requestAuthentication,
+  resetAuthenticationState,
+  updateAuthentication,
+} from "../../auth/dispatch/authentication";
+import { resetCredentialsState } from "../../auth/dispatch/credentials";
+import { resetTokenState, updateToken } from "../../auth/dispatch/token";
+import { AUTHENTICATION_STATUS } from "../../auth/types/authentication";
+import type { OAuthProvider } from "../../config/entities";
+import type { GoogleProfile, SessionDispatch } from "../types";
+import { fetchProfile, getAuthenticationRequestOptions } from "../utils/auth";
+
+export type LoginDispatch = Pick<
+  SessionDispatch,
+  "authDispatch" | "authenticationDispatch" | "tokenDispatch"
+>;
+
+/**
+ * Creates a function that resets the session state on auth failure.
+ * @param dispatch - Dispatch functions for auth state.
+ * @returns reset session function.
+ */
+export function createResetSession(dispatch: LoginDispatch): () => void {
+  return (): void => {
+    dispatch.authDispatch?.(resetAuthState());
+    dispatch.authenticationDispatch?.(
+      updateAuthentication({
+        profile: undefined,
+        status: AUTHENTICATION_STATUS.SETTLED,
+      }),
+    );
+    dispatch.tokenDispatch?.(resetTokenState());
+  };
+}
+
+/**
+ * Creates a function that handles a successful access token.
+ * Dispatches auth state updates and fetches the user profile.
+ * @param provider - OAuth provider configuration.
+ * @param dispatch - Dispatch functions for auth state.
+ * @param resetSession - Reset session function.
+ * @returns on access token function.
+ */
+export function createOnAccessToken(
+  provider: OAuthProvider,
+  dispatch: LoginDispatch,
+  resetSession: () => void,
+): (token: string) => void {
+  const { id, profile, userinfo } = provider;
+  return (token: string): void => {
+    dispatch.authDispatch?.(requestAuth());
+    dispatch.authenticationDispatch?.(requestAuthentication());
+    dispatch.tokenDispatch?.(updateToken({ providerId: id, token }));
+    fetchProfile(userinfo, getAuthenticationRequestOptions(token), {
+      onError: resetSession,
+      onSuccess: (r: GoogleProfile) =>
+        dispatch.authenticationDispatch?.(
+          updateAuthentication({
+            profile: profile(r),
+            status: AUTHENTICATION_STATUS.PENDING,
+          }),
+        ),
+    });
+  };
+}
+
+/**
+ * Logout and clear all auth state.
+ * @param dispatch - Dispatch functions for auth state.
+ */
+export function logout(dispatch: SessionDispatch): void {
+  dispatch.authDispatch?.(resetAuthState());
+  dispatch.authenticationDispatch?.(resetAuthenticationState());
+  dispatch.credentialsDispatch?.(resetCredentialsState());
+  dispatch.tokenDispatch?.(resetTokenState());
+}

--- a/src/google/services/implicitFlow.ts
+++ b/src/google/services/implicitFlow.ts
@@ -1,0 +1,28 @@
+import type { OAuthProvider } from "../../config/entities";
+import type { TokenSetParameters } from "../types";
+import {
+  createOnAccessToken,
+  createResetSession,
+  type LoginDispatch,
+} from "./common";
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any -- TODO see https://github.com/clevercanary/data-browser/issues/544.
+declare const google: any;
+
+/**
+ * Login using the OAuth 2.0 implicit flow.
+ * Uses Google's initTokenClient to request an access token directly.
+ * @param provider - OAuth provider configuration.
+ * @param dispatch - Dispatch functions for auth state.
+ */
+export function login(provider: OAuthProvider, dispatch: LoginDispatch): void {
+  const resetSession = createResetSession(dispatch);
+  const onAccessToken = createOnAccessToken(provider, dispatch, resetSession);
+  const client = google.accounts.oauth2.initTokenClient({
+    callback: (response: TokenSetParameters) =>
+      onAccessToken(response.access_token),
+    client_id: provider.clientId,
+    scope: provider.authorization.params.scope,
+  });
+  client.requestAccessToken();
+}

--- a/src/google/services/implicitFlow.ts
+++ b/src/google/services/implicitFlow.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvider } from "../../config/entities";
+import type { ImplicitFlowProvider } from "../../config/entities";
 import type { TokenSetParameters } from "../types";
 import {
   createOnAccessToken,
@@ -15,7 +15,10 @@ declare const google: any;
  * @param provider - OAuth provider configuration.
  * @param dispatch - Dispatch functions for auth state.
  */
-export function login(provider: OAuthProvider, dispatch: LoginDispatch): void {
+export function login(
+  provider: ImplicitFlowProvider,
+  dispatch: LoginDispatch,
+): void {
   const resetSession = createResetSession(dispatch);
   const onAccessToken = createOnAccessToken(provider, dispatch, resetSession);
   const client = google.accounts.oauth2.initTokenClient({

--- a/src/google/types.ts
+++ b/src/google/types.ts
@@ -18,12 +18,12 @@ import {
  * Authorization code response from Google OAuth.
  */
 export interface CodeResponse {
-  code: string;
-  error: string;
-  error_description: string;
-  error_uri: string;
-  scope: string;
-  state: string;
+  code?: string;
+  error?: string;
+  error_description?: string;
+  error_uri?: string;
+  scope?: string;
+  state?: string;
 }
 
 /**

--- a/src/google/types.ts
+++ b/src/google/types.ts
@@ -15,6 +15,18 @@ import {
 } from "../auth/types/token";
 
 /**
+ * Authorization code response from Google OAuth.
+ */
+export interface CodeResponse {
+  code: string;
+  error: string;
+  error_description: string;
+  error_uri: string;
+  scope: string;
+  state: string;
+}
+
+/**
  * Google Sign-In authentication provider props.
  */
 export interface GoogleSignInAuthenticationProviderProps {

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -1,0 +1,74 @@
+import { jest } from "@jest/globals";
+import type { OAuthProvider } from "../src/config/entities";
+import { service } from "../src/google/service";
+import type { SessionDispatch } from "../src/google/types";
+
+const PROVIDER_BASE: OAuthProvider = {
+  authorization: { params: { scope: "openid email profile" } },
+  clientId: "test-client-id",
+  icon: null,
+  id: "google",
+  name: "Google",
+  profile: (p) => p,
+  userinfo: "https://example.com/userinfo",
+};
+
+const DISPATCH_NO_OPS: Pick<
+  SessionDispatch,
+  "authDispatch" | "authenticationDispatch" | "tokenDispatch"
+> = {
+  authDispatch: jest.fn(),
+  authenticationDispatch: jest.fn(),
+  tokenDispatch: jest.fn(),
+};
+
+describe("service.login (Google)", () => {
+  let initCodeClient: jest.Mock;
+  let initTokenClient: jest.Mock;
+  let requestCode: jest.Mock;
+  let requestAccessToken: jest.Mock;
+
+  beforeEach(() => {
+    requestCode = jest.fn();
+    requestAccessToken = jest.fn();
+    initCodeClient = jest.fn(() => ({ requestCode }));
+    initTokenClient = jest.fn(() => ({ requestAccessToken }));
+    (globalThis as unknown as { google: unknown }).google = {
+      accounts: { oauth2: { initCodeClient, initTokenClient } },
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { google?: unknown }).google;
+  });
+
+  it("uses the authorization code flow when provider.authorize is set", () => {
+    const provider: OAuthProvider = {
+      ...PROVIDER_BASE,
+      authorize: "https://service.example.com/user/authorize",
+    };
+
+    service.login(provider, DISPATCH_NO_OPS);
+
+    expect(initCodeClient).toHaveBeenCalledTimes(1);
+    expect(requestCode).toHaveBeenCalledTimes(1);
+    expect(initTokenClient).not.toHaveBeenCalled();
+    expect(requestAccessToken).not.toHaveBeenCalled();
+
+    const config = initCodeClient.mock.calls[0]?.[0] as {
+      client_id: string;
+      scope: string;
+    };
+    expect(config.client_id).toBe(PROVIDER_BASE.clientId);
+    expect(config.scope).toBe(PROVIDER_BASE.authorization.params.scope);
+  });
+
+  it("falls back to the implicit token flow when provider.authorize is unset", () => {
+    service.login(PROVIDER_BASE, DISPATCH_NO_OPS);
+
+    expect(initTokenClient).toHaveBeenCalledTimes(1);
+    expect(requestAccessToken).toHaveBeenCalledTimes(1);
+    expect(initCodeClient).not.toHaveBeenCalled();
+    expect(requestCode).not.toHaveBeenCalled();
+  });
+});

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -1,12 +1,13 @@
 import { jest } from "@jest/globals";
 import { resetTokenState, updateToken } from "../src/auth/dispatch/token";
-import type { OAuthProvider } from "../src/config/entities";
+import { OAUTH_FLOW, type OAuthProvider } from "../src/config/entities";
 import { service } from "../src/google/service";
 import type { CodeResponse, SessionDispatch } from "../src/google/types";
 
 const PROVIDER_BASE: OAuthProvider = {
   authorization: { params: { scope: "openid email profile" } },
   clientId: "test-client-id",
+  flow: OAUTH_FLOW.IMPLICIT,
   icon: null,
   id: "google",
   name: "Google",
@@ -15,6 +16,12 @@ const PROVIDER_BASE: OAuthProvider = {
 };
 
 const AUTHORIZE_URL = "https://service.example.com/user/authorize";
+
+const PROVIDER_AUTH_CODE: OAuthProvider = {
+  ...PROVIDER_BASE,
+  authorize: AUTHORIZE_URL,
+  flow: OAUTH_FLOW.AUTHORIZATION_CODE,
+};
 
 const CODE_RESPONSE: CodeResponse = { code: "test-code" };
 
@@ -56,13 +63,8 @@ describe("service.login (Google)", () => {
     delete (globalThis as unknown as { fetch?: unknown }).fetch;
   });
 
-  it("uses the authorization code flow when provider.authorize is set", () => {
-    const provider: OAuthProvider = {
-      ...PROVIDER_BASE,
-      authorize: AUTHORIZE_URL,
-    };
-
-    service.login(provider, dispatch);
+  it("uses the authorization code flow when provider.flow is OAUTH_FLOW.AUTHORIZATION_CODE", () => {
+    service.login(PROVIDER_AUTH_CODE, dispatch);
 
     expect(initCodeClient).toHaveBeenCalledTimes(1);
     expect(requestCode).toHaveBeenCalledTimes(1);
@@ -77,7 +79,7 @@ describe("service.login (Google)", () => {
     expect(config.scope).toBe(PROVIDER_BASE.authorization.params.scope);
   });
 
-  it("falls back to the implicit token flow when provider.authorize is unset", () => {
+  it("uses the implicit token flow when provider.flow is OAUTH_FLOW.IMPLICIT", () => {
     service.login(PROVIDER_BASE, dispatch);
 
     expect(initTokenClient).toHaveBeenCalledTimes(1);
@@ -96,11 +98,7 @@ describe("service.login (Google)", () => {
     (globalThis as unknown as { fetch: typeof fetch }).fetch =
       fetchMock as unknown as typeof fetch;
 
-    const provider: OAuthProvider = {
-      ...PROVIDER_BASE,
-      authorize: AUTHORIZE_URL,
-    };
-    service.login(provider, dispatch);
+    service.login(PROVIDER_AUTH_CODE, dispatch);
 
     const config = initCodeClient.mock.calls[0]?.[0] as {
       callback: (response: CodeResponse) => void;
@@ -129,11 +127,7 @@ describe("service.login (Google)", () => {
     (globalThis as unknown as { fetch: typeof fetch }).fetch =
       fetchMock as unknown as typeof fetch;
 
-    const provider: OAuthProvider = {
-      ...PROVIDER_BASE,
-      authorize: AUTHORIZE_URL,
-    };
-    service.login(provider, dispatch);
+    service.login(PROVIDER_AUTH_CODE, dispatch);
 
     const config = initCodeClient.mock.calls[0]?.[0] as {
       callback: (response: CodeResponse) => void;
@@ -159,11 +153,7 @@ describe("service.login (Google)", () => {
     (globalThis as unknown as { fetch: typeof fetch }).fetch =
       fetchMock as unknown as typeof fetch;
 
-    const provider: OAuthProvider = {
-      ...PROVIDER_BASE,
-      authorize: AUTHORIZE_URL,
-    };
-    service.login(provider, dispatch);
+    service.login(PROVIDER_AUTH_CODE, dispatch);
 
     const config = initCodeClient.mock.calls[0]?.[0] as {
       callback: (response: CodeResponse) => void;

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -16,14 +16,7 @@ const PROVIDER_BASE: OAuthProvider = {
 
 const AUTHORIZE_URL = "https://service.example.com/user/authorize";
 
-const CODE_RESPONSE: CodeResponse = {
-  code: "test-code",
-  error: "",
-  error_description: "",
-  error_uri: "",
-  scope: "",
-  state: "",
-};
+const CODE_RESPONSE: CodeResponse = { code: "test-code" };
 
 type LoginDispatch = Pick<
   SessionDispatch,

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -42,6 +42,7 @@ describe("service.login (Google)", () => {
   let requestCode: jest.Mock;
   let requestAccessToken: jest.Mock;
   let dispatch: LoginDispatch;
+  let originalFetch: typeof fetch | undefined;
 
   beforeEach(() => {
     requestCode = jest.fn();
@@ -56,11 +57,16 @@ describe("service.login (Google)", () => {
     (globalThis as unknown as { google: unknown }).google = {
       accounts: { oauth2: { initCodeClient, initTokenClient } },
     };
+    originalFetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
   });
 
   afterEach(() => {
     delete (globalThis as unknown as { google?: unknown }).google;
-    delete (globalThis as unknown as { fetch?: unknown }).fetch;
+    if (originalFetch === undefined) {
+      delete (globalThis as unknown as { fetch?: unknown }).fetch;
+    } else {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
   });
 
   it("uses the authorization code flow when provider.flow is OAUTH_FLOW.AUTHORIZATION_CODE", () => {

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -1,7 +1,8 @@
 import { jest } from "@jest/globals";
+import { resetTokenState, updateToken } from "../src/auth/dispatch/token";
 import type { OAuthProvider } from "../src/config/entities";
 import { service } from "../src/google/service";
-import type { SessionDispatch } from "../src/google/types";
+import type { CodeResponse, SessionDispatch } from "../src/google/types";
 
 const PROVIDER_BASE: OAuthProvider = {
   authorization: { params: { scope: "openid email profile" } },
@@ -13,13 +14,26 @@ const PROVIDER_BASE: OAuthProvider = {
   userinfo: "https://example.com/userinfo",
 };
 
-const DISPATCH_NO_OPS: Pick<
+const AUTHORIZE_URL = "https://service.example.com/user/authorize";
+
+const CODE_RESPONSE: CodeResponse = {
+  code: "test-code",
+  error: "",
+  error_description: "",
+  error_uri: "",
+  scope: "",
+  state: "",
+};
+
+type LoginDispatch = Pick<
   SessionDispatch,
   "authDispatch" | "authenticationDispatch" | "tokenDispatch"
-> = {
-  authDispatch: jest.fn(),
-  authenticationDispatch: jest.fn(),
-  tokenDispatch: jest.fn(),
+>;
+
+const flushPromises = async (): Promise<void> => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
 };
 
 describe("service.login (Google)", () => {
@@ -27,12 +41,18 @@ describe("service.login (Google)", () => {
   let initTokenClient: jest.Mock;
   let requestCode: jest.Mock;
   let requestAccessToken: jest.Mock;
+  let dispatch: LoginDispatch;
 
   beforeEach(() => {
     requestCode = jest.fn();
     requestAccessToken = jest.fn();
     initCodeClient = jest.fn(() => ({ requestCode }));
     initTokenClient = jest.fn(() => ({ requestAccessToken }));
+    dispatch = {
+      authDispatch: jest.fn(),
+      authenticationDispatch: jest.fn(),
+      tokenDispatch: jest.fn(),
+    };
     (globalThis as unknown as { google: unknown }).google = {
       accounts: { oauth2: { initCodeClient, initTokenClient } },
     };
@@ -40,15 +60,16 @@ describe("service.login (Google)", () => {
 
   afterEach(() => {
     delete (globalThis as unknown as { google?: unknown }).google;
+    delete (globalThis as unknown as { fetch?: unknown }).fetch;
   });
 
   it("uses the authorization code flow when provider.authorize is set", () => {
     const provider: OAuthProvider = {
       ...PROVIDER_BASE,
-      authorize: "https://service.example.com/user/authorize",
+      authorize: AUTHORIZE_URL,
     };
 
-    service.login(provider, DISPATCH_NO_OPS);
+    service.login(provider, dispatch);
 
     expect(initCodeClient).toHaveBeenCalledTimes(1);
     expect(requestCode).toHaveBeenCalledTimes(1);
@@ -64,11 +85,99 @@ describe("service.login (Google)", () => {
   });
 
   it("falls back to the implicit token flow when provider.authorize is unset", () => {
-    service.login(PROVIDER_BASE, DISPATCH_NO_OPS);
+    service.login(PROVIDER_BASE, dispatch);
 
     expect(initTokenClient).toHaveBeenCalledTimes(1);
     expect(requestAccessToken).toHaveBeenCalledTimes(1);
     expect(initCodeClient).not.toHaveBeenCalled();
     expect(requestCode).not.toHaveBeenCalled();
+  });
+
+  it("exchanges the authorization code at provider.authorize and dispatches updateToken", async () => {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ access_token: "fake-access-token" }),
+        ok: true,
+      } as Response),
+    );
+    (globalThis as unknown as { fetch: typeof fetch }).fetch =
+      fetchMock as unknown as typeof fetch;
+
+    const provider: OAuthProvider = {
+      ...PROVIDER_BASE,
+      authorize: AUTHORIZE_URL,
+    };
+    service.login(provider, dispatch);
+
+    const config = initCodeClient.mock.calls[0]?.[0] as {
+      callback: (response: CodeResponse) => void;
+    };
+    config.callback(CODE_RESPONSE);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(AUTHORIZE_URL, {
+      body: JSON.stringify(CODE_RESPONSE),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+    expect(dispatch.tokenDispatch).toHaveBeenCalledWith(
+      updateToken({ providerId: "google", token: "fake-access-token" }),
+    );
+  });
+
+  it("resets session state when the authorize request returns a non-ok response", async () => {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({}),
+        ok: false,
+        status: 500,
+      } as Response),
+    );
+    (globalThis as unknown as { fetch: typeof fetch }).fetch =
+      fetchMock as unknown as typeof fetch;
+
+    const provider: OAuthProvider = {
+      ...PROVIDER_BASE,
+      authorize: AUTHORIZE_URL,
+    };
+    service.login(provider, dispatch);
+
+    const config = initCodeClient.mock.calls[0]?.[0] as {
+      callback: (response: CodeResponse) => void;
+    };
+    config.callback(CODE_RESPONSE);
+    await flushPromises();
+
+    expect(dispatch.tokenDispatch).toHaveBeenCalledWith(resetTokenState());
+    expect(dispatch.tokenDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ token: expect.any(String) }),
+      }),
+    );
+  });
+
+  it("resets session state when the authorize response is missing access_token", async () => {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({}),
+        ok: true,
+      } as Response),
+    );
+    (globalThis as unknown as { fetch: typeof fetch }).fetch =
+      fetchMock as unknown as typeof fetch;
+
+    const provider: OAuthProvider = {
+      ...PROVIDER_BASE,
+      authorize: AUTHORIZE_URL,
+    };
+    service.login(provider, dispatch);
+
+    const config = initCodeClient.mock.calls[0]?.[0] as {
+      callback: (response: CodeResponse) => void;
+    };
+    config.callback(CODE_RESPONSE);
+    await flushPromises();
+
+    expect(dispatch.tokenDispatch).toHaveBeenCalledWith(resetTokenState());
   });
 });


### PR DESCRIPTION
## Summary

- Add Google authorization code flow as an opt-in alternative to the existing implicit token flow on `service.login`
- New optional `authorize?: string` field on `OAuthProvider` — when set, `initCodeClient` + `requestCode()` is used and the resulting code is POSTed to that URL to exchange for an access token; when unset, the existing `initTokenClient` + `requestAccessToken()` flow is preserved
- Initial commit applies @hannes-ucsc's POC verbatim (URL hardcoded); follow-up commit factors out the access-token handling and makes the authorize URL configurable

Closes #906. Refs DataBiosphere/data-browser#4793. Companion PR in data-browser wires this up for the anvil-cmg/dev site.

## Test plan

- [x] `npm run check-format` clean
- [x] `npm run lint` clean
- [x] `npm run test-compile` clean
- [x] `npm test` — 47 suites, 389 tests pass (includes new `googleService.test.ts` covering both branches)
- [x] Manually verified end-to-end against anvildev via tarball install in data-browser: login (POST `/user/authorize` returns tokens, profile loads), logout, inactivity timeout, Terra checks