### PR TITLE
refactor: make codeResponse fields optional (#907)

### DIFF
--- a/src/google/types.ts
+++ b/src/google/types.ts
@@ -18,12 +18,12 @@ import {
  * Authorization code response from Google OAuth.
  */
 export interface CodeResponse {
-  code: string;
-  error: string;
-  error_description: string;
-  error_uri: string;
-  scope: string;
-  state: string;
+  code?: string;
+  error?: string;
+  error_description?: string;
+  error_uri?: string;
+  scope?: string;
+  state?: string;
 }
 
 /**

--- a/tests/googleService.test.ts
+++ b/tests/googleService.test.ts
@@ -16,14 +16,7 @@ const PROVIDER_BASE: OAuthProvider = {
 
 const AUTHORIZE_URL = "https://service.example.com/user/authorize";
 
-const CODE_RESPONSE: CodeResponse = {
-  code: "test-code",
-  error: "",
-  error_description: "",
-  error_uri: "",
-  scope: "",
-  state: "",
-};
+const CODE_RESPONSE: CodeResponse = { code: "test-code" };
 
 type LoginDispatch = Pick<
   SessionDispatch,


### PR DESCRIPTION
## Summary

- Flip every field on `CodeResponse` from required `string` to optional, so the type reflects Google's actual code-flow callback contract (success vs error payloads have disjoint fields)
- Trim `CODE_RESPONSE` test fixture down to the only field we actually populate

Stacked on top of #905 (which introduces `CodeResponse`); will rebase onto `main` once that lands.

Closes #907.

## Test plan

- [x] `npm run check-format` clean
- [x] `npm run lint` clean
- [x] `npm run test-compile` clean
- [x] `npm test` — 47 suites, 392 tests pass