### PR TITLE
feat!: filter popover: flip placement above the trigger row when bottom-anchored (#912)

### DIFF
--- a/src/components/Filter/components/Filter/components/Backdrop/backdrop.styles.ts
+++ b/src/components/Filter/components/Filter/components/Backdrop/backdrop.styles.ts
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+import { Backdrop } from "@mui/material";
+
+export const StyledBackdrop = styled(Backdrop)`
+  background-color: transparent;
+  overflow: hidden;
+  overscroll-behavior: none;
+  z-index: 1300;
+`;

--- a/src/components/Filter/components/Filter/components/Backdrop/backdrop.tsx
+++ b/src/components/Filter/components/Filter/components/Backdrop/backdrop.tsx
@@ -1,0 +1,15 @@
+import { Portal } from "@mui/material";
+import { JSX } from "react";
+import { useCloseOnEscape } from "../../hooks/UseCloseOnEscape/hook";
+import { StyledBackdrop } from "./backdrop.styles";
+import { BACKDROP_PROPS } from "./constants";
+import { BackdropProps } from "./types";
+
+export const Backdrop = (props: BackdropProps): JSX.Element => {
+  useCloseOnEscape({ onClose: props.onClick, open: props.open });
+  return (
+    <Portal>
+      <StyledBackdrop {...BACKDROP_PROPS} {...props} />
+    </Portal>
+  );
+};

--- a/src/components/Filter/components/Filter/components/Backdrop/constants.ts
+++ b/src/components/Filter/components/Filter/components/Backdrop/constants.ts
@@ -1,0 +1,5 @@
+import { BackdropProps } from "@mui/material";
+
+export const BACKDROP_PROPS: Omit<BackdropProps, "open"> = {
+  slotProps: { transition: { unmountOnExit: true } },
+};

--- a/src/components/Filter/components/Filter/components/Backdrop/types.ts
+++ b/src/components/Filter/components/Filter/components/Backdrop/types.ts
@@ -1,0 +1,5 @@
+import { BackdropProps as MBackdropProps } from "@mui/material";
+
+export interface BackdropProps extends Omit<MBackdropProps, "onClick"> {
+  onClick: () => void;
+}

--- a/src/components/Filter/components/Filter/components/DrawerTransition/constants.ts
+++ b/src/components/Filter/components/Filter/components/DrawerTransition/constants.ts
@@ -1,0 +1,8 @@
+import { SlideProps } from "@mui/material";
+
+export const SIDE_PROPS: Omit<SlideProps, "children"> = {
+  direction: "right",
+  easing: "ease-out",
+  timeout: { enter: 250, exit: 300 },
+  unmountOnExit: true,
+};

--- a/src/components/Filter/components/Filter/components/DrawerTransition/drawerTransition.tsx
+++ b/src/components/Filter/components/Filter/components/DrawerTransition/drawerTransition.tsx
@@ -19,7 +19,7 @@ export const DrawerTransition = ({
   ...props
 }: DrawerTransitionProps): JSX.Element => {
   return (
-    <Slide {...SIDE_PROPS} ref={ref} {...props}>
+    <Slide {...props} {...SIDE_PROPS} ref={ref}>
       {children}
     </Slide>
   );

--- a/src/components/Filter/components/Filter/components/DrawerTransition/drawerTransition.tsx
+++ b/src/components/Filter/components/Filter/components/DrawerTransition/drawerTransition.tsx
@@ -1,24 +1,26 @@
-import { Slide as MSlide, SlideProps as MSlideProps } from "@mui/material";
-import { JSX, forwardRef } from "react";
+import { Slide } from "@mui/material";
+import { JSX } from "react";
+import { SIDE_PROPS } from "./constants";
+import { DrawerTransitionProps } from "./types";
 
-export const DrawerTransition = forwardRef<Element, MSlideProps>(
-  function DrawerTransition(
-    {
-      children,
-      ...props /* Spread props to allow for Mui SlideProps specific prop overrides. */
-    }: MSlideProps,
-    ref,
-  ): JSX.Element {
-    return (
-      <MSlide
-        direction="right"
-        easing="ease-out"
-        ref={ref}
-        unmountOnExit
-        {...props}
-      >
-        {children}
-      </MSlide>
-    );
-  },
-);
+/**
+ * Slide transition used for the drawer-surface filter popover.
+ * @param props - Component props (extends MUI SlideProps).
+ * @param props.children - Transition child.
+ * @param props.placement - Popper placement; consumed only to keep it off the DOM.
+ * @param props.ref - Forwarded ref.
+ * @returns Slide transition element.
+ */
+export const DrawerTransition = ({
+  children,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructured out so it doesn't spread onto the DOM Slide element
+  placement: _placement,
+  ref,
+  ...props
+}: DrawerTransitionProps): JSX.Element => {
+  return (
+    <Slide {...SIDE_PROPS} ref={ref} {...props}>
+      {children}
+    </Slide>
+  );
+};

--- a/src/components/Filter/components/Filter/components/DrawerTransition/types.ts
+++ b/src/components/Filter/components/Filter/components/DrawerTransition/types.ts
@@ -1,0 +1,7 @@
+import { PopperPlacementType, SlideProps } from "@mui/material";
+import { Ref } from "react";
+
+export interface DrawerTransitionProps extends SlideProps {
+  placement?: PopperPlacementType;
+  ref?: Ref<unknown>;
+}

--- a/src/components/Filter/components/Filter/components/MenuTransition/constants.ts
+++ b/src/components/Filter/components/Filter/components/MenuTransition/constants.ts
@@ -1,0 +1,11 @@
+import { PopperPlacementType } from "@mui/material";
+import { CSSProperties } from "react";
+import { POPPER_PROPS } from "../../../../../../styles/common/mui/popper";
+
+export const PLACEMENT_TRANSFORM_ORIGIN: Partial<
+  Record<PopperPlacementType, CSSProperties["transformOrigin"]>
+> = {
+  [POPPER_PROPS.PLACEMENT.BOTTOM_START]: "0 0 0",
+  [POPPER_PROPS.PLACEMENT.RIGHT]: "0 50% 0",
+  [POPPER_PROPS.PLACEMENT.TOP_START]: "0 100% 0",
+};

--- a/src/components/Filter/components/Filter/components/MenuTransition/menuTransition.tsx
+++ b/src/components/Filter/components/Filter/components/MenuTransition/menuTransition.tsx
@@ -1,0 +1,31 @@
+import { Grow } from "@mui/material";
+import { JSX } from "react";
+import { POPPER_PROPS } from "../../../../../../styles/common/mui/popper";
+import { PLACEMENT_TRANSFORM_ORIGIN } from "./constants";
+import { MenuTransitionProps } from "./types";
+
+/**
+ * Grow transition with a placement-driven transform origin.
+ * @param props - Component props.
+ * @param props.placement - Popper placement, drives the transform origin.
+ * @param props.ref - Forwarded ref.
+ * @param props.style - Style merged with the placement-derived transform origin.
+ * @returns Grow transition element.
+ */
+export const MenuTransition = ({
+  placement = POPPER_PROPS.PLACEMENT.BOTTOM_START,
+  ref,
+  style,
+  ...props
+}: MenuTransitionProps): JSX.Element => {
+  return (
+    <Grow
+      {...props}
+      ref={ref}
+      style={{
+        ...style,
+        transformOrigin: PLACEMENT_TRANSFORM_ORIGIN[placement],
+      }}
+    />
+  );
+};

--- a/src/components/Filter/components/Filter/components/MenuTransition/types.ts
+++ b/src/components/Filter/components/Filter/components/MenuTransition/types.ts
@@ -1,0 +1,7 @@
+import { GrowProps, PopperPlacementType } from "@mui/material";
+import { Ref } from "react";
+
+export interface MenuTransitionProps extends GrowProps {
+  placement?: PopperPlacementType;
+  ref?: Ref<unknown>;
+}

--- a/src/components/Filter/components/Filter/components/Popper/constants.ts
+++ b/src/components/Filter/components/Filter/components/Popper/constants.ts
@@ -1,0 +1,22 @@
+import { PopperProps } from "@mui/material";
+import { POPPER_PROPS as MUI_POPPER_PROPS } from "../../../../../../styles/common/mui/popper";
+
+export const POPPER_PROPS: Omit<PopperProps, "open"> = {
+  placement: MUI_POPPER_PROPS.PLACEMENT.BOTTOM_START,
+  popperOptions: {
+    modifiers: [
+      {
+        name: "flip",
+        options: {
+          fallbackPlacements: [
+            MUI_POPPER_PROPS.PLACEMENT.TOP_START,
+            MUI_POPPER_PROPS.PLACEMENT.RIGHT,
+          ],
+        },
+      },
+      { name: "offset", options: { offset: [0, 4] } },
+    ],
+  },
+  role: "dialog",
+  transition: true,
+};

--- a/src/components/Filter/components/Filter/components/Popper/constants.ts
+++ b/src/components/Filter/components/Filter/components/Popper/constants.ts
@@ -17,6 +17,5 @@ export const POPPER_PROPS: Omit<PopperProps, "open"> = {
       { name: "offset", options: { offset: [0, 4] } },
     ],
   },
-  role: "dialog",
   transition: true,
 };

--- a/src/components/Filter/components/Filter/filter.styles.ts
+++ b/src/components/Filter/components/Filter/filter.styles.ts
@@ -1,26 +1,34 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Popover } from "@mui/material";
+import { Popper } from "@mui/material";
 import { PALETTE } from "../../../../styles/common/constants/palette";
 import { SURFACE_TYPE } from "../surfaces/types";
-import { FilterProps } from "./filter";
+import { FilterProps } from "./types";
 
-export const StyledPopover = styled(Popover, {
+export const StyledPopper = styled(Popper, {
   shouldForwardProp: (prop) => prop !== "surfaceType",
 })<Pick<FilterProps, "surfaceType">>`
-  .MuiPaper-menu {
-    margin: 4px 0;
+  z-index: 1300;
+
+  .MuiPaper-root {
+    overflow: hidden;
+    overscroll-behavior: none;
   }
 
   ${({ surfaceType }) =>
     surfaceType === SURFACE_TYPE.DRAWER &&
     css`
+      inset: 0 auto 0 0 !important; // required to override Popper's default positioning for correct placement within the drawer.
+      transform: none !important; // required to override Popper's transform for correct positioning within the drawer.
+
       .MuiPaper-root {
         background-color: ${PALETTE.SMOKE_LIGHT};
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
         height: 100%;
         margin: 0;
         max-height: 100%;
-        overflow: visible; // required; allows backdrop button to render outside of drawer container.
       }
     `}
 `;

--- a/src/components/Filter/components/Filter/filter.tsx
+++ b/src/components/Filter/components/Filter/filter.tsx
@@ -1,41 +1,26 @@
-import { Grow, PopoverPosition, PopoverProps } from "@mui/material";
-import { JSX, MouseEvent, ReactNode, useState } from "react";
+import { Paper } from "@mui/material";
+import { JSX } from "react";
 import { isRangeCategoryView } from "../../../../common/categories/views/range/typeGuards";
-import { CategoryView } from "../../../../common/categories/views/types";
-import { TrackFilterOpenedFunction } from "../../../../config/entities";
-import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
+import { PAPER_PROPS } from "../../../../styles/common/mui/paper";
 import { TEST_IDS } from "../../../../tests/testIds";
+import { PopperProvider } from "../../../common/Popper/provider/provider";
 import { FilterLabel } from "../FilterLabel/filterLabel";
 import { FilterMenu } from "../FilterMenu/filterMenu";
 import { FilterRange } from "../FilterRange/filterRange";
 import { IconButton } from "../surfaces/drawer/components/IconButton/iconButton";
 import { SURFACE_TYPE } from "../surfaces/types";
+import { Backdrop } from "./components/Backdrop/backdrop";
 import { DrawerTransition } from "./components/DrawerTransition/drawerTransition";
-import { StyledPopover } from "./filter.styles";
+import { MenuTransition } from "./components/MenuTransition/menuTransition";
+import { POPPER_PROPS } from "./components/Popper/constants";
+import { StyledPopper } from "./filter.styles";
+import { FilterProps } from "./types";
 
 /**
  * Filter component.
  * TODO(cc) refactor: build tags from categoryView for selected values.
  * TODO(cc) tests: add tests for selected values (rending of tags) for select and range categories.
  */
-
-const DEFAULT_POSITION: PopoverPosition = { left: 0, top: 0 };
-const DEFAULT_SLOT_PROPS: PopoverProps["slotProps"] = {
-  paper: { variant: "menu" },
-};
-const DRAWER_SLOT_PROPS: PopoverProps["slotProps"] = {
-  paper: { elevation: 0 },
-};
-
-export interface FilterProps {
-  categorySection?: string;
-  categoryView: CategoryView;
-  closeAncestor?: () => void;
-  onFilter: OnFilterFn;
-  surfaceType: SURFACE_TYPE;
-  tags?: ReactNode; // e.g. filter tags
-  trackFilterOpened?: TrackFilterOpenedFunction;
-}
 
 export const Filter = ({
   categorySection,
@@ -46,97 +31,92 @@ export const Filter = ({
   tags,
   trackFilterOpened,
 }: FilterProps): JSX.Element => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [position, setPosition] = useState<PopoverPosition>(DEFAULT_POSITION);
   const isDrawer = surfaceType === SURFACE_TYPE.DRAWER;
-  const anchorPosition = isDrawer ? DEFAULT_POSITION : position;
-  const slotProps = isDrawer ? DRAWER_SLOT_PROPS : DEFAULT_SLOT_PROPS;
-  const TransitionComponent = isDrawer ? DrawerTransition : Grow;
-  const transitionDuration = isOpen ? 250 : 300;
-  const TransitionDuration = isDrawer ? transitionDuration : undefined;
   const isRangeView = isRangeCategoryView(categoryView);
-
-  /**
-   * Closes filter popover.
-   */
-  const onCloseFilter = (): void => {
-    setIsOpen(false);
-  };
-
-  /**
-   * Closes filter and all open ancestors e.g. filter drawer.
-   */
-  const onCloseFilters = (): void => {
-    closeAncestor?.();
-    onCloseFilter();
-  };
-
-  /**
-   * Opens filter popover and sets popover position.
-   * @param event - Mouse event interaction with filter target.
-   */
-  const onOpenFilter = (event: MouseEvent<HTMLButtonElement>): void => {
-    // Grab the filter target size and position and calculate the popover position.
-    const targetDOMRect = event.currentTarget.getBoundingClientRect();
-    const popoverLeftPos = targetDOMRect.x;
-    const popoverTopPos = targetDOMRect.y + targetDOMRect.height - 1;
-    // Set popover position and open state.
-    setPosition({ left: popoverLeftPos, top: popoverTopPos });
-    setIsOpen(true);
-    trackFilterOpened?.({ category: categoryView.key });
-  };
-
   return (
-    <>
-      <FilterLabel
-        annotation={categoryView.annotation}
-        count={isRangeView ? undefined : categoryView.values.length}
-        disabled={categoryView.isDisabled}
-        isOpen={isOpen}
-        label={categoryView.label}
-        onClick={onOpenFilter}
-        surfaceType={surfaceType}
-      />
-      <StyledPopover
-        anchorPosition={anchorPosition}
-        anchorReference="anchorPosition"
-        data-testid={TEST_IDS.FILTER_POPOVER}
-        marginThreshold={0}
-        onClose={onCloseFilters}
-        open={isOpen}
-        slotProps={slotProps}
-        slots={{ transition: TransitionComponent }}
-        surfaceType={surfaceType}
-        transitionDuration={TransitionDuration}
-      >
-        {isDrawer && <IconButton onClick={onCloseFilters} />}
-        {isRangeView ? (
-          <FilterRange
-            categoryKey={categoryView.key}
-            categoryLabel={categoryView.label}
-            categorySection={categorySection}
-            max={categoryView.max}
-            min={categoryView.min}
-            selectedMax={categoryView.selectedMax}
-            selectedMin={categoryView.selectedMin}
-            onCloseFilter={onCloseFilter}
-            onFilter={onFilter}
-            surfaceType={surfaceType}
-            unit={categoryView.unit}
-          />
-        ) : (
-          <FilterMenu
-            categoryKey={categoryView.key}
-            categoryLabel={categoryView.label}
-            categorySection={categorySection}
-            onCloseFilter={onCloseFilter}
-            onFilter={onFilter}
-            surfaceType={surfaceType}
-            values={categoryView.values}
-          />
-        )}
-      </StyledPopover>
-      {tags}
-    </>
+    <PopperProvider>
+      {({ anchorEl, onClose, onOpen, open }): JSX.Element => {
+        const TransitionComponent = isDrawer
+          ? DrawerTransition
+          : MenuTransition;
+        return (
+          <>
+            <FilterLabel
+              annotation={categoryView.annotation}
+              count={isRangeView ? undefined : categoryView.values.length}
+              disabled={categoryView.isDisabled}
+              isOpen={open}
+              label={categoryView.label}
+              onClick={(e) => {
+                onOpen(e);
+                trackFilterOpened?.({ category: categoryView.key });
+              }}
+              surfaceType={surfaceType}
+            />
+            <Backdrop
+              onClick={() => {
+                onClose();
+                closeAncestor?.();
+              }}
+              open={open}
+            />
+            <StyledPopper
+              {...POPPER_PROPS}
+              anchorEl={anchorEl}
+              aria-label={categoryView.label}
+              data-testid={TEST_IDS.FILTER_POPOVER}
+              open={open}
+              surfaceType={surfaceType}
+            >
+              {({ placement, TransitionProps }): JSX.Element => {
+                return (
+                  <TransitionComponent
+                    {...TransitionProps}
+                    placement={placement}
+                  >
+                    <Paper variant={PAPER_PROPS.VARIANT.MENU}>
+                      {isDrawer && (
+                        <IconButton
+                          onClick={() => {
+                            onClose();
+                            closeAncestor?.();
+                          }}
+                        />
+                      )}
+                      {isRangeView ? (
+                        <FilterRange
+                          categoryKey={categoryView.key}
+                          categoryLabel={categoryView.label}
+                          categorySection={categorySection}
+                          max={categoryView.max}
+                          min={categoryView.min}
+                          selectedMax={categoryView.selectedMax}
+                          selectedMin={categoryView.selectedMin}
+                          onCloseFilter={onClose}
+                          onFilter={onFilter}
+                          surfaceType={surfaceType}
+                          unit={categoryView.unit}
+                        />
+                      ) : (
+                        <FilterMenu
+                          categoryKey={categoryView.key}
+                          categoryLabel={categoryView.label}
+                          categorySection={categorySection}
+                          onCloseFilter={onClose}
+                          onFilter={onFilter}
+                          surfaceType={surfaceType}
+                          values={categoryView.values}
+                        />
+                      )}
+                    </Paper>
+                  </TransitionComponent>
+                );
+              }}
+            </StyledPopper>
+            {tags}
+          </>
+        );
+      }}
+    </PopperProvider>
   );
 };

--- a/src/components/Filter/components/Filter/hooks/UseCloseOnEscape/hook.ts
+++ b/src/components/Filter/components/Filter/hooks/UseCloseOnEscape/hook.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { UseCloseOnEscapeProps } from "./types";
+
+/**
+ * Closes the popper, and any ancestor drawer, when the Escape key is pressed.
+ * @param props - Hook props.
+ * @param props.onClose - Function to call when the Escape key is pressed.
+ * @param props.open - Whether the popper is open.
+ */
+export const useCloseOnEscape = ({
+  onClose,
+  open,
+}: UseCloseOnEscapeProps): void => {
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return (): void => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose, open]);
+};

--- a/src/components/Filter/components/Filter/hooks/UseCloseOnEscape/types.ts
+++ b/src/components/Filter/components/Filter/hooks/UseCloseOnEscape/types.ts
@@ -1,0 +1,4 @@
+export interface UseCloseOnEscapeProps {
+  onClose: () => void;
+  open: boolean;
+}

--- a/src/components/Filter/components/Filter/types.ts
+++ b/src/components/Filter/components/Filter/types.ts
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+import { CategoryView } from "../../../../common/categories/views/types";
+import { TrackFilterOpenedFunction } from "../../../../config/entities";
+import { OnFilterFn } from "../../../../hooks/useCategoryFilter";
+import { SURFACE_TYPE } from "../surfaces/types";
+
+export interface FilterProps {
+  categorySection?: string;
+  categoryView: CategoryView;
+  closeAncestor?: () => void;
+  onFilter: OnFilterFn;
+  surfaceType: SURFACE_TYPE;
+  tags?: ReactNode; // e.g. filter tags
+  trackFilterOpened?: TrackFilterOpenedFunction;
+}

--- a/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
+++ b/src/components/Filter/components/FilterMenu/filterMenu.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { FilterProps } from "../Filter/filter";
+import { FilterProps } from "../Filter/types";
 import { SURFACE_TYPE } from "../surfaces/types";
 
 interface Props {

--- a/src/components/Filter/components/FilterRange/filterRange.styles.ts
+++ b/src/components/Filter/components/FilterRange/filterRange.styles.ts
@@ -99,23 +99,21 @@ export const StyledForm = styled("form")<Pick<FilterRangeProps, "surfaceType">>`
   ${({ surfaceType }) =>
     surfaceType === SURFACE_TYPE.DRAWER &&
     css`
-       {
-        padding: 0 16px;
-        width: 312px;
+      padding: 0 16px;
+      width: 312px;
 
-        .MuiGrid-root {
-          gap: 16px 0;
-          grid-template-rows: auto auto;
-          margin: 16px 0;
+      .MuiGrid-root {
+        gap: 16px 0;
+        grid-template-rows: auto auto;
+        margin: 16px 0;
 
-          .MuiFormControl-root {
-            grid-row: unset;
-            grid-template-rows: unset;
-          }
+        .MuiFormControl-root {
+          grid-row: unset;
+          grid-template-rows: unset;
+        }
 
-          .MuiDivider-root {
-            display: none;
-          }
+        .MuiDivider-root {
+          display: none;
         }
       }
     `}

--- a/src/components/Filter/components/Filters/stories/filters.stories.tsx
+++ b/src/components/Filter/components/Filters/stories/filters.stories.tsx
@@ -8,11 +8,23 @@ const meta: Meta<typeof Filters> = {
   component: Filters,
   decorators: [
     (Story): JSX.Element => (
-      <Box sx={{ width: 264 }}>
-        <Story />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          minHeight: "100vh",
+        }}
+      >
+        <Box sx={{ width: 264 }}>
+          <Story />
+        </Box>
       </Box>
     ),
   ],
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export default meta;

--- a/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
+++ b/src/components/Filter/components/VariableSizeList/VariableSizeList.tsx
@@ -120,6 +120,7 @@ export const VariableSizeList = ({
       onItemsRendered={(): void => listRef.current?.resetAfterIndex(0)} // Facilitates correct positioning of list items when list scrolls.
       overscanCount={overscanCount}
       ref={listRef}
+      style={{ overscrollBehavior: "none" }}
       width={width}
     >
       {renderListItem}

--- a/src/components/Layout/components/Header/components/Content/components/Actions/components/Authentication/components/AuthenticationMenu/constants.ts
+++ b/src/components/Layout/components/Header/components/Content/components/Actions/components/Authentication/components/AuthenticationMenu/constants.ts
@@ -1,5 +1,5 @@
 import { MenuProps } from "@mui/material";
-import { VARIANT } from "../../../../../../../../../../../../styles/common/mui/paper";
+import { PAPER_PROPS } from "../../../../../../../../../../../../styles/common/mui/paper";
 import {
   POPOVER_ORIGIN_HORIZONTAL,
   POPOVER_ORIGIN_VERTICAL,
@@ -11,7 +11,7 @@ export const MENU_PROPS: Partial<MenuProps> = {
     vertical: POPOVER_ORIGIN_VERTICAL.BOTTOM,
   },
   autoFocus: false,
-  slotProps: { paper: { variant: VARIANT.MENU } },
+  slotProps: { paper: { variant: PAPER_PROPS.VARIANT.MENU } },
   transformOrigin: {
     horizontal: POPOVER_ORIGIN_HORIZONTAL.RIGHT,
     vertical: POPOVER_ORIGIN_VERTICAL.TOP,

--- a/src/components/Layout/components/Sidebar/components/SidebarDrawer/sidebarDrawer.tsx
+++ b/src/components/Layout/components/Sidebar/components/SidebarDrawer/sidebarDrawer.tsx
@@ -33,7 +33,6 @@ export const SidebarDrawer = ({
       open={open}
       slotProps={DRAWER_SLOT_PROPS}
       TransitionComponent={DrawerTransition}
-      transitionDuration={open ? 250 : 300}
     >
       <IconButton Icon={CloseRounded} onClick={onClose} size="medium" />
       {children}

--- a/src/components/common/Popper/provider/context.ts
+++ b/src/components/common/Popper/provider/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+import { PopperContextProps } from "./types";
+
+export const PopperContext = createContext<PopperContextProps>({
+  anchorEl: null,
+  onClose: () => {},
+  onOpen: () => {},
+  open: false,
+});

--- a/src/components/common/Popper/provider/hook.ts
+++ b/src/components/common/Popper/provider/hook.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { PopperContext } from "./context";
+import { PopperContextProps } from "./types";
+
+/**
+ * Returns popper context.
+ * @returns popper context.
+ */
+export const usePopper = (): PopperContextProps => {
+  return useContext(PopperContext);
+};

--- a/src/components/common/Popper/provider/provider.tsx
+++ b/src/components/common/Popper/provider/provider.tsx
@@ -1,0 +1,24 @@
+import { JSX, MouseEvent, useCallback, useState } from "react";
+import { PopperContext } from "./context";
+import { PopperProviderProps } from "./types";
+
+export function PopperProvider({ children }: PopperProviderProps): JSX.Element {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const open = Boolean(anchorEl);
+
+  const onClose = useCallback(() => setAnchorEl(null), []);
+
+  const onOpen = useCallback(
+    (event: MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget),
+    [],
+  );
+
+  return (
+    <PopperContext.Provider value={{ anchorEl, onClose, onOpen, open }}>
+      {typeof children === "function"
+        ? children({ anchorEl, onClose, onOpen, open })
+        : children}
+    </PopperContext.Provider>
+  );
+}

--- a/src/components/common/Popper/provider/types.ts
+++ b/src/components/common/Popper/provider/types.ts
@@ -1,0 +1,11 @@
+import { PopperProps } from "@mui/material";
+import { MouseEvent, ReactNode } from "react";
+
+export type PopperContextProps = Pick<PopperProps, "anchorEl" | "open"> & {
+  onClose: () => void;
+  onOpen: (e: MouseEvent<HTMLElement>) => void;
+};
+
+export type PopperProviderProps = {
+  children: ReactNode | ((props: PopperContextProps) => ReactNode);
+};

--- a/src/styles/common/mui/paper.ts
+++ b/src/styles/common/mui/paper.ts
@@ -1,10 +1,18 @@
 import { PaperProps } from "@mui/material";
 
-export const VARIANT: Record<string, PaperProps["variant"]> = {
+type PaperPropsOptions = {
+  VARIANT: typeof VARIANT;
+};
+
+const VARIANT = {
   ELEVATION: "elevation",
   FOOTER: "footer",
   MENU: "menu",
   OUTLINED: "outlined",
   PANEL: "panel",
   SEARCH_BAR: "searchbar",
+} as const satisfies Record<string, PaperProps["variant"]>;
+
+export const PAPER_PROPS: PaperPropsOptions = {
+  VARIANT,
 };

--- a/src/styles/common/mui/popper.ts
+++ b/src/styles/common/mui/popper.ts
@@ -1,0 +1,27 @@
+import { PopperProps } from "@mui/material";
+
+type PopperPropsOptions = {
+  PLACEMENT: typeof PLACEMENT;
+};
+
+const PLACEMENT = {
+  AUTO: "auto",
+  AUTO_END: "auto-end",
+  AUTO_START: "auto-start",
+  BOTTOM: "bottom",
+  BOTTOM_END: "bottom-end",
+  BOTTOM_START: "bottom-start",
+  LEFT: "left",
+  LEFT_END: "left-end",
+  LEFT_START: "left-start",
+  RIGHT: "right",
+  RIGHT_END: "right-end",
+  RIGHT_START: "right-start",
+  TOP: "top",
+  TOP_END: "top-end",
+  TOP_START: "top-start",
+} as const satisfies Record<string, PopperProps["placement"]>;
+
+export const POPPER_PROPS: PopperPropsOptions = {
+  PLACEMENT,
+};


### PR DESCRIPTION
## Summary

Closes #912.

- Migrates the Filter popover from MUI `Popover` (anchor-position) to MUI `Popper` (Popper.js) so the popover flips above the trigger row when there isn't enough room below — keeping the selected filter label visible. Default placement `bottom-start`, fallbacks `top-start` then `right`.
- Adds `PopperProvider` (`src/components/common/Popper/provider/`) for popper open/anchor state, a local `Backdrop` (Popper doesn't ship one), and a `useCloseOnEscape` hook that listens in capture phase and `stopPropagation`s — so Escape closes only the filter popover, not parent Dialog/Modal contexts (preserves prior Popover-as-Modal scoping behaviour).
- Splits transitions: new `MenuTransition` (Grow with placement-driven `transformOrigin`) and refactored `DrawerTransition` (Slide). Aligns `src/styles/common/mui/popper.ts` and `paper.ts` to the `svgIcon.ts` pattern (`POPPER_PROPS.PLACEMENT.*`, `PAPER_PROPS.VARIANT.*`).

Addresses the consuming-app request in [human-pangenomics/hprc-data-explorer#278](https://github.com/human-pangenomics/hprc-data-explorer/issues/278); original report at [clevercanary/cc-design#307](https://github.com/clevercanary/cc-design/issues/307).

## Test plan

- [x] Visual: open a filter near the bottom of the viewport — popper flips above the trigger row, label stays visible
- [x] Visual: open a filter in drawer surface (mobile breakpoint) — popper sits over the open drawer and slides in from the left
- [x] Escape inside a filter popover that sits inside a parent Dialog/Modal closes only the filter (parent Dialog stays open) — regression test for consumers like brc-analytics ColumnFilters in workflow stepper
- [x] Backdrop click closes the popper and any ancestor drawer
- [x] Escape inside an open filter popover closes the popover and any ancestor drawer
- [x] Drawer-mode IconButton close still closes both popper and drawer
- [x] Range filter and select filter views render correctly in both menu and drawer surfaces
- [x] No regressions in existing Filter, FilterMenu, FilterRange, Filters stories

<img width="1575" height="1285" alt="image" src="https://github.com/user-attachments/assets/9cc3e6eb-c096-4574-8192-0f5c1b8426ad" />

<img width="2558" height="1071" alt="image" src="https://github.com/user-attachments/assets/e7693a6e-aaff-45fd-863e-c26fbbc77949" />

<img width="1231" height="1067" alt="image" src="https://github.com/user-attachments/assets/7206d571-7cb9-4f8f-9a03-2ae49958435c" />

<img width="2413" height="565" alt="image" src="https://github.com/user-attachments/assets/c6fee87f-3c80-4d6f-abb5-566ae449f4d7" />

