### PR TITLE
feat: add GA4 login event tracking

### DIFF
--- a/src/common/analytics/entities.ts
+++ b/src/common/analytics/entities.ts
@@ -16,6 +16,7 @@ export enum EVENT_NAME {
   FILTER_SELECTED = "filter_selected",
   INDEX_ANALYZE_IN_TERRA_REQUESTED = "index_analyze_in_terra_requested",
   INDEX_FILE_MANIFEST_REQUESTED = "index_file_manifest_requested",
+  LOGIN = "login",
 }
 
 /**
@@ -26,6 +27,7 @@ export enum EVENT_PARAM {
   ENTITY_NAME = "entity_name",
   FILTER_NAME = "filter_name",
   FILTER_VALUE = "filter_value",
+  METHOD = "method",
   PAGINATION_DIRECTION = "pagination_direction",
   RELATED_ENTITY_ID = "related_entity_id",
   RELATED_ENTITY_NAME = "related_entity_name",
@@ -82,4 +84,5 @@ export type EventParams = {
   [EVENT_NAME.INDEX_FILE_MANIFEST_REQUESTED]: {
     [EVENT_PARAM.ENTITY_NAME]: string;
   };
+  [EVENT_NAME.LOGIN]: { [EVENT_PARAM.METHOD]: string };
 };

--- a/src/common/analytics/entities.ts
+++ b/src/common/analytics/entities.ts
@@ -16,7 +16,7 @@ export enum EVENT_NAME {
   FILTER_SELECTED = "filter_selected",
   INDEX_ANALYZE_IN_TERRA_REQUESTED = "index_analyze_in_terra_requested",
   INDEX_FILE_MANIFEST_REQUESTED = "index_file_manifest_requested",
-  LOGIN = "login",
+  LOGIN = "login", // GA4 recommended event name; not past tense to match GA4 standard.
 }
 
 /**
@@ -27,7 +27,6 @@ export enum EVENT_PARAM {
   ENTITY_NAME = "entity_name",
   FILTER_NAME = "filter_name",
   FILTER_VALUE = "filter_value",
-  METHOD = "method",
   PAGINATION_DIRECTION = "pagination_direction",
   RELATED_ENTITY_ID = "related_entity_id",
   RELATED_ENTITY_NAME = "related_entity_name",
@@ -84,5 +83,5 @@ export type EventParams = {
   [EVENT_NAME.INDEX_FILE_MANIFEST_REQUESTED]: {
     [EVENT_PARAM.ENTITY_NAME]: string;
   };
-  [EVENT_NAME.LOGIN]: { [EVENT_PARAM.METHOD]: string };
+  [EVENT_NAME.LOGIN]: { [EVENT_PARAM.TOOL_NAME]: string };
 };

--- a/src/google/provider.tsx
+++ b/src/google/provider.tsx
@@ -8,6 +8,7 @@ import { useCredentialsReducer } from "../auth/hooks/useCredentialsReducer";
 import { useSessionIdleTimer } from "../auth/hooks/useSessionIdleTimer";
 import { useSessionActive } from "../hooks/authentication/session/useSessionActive";
 import { useSessionCallbackUrl } from "../hooks/authentication/session/useSessionCallbackUrl";
+import { useLoginTracking } from "../hooks/authentication/useLoginTracking";
 import { AUTH_STATE, AUTHENTICATION_STATE } from "./constants";
 import { useGoogleSignInService } from "./hooks/useGoogleSignInService";
 import { useTokenReducer } from "./hooks/useTokenReducer";
@@ -41,6 +42,7 @@ export function GoogleSignInAuthenticationProvider({
   const { authDispatch, authState } = authReducer;
   const { isAuthenticated } = authState;
   const { authenticationState } = authenticationReducer;
+  useLoginTracking(isAuthenticated);
   useSessionActive(authState, authenticationState);
   useSessionIdleTimer({
     disabled: !isAuthenticated,

--- a/src/google/provider.tsx
+++ b/src/google/provider.tsx
@@ -42,7 +42,7 @@ export function GoogleSignInAuthenticationProvider({
   const { authDispatch, authState } = authReducer;
   const { isAuthenticated } = authState;
   const { authenticationState } = authenticationReducer;
-  useLoginTracking(isAuthenticated);
+  useLoginTracking(isAuthenticated, authState.status);
   useSessionActive(authState, authenticationState);
   useSessionIdleTimer({
     disabled: !isAuthenticated,

--- a/src/hooks/authentication/useLoginTracking.ts
+++ b/src/hooks/authentication/useLoginTracking.ts
@@ -1,22 +1,28 @@
 import { useEffect, useRef } from "react";
+import { AUTH_STATUS } from "../../auth/types/auth";
 import { track } from "../../common/analytics/analytics";
 import { EVENT_NAME, EVENT_PARAM } from "../../common/analytics/entities";
 import { GOOGLE_SIGN_IN_PROVIDER_ID } from "../../google/constants";
 
 /**
  * Tracks a GA4 login event when the user transitions from unauthenticated to authenticated.
- * Does not fire on initial mount if the user is already authenticated.
+ * Does not fire during initial session hydration or on mount if already authenticated.
  * @param isAuthenticated - Current authentication state.
+ * @param status - Current auth status; tracking only begins after status has settled.
  * @returns void.
  */
-export function useLoginTracking(isAuthenticated: boolean): void {
+export function useLoginTracking(
+  isAuthenticated: boolean,
+  status: AUTH_STATUS,
+): void {
   const wasAuthenticated = useRef<boolean | undefined>(undefined);
   useEffect(() => {
+    if (status !== AUTH_STATUS.SETTLED) return;
     if (wasAuthenticated.current === false && isAuthenticated) {
       track(EVENT_NAME.LOGIN, {
         [EVENT_PARAM.TOOL_NAME]: GOOGLE_SIGN_IN_PROVIDER_ID,
       });
     }
     wasAuthenticated.current = isAuthenticated;
-  }, [isAuthenticated]);
+  }, [isAuthenticated, status]);
 }

--- a/src/hooks/authentication/useLoginTracking.ts
+++ b/src/hooks/authentication/useLoginTracking.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+import { track } from "../../common/analytics/analytics";
+import { EVENT_NAME, EVENT_PARAM } from "../../common/analytics/entities";
+
+/**
+ * Tracks a GA4 login event when the user transitions from unauthenticated to authenticated.
+ * Does not fire on initial mount if the user is already authenticated.
+ * @param isAuthenticated - Current authentication state.
+ * @returns void.
+ */
+export function useLoginTracking(isAuthenticated: boolean): void {
+  const wasAuthenticated = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (wasAuthenticated.current === false && isAuthenticated) {
+      track(EVENT_NAME.LOGIN, { [EVENT_PARAM.METHOD]: "google" });
+    }
+    wasAuthenticated.current = isAuthenticated;
+  }, [isAuthenticated]);
+}

--- a/src/hooks/authentication/useLoginTracking.ts
+++ b/src/hooks/authentication/useLoginTracking.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { track } from "../../common/analytics/analytics";
 import { EVENT_NAME, EVENT_PARAM } from "../../common/analytics/entities";
+import { GOOGLE_SIGN_IN_PROVIDER_ID } from "../../google/constants";
 
 /**
  * Tracks a GA4 login event when the user transitions from unauthenticated to authenticated.
@@ -12,7 +13,9 @@ export function useLoginTracking(isAuthenticated: boolean): void {
   const wasAuthenticated = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     if (wasAuthenticated.current === false && isAuthenticated) {
-      track(EVENT_NAME.LOGIN, { [EVENT_PARAM.METHOD]: "google" });
+      track(EVENT_NAME.LOGIN, {
+        [EVENT_PARAM.TOOL_NAME]: GOOGLE_SIGN_IN_PROVIDER_ID,
+      });
     }
     wasAuthenticated.current = isAuthenticated;
   }, [isAuthenticated]);

--- a/src/nextauth/provider.tsx
+++ b/src/nextauth/provider.tsx
@@ -31,7 +31,7 @@ export function NextAuthAuthenticationProvider({
   const service = useNextAuthService();
   const { authDispatch, authState } = authReducer;
   const { isAuthenticated } = authState;
-  useLoginTracking(isAuthenticated);
+  useLoginTracking(isAuthenticated, authState.status);
   const { callbackUrl } = useSessionCallbackUrl();
   useSessionIdleTimer({
     crossTab: true,

--- a/src/nextauth/provider.tsx
+++ b/src/nextauth/provider.tsx
@@ -6,6 +6,7 @@ import { useAuthenticationReducer } from "../auth/hooks/useAuthenticationReducer
 import { useAuthReducer } from "../auth/hooks/useAuthReducer";
 import { useSessionIdleTimer } from "../auth/hooks/useSessionIdleTimer";
 import { useSessionCallbackUrl } from "../hooks/authentication/session/useSessionCallbackUrl";
+import { useLoginTracking } from "../hooks/authentication/useLoginTracking";
 import { useNextAuthService } from "./hooks/useNextAuthService";
 import { SessionController } from "./session-controller";
 import { NextAuthAuthenticationProviderProps } from "./types";
@@ -30,6 +31,7 @@ export function NextAuthAuthenticationProvider({
   const service = useNextAuthService();
   const { authDispatch, authState } = authReducer;
   const { isAuthenticated } = authState;
+  useLoginTracking(isAuthenticated);
   const { callbackUrl } = useSessionCallbackUrl();
   useSessionIdleTimer({
     crossTab: true,

--- a/tests/useLoginTracking.test.ts
+++ b/tests/useLoginTracking.test.ts
@@ -1,5 +1,6 @@
 import { jest } from "@jest/globals";
 import { renderHook } from "@testing-library/react";
+import { AUTH_STATUS } from "../src/auth/types/auth";
 
 const mockTrack = jest.fn();
 
@@ -10,48 +11,65 @@ jest.unstable_mockModule("../src/common/analytics/analytics", () => ({
 const { useLoginTracking } =
   await import("../src/hooks/authentication/useLoginTracking");
 
+const SETTLED = AUTH_STATUS.SETTLED;
+const PENDING = AUTH_STATUS.PENDING;
+
 describe("useLoginTracking", () => {
   beforeEach(() => {
     mockTrack.mockReset();
   });
 
   test("does not fire on initial mount when unauthenticated", () => {
-    renderHook(() => useLoginTracking(false));
+    renderHook(() => useLoginTracking(false, SETTLED));
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
   test("does not fire on initial mount when already authenticated", () => {
-    renderHook(() => useLoginTracking(true));
+    renderHook(() => useLoginTracking(true, SETTLED));
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
   test("fires login event on transition from unauthenticated to authenticated", () => {
     const { rerender } = renderHook(
-      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
-      { initialProps: { isAuthenticated: false } },
+      ({ isAuthenticated, status }) =>
+        useLoginTracking(isAuthenticated, status),
+      { initialProps: { isAuthenticated: false, status: SETTLED } },
     );
-    rerender({ isAuthenticated: true });
+    rerender({ isAuthenticated: true, status: SETTLED });
     expect(mockTrack).toHaveBeenCalledTimes(1);
     expect(mockTrack).toHaveBeenCalledWith("login", { tool_name: "google" });
   });
 
   test("does not fire on transition from authenticated to unauthenticated", () => {
     const { rerender } = renderHook(
-      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
-      { initialProps: { isAuthenticated: true } },
+      ({ isAuthenticated, status }) =>
+        useLoginTracking(isAuthenticated, status),
+      { initialProps: { isAuthenticated: true, status: SETTLED } },
     );
-    rerender({ isAuthenticated: false });
+    rerender({ isAuthenticated: false, status: SETTLED });
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
-  test("fires only once for multiple login transitions", () => {
+  test("fires for each login transition", () => {
     const { rerender } = renderHook(
-      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
-      { initialProps: { isAuthenticated: false } },
+      ({ isAuthenticated, status }) =>
+        useLoginTracking(isAuthenticated, status),
+      { initialProps: { isAuthenticated: false, status: SETTLED } },
     );
-    rerender({ isAuthenticated: true });
-    rerender({ isAuthenticated: false });
-    rerender({ isAuthenticated: true });
+    rerender({ isAuthenticated: true, status: SETTLED });
+    rerender({ isAuthenticated: false, status: SETTLED });
+    rerender({ isAuthenticated: true, status: SETTLED });
     expect(mockTrack).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not fire during session hydration when status is pending", () => {
+    const { rerender } = renderHook(
+      ({ isAuthenticated, status }) =>
+        useLoginTracking(isAuthenticated, status),
+      { initialProps: { isAuthenticated: false, status: PENDING } },
+    );
+    // Session hydrates: isAuthenticated becomes true while status settles.
+    rerender({ isAuthenticated: true, status: SETTLED });
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 });

--- a/tests/useLoginTracking.test.ts
+++ b/tests/useLoginTracking.test.ts
@@ -1,0 +1,57 @@
+import { jest } from "@jest/globals";
+import { renderHook } from "@testing-library/react";
+
+const mockTrack = jest.fn();
+
+jest.unstable_mockModule("../src/common/analytics/analytics", () => ({
+  track: mockTrack,
+}));
+
+const { useLoginTracking } =
+  await import("../src/hooks/authentication/useLoginTracking");
+
+describe("useLoginTracking", () => {
+  beforeEach(() => {
+    mockTrack.mockReset();
+  });
+
+  test("does not fire on initial mount when unauthenticated", () => {
+    renderHook(() => useLoginTracking(false));
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  test("does not fire on initial mount when already authenticated", () => {
+    renderHook(() => useLoginTracking(true));
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  test("fires login event on transition from unauthenticated to authenticated", () => {
+    const { rerender } = renderHook(
+      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
+      { initialProps: { isAuthenticated: false } },
+    );
+    rerender({ isAuthenticated: true });
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith("login", { method: "google" });
+  });
+
+  test("does not fire on transition from authenticated to unauthenticated", () => {
+    const { rerender } = renderHook(
+      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
+      { initialProps: { isAuthenticated: true } },
+    );
+    rerender({ isAuthenticated: false });
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  test("fires only once for multiple login transitions", () => {
+    const { rerender } = renderHook(
+      ({ isAuthenticated }) => useLoginTracking(isAuthenticated),
+      { initialProps: { isAuthenticated: false } },
+    );
+    rerender({ isAuthenticated: true });
+    rerender({ isAuthenticated: false });
+    rerender({ isAuthenticated: true });
+    expect(mockTrack).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/useLoginTracking.test.ts
+++ b/tests/useLoginTracking.test.ts
@@ -32,7 +32,7 @@ describe("useLoginTracking", () => {
     );
     rerender({ isAuthenticated: true });
     expect(mockTrack).toHaveBeenCalledTimes(1);
-    expect(mockTrack).toHaveBeenCalledWith("login", { method: "google" });
+    expect(mockTrack).toHaveBeenCalledWith("login", { tool_name: "google" });
   });
 
   test("does not fire on transition from authenticated to unauthenticated", () => {


### PR DESCRIPTION
## Ticket
Closes #913

## Summary
- Add GA4 `login` event (recommended event) that fires when a user authenticates via Google Sign-In
- Track the `false` → `true` transition of `isAuthenticated` in both auth providers (`GoogleSignInAuthenticationProvider` and `NextAuthAuthenticationProvider`)
- Gate tracking on `AUTH_STATUS.SETTLED` to prevent false positives during session hydration
- Use existing `tool_name` custom dimension (instead of `method`) to avoid provisioning a new GA4 dimension

## Test plan
- [ ] Unit tests pass (`useLoginTracking.test.ts` — 6 cases covering mount, transition, logout, and hydration scenarios)
- [ ] Run AnVIL CMG locally, sign in, and verify `window.dataLayer` contains `{ event: "login", params: { tool_name: "google" } }`
- [ ] Verify the event does not appear on page refresh when already signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)