### PR TITLE
feat: collapsible terrasetupform with opt-in prop (#921)

### DIFF
--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.styles.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.styles.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+import { Button } from "@mui/material";
+
+export const StyledButton = styled(Button)`
+  align-self: center;
+  text-transform: none;
+`;

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.tsx
@@ -1,0 +1,23 @@
+import { JSX } from "react";
+import { BUTTON_PROPS } from "../../../../../../../../styles/common/mui/button";
+import { useTerraSetUpUI } from "../../../../../../../../terra/setUpUI/provider/hook";
+import { StyledButton } from "./button.styles";
+import { ButtonProps } from "./types";
+
+export const Button = ({
+  collapsible = false,
+}: ButtonProps): JSX.Element | null => {
+  const { isOpen, onChange } = useTerraSetUpUI();
+
+  if (!collapsible) return null;
+
+  return (
+    <StyledButton
+      color={isOpen ? BUTTON_PROPS.COLOR.SECONDARY : BUTTON_PROPS.COLOR.PRIMARY}
+      onClick={onChange}
+      variant={BUTTON_PROPS.VARIANT.CONTAINED}
+    >
+      {isOpen ? "Save & continue later" : "Continue"}
+    </StyledButton>
+  );
+};

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/button.tsx
@@ -1,6 +1,7 @@
 import { JSX } from "react";
 import { BUTTON_PROPS } from "../../../../../../../../styles/common/mui/button";
 import { useTerraSetUpUI } from "../../../../../../../../terra/setUpUI/provider/hook";
+import { STEPS_REGION_ID } from "../../constants";
 import { StyledButton } from "./button.styles";
 import { ButtonProps } from "./types";
 
@@ -13,6 +14,8 @@ export const Button = ({
 
   return (
     <StyledButton
+      aria-controls={STEPS_REGION_ID}
+      aria-expanded={isOpen}
       color={isOpen ? BUTTON_PROPS.COLOR.SECONDARY : BUTTON_PROPS.COLOR.PRIMARY}
       onClick={onChange}
       variant={BUTTON_PROPS.VARIANT.CONTAINED}

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/types.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/Button/types.ts
@@ -1,0 +1,3 @@
+export interface ButtonProps {
+  collapsible?: boolean;
+}

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.styles.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.styles.ts
@@ -8,7 +8,7 @@ export const Section = styled("div")`
   border-top: 1px solid ${PALETTE.SMOKE_MAIN};
   display: grid;
   gap: 16px;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr;
 `;
 
 export const SectionContent = styled.div`

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.styles.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.styles.ts
@@ -1,8 +1,26 @@
 import styled from "@emotion/styled";
-import { SectionContent as DXSectionContent } from "../../terraSetUpForm.styles";
+import { PALETTE } from "../../../../../../../../styles/common/constants/palette";
+import { sectionPadding } from "../../../../../../../common/Section/section.styles";
 
-export const SectionContent = styled(DXSectionContent)`
+export const Section = styled("div")`
+  ${sectionPadding};
+  background-color: ${PALETTE.COMMON_WHITE};
+  border-top: 1px solid ${PALETTE.SMOKE_MAIN};
+  display: grid;
+  gap: 16px;
+  grid-template-columns: auto 1fr auto;
+`;
+
+export const SectionContent = styled.div`
+  display: grid;
   gap: 2px;
+  grid-row: 1;
+
+  .MuiTypography-body-400-2lines {
+    p {
+      margin: 0;
+    }
+  }
 
   .MuiTypography-body-500 {
     margin: 2px 0;

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/components/FormStep/formStep.tsx
@@ -2,12 +2,8 @@ import { StepIcon, Typography } from "@mui/material";
 import { JSX, ReactNode } from "react";
 import { TYPOGRAPHY_PROPS } from "../../../../../../../../styles/common/mui/typography";
 import { FormStatusCompletedIcon } from "../../../../../../../common/CustomIcon/components/FormStatusCompletedIcon/formStatusCompletedIcon";
-import {
-  Section,
-  SectionActions,
-  SectionStatus,
-} from "../../terraSetUpForm.styles";
-import { SectionContent } from "./formStep.styles";
+import { SectionActions, SectionStatus } from "../../terraSetUpForm.styles";
+import { Section, SectionContent } from "./formStep.styles";
 
 export interface FormStepProps {
   action: ReactNode;

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/constants.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * DOM id of the collapsible steps region. Used by the toggle button's
+ * `aria-controls` so assistive tech can associate the toggle with the
+ * region it expands/collapses.
+ */
+export const STEPS_REGION_ID = "terra-set-up-form-steps";

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/args.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/args.ts
@@ -1,0 +1,45 @@
+import { ComponentProps } from "react";
+import { AUTH_STATUS, AuthState } from "../../../../../../../auth/types/auth";
+import { REQUEST_STATUS } from "../../../../../../../terra/types/common";
+import { TerraProfileContextProps } from "../../../../../../../terra/types/context";
+import { TerraSetUpForm } from "../terraSetUpForm";
+
+/**
+ * Authenticated, settled auth state — used so `TerraSetUpForm` doesn't bail
+ * early on its `isAuthenticated` / status guards.
+ */
+export const MOCK_AUTH_STATE: AuthState = {
+  isAuthenticated: true,
+  status: AUTH_STATUS.SETTLED,
+};
+
+/**
+ * Terra profile statuses where every onboarding step is supported but not yet
+ * complete — produces three incomplete steps in the rendered form.
+ */
+export const MOCK_TERRA_PROFILE_INCOMPLETE: TerraProfileContextProps = {
+  terraNIHProfileLoginStatus: {
+    isSuccess: false,
+    isSupported: true,
+    requestStatus: REQUEST_STATUS.COMPLETED,
+    response: undefined,
+  },
+  terraProfileLoginStatus: {
+    isSuccess: false,
+    isSupported: true,
+    requestStatus: REQUEST_STATUS.COMPLETED,
+    response: undefined,
+  },
+  terraTOSLoginStatus: {
+    isSuccess: false,
+    isSupported: true,
+    requestStatus: REQUEST_STATUS.COMPLETED,
+    response: undefined,
+  },
+};
+
+export const DEFAULT_TERRA_SET_UP_FORM_ARGS: ComponentProps<
+  typeof TerraSetUpForm
+> = {
+  collapsible: true,
+};

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/constants.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/constants.ts
@@ -1,0 +1,5 @@
+import { ComponentProps } from "react";
+import { TerraSetUpForm } from "../terraSetUpForm";
+
+export const BOOLEAN_CONTROLS: (keyof ComponentProps<typeof TerraSetUpForm>)[] =
+  ["collapsible"];

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/terraSetUpForm.stories.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/stories/terraSetUpForm.stories.tsx
@@ -1,0 +1,59 @@
+import { Box } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ComponentProps, JSX } from "react";
+import { AuthContext } from "../../../../../../../auth/contexts/auth";
+import { CONTROL_TYPE } from "../../../../../../../storybook/controls/types";
+import { configureControls } from "../../../../../../../storybook/controls/utils";
+import { TerraProfileContext } from "../../../../../../../terra/context";
+import { TerraSetUpUIProvider } from "../../../../../../../terra/setUpUI/provider/provider";
+import { TerraSetUpForm } from "../terraSetUpForm";
+import {
+  DEFAULT_TERRA_SET_UP_FORM_ARGS,
+  MOCK_AUTH_STATE,
+  MOCK_TERRA_PROFILE_INCOMPLETE,
+} from "./args";
+import { BOOLEAN_CONTROLS } from "./constants";
+
+const meta: Meta<typeof TerraSetUpForm> = {
+  argTypes: {
+    ...configureControls<ComponentProps<typeof TerraSetUpForm>>(
+      BOOLEAN_CONTROLS,
+      CONTROL_TYPE.BOOLEAN,
+    ),
+  },
+  component: TerraSetUpForm,
+  decorators: [
+    (Story): JSX.Element => (
+      <AuthContext.Provider
+        value={{
+          authDispatch: null,
+          authState: MOCK_AUTH_STATE,
+          service: undefined,
+        }}
+      >
+        <TerraProfileContext.Provider value={MOCK_TERRA_PROFILE_INCOMPLETE}>
+          <TerraSetUpUIProvider>
+            <Box m={8}>
+              <Story />
+            </Box>
+          </TerraSetUpUIProvider>
+        </TerraProfileContext.Provider>
+      </AuthContext.Provider>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: DEFAULT_TERRA_SET_UP_FORM_ARGS,
+};
+
+export const NotCollapsible: Story = {
+  args: { ...DEFAULT_TERRA_SET_UP_FORM_ARGS, collapsible: false },
+};

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.styles.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.styles.ts
@@ -1,25 +1,16 @@
 import styled from "@emotion/styled";
+import { Stack } from "@mui/material";
 import { PALETTE } from "../../../../../../styles/common/constants/palette";
+import { FluidPaper } from "../../../../../common/Paper/components/FluidPaper/fluidPaper";
 import { sectionPadding } from "../../../../../common/Section/section.styles";
 
-export const Section = styled("div")`
-  ${sectionPadding};
+export const StyledFluidPaper = styled(FluidPaper)`
   background-color: ${PALETTE.COMMON_WHITE};
-  display: grid;
-  gap: 16px;
-  grid-template-columns: auto 1fr;
 `;
 
-export const SectionContent = styled("div")`
-  display: grid;
-  gap: 4px;
-  grid-row: 1;
-
-  .MuiTypography-body-400-2lines {
-    p {
-      margin: 0;
-    }
-  }
+export const StyledStack = styled(Stack)`
+  ${sectionPadding};
+  justify-content: space-between;
 `;
 
 export const SectionStatus = styled("div")`

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
@@ -15,6 +15,7 @@ import { Button } from "./components/Button/button";
 import { AcceptTerraTOS } from "./components/FormStep/components/AcceptTerraTOS/acceptTerraTOS";
 import { ConnectTerraToNIHAccount } from "./components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount";
 import { CreateTerraAccount } from "./components/FormStep/components/CreateTerraAccount/createTerraAccount";
+import { STEPS_REGION_ID } from "./constants";
 import { StyledFluidPaper, StyledStack } from "./terraSetUpForm.styles";
 import { TerraSetUpFormProps } from "./types";
 
@@ -46,7 +47,7 @@ export const TerraSetUpForm = ({
         </Stack>
         <Button collapsible={collapsible} />
       </StyledStack>
-      <Collapse in={collapsible ? isOpen : true}>
+      <Collapse id={STEPS_REGION_ID} in={collapsible ? isOpen : true}>
         <CreateTerraAccount
           active={isStepActive(
             onboardingStatusByStep,

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@mui/material";
+import { Collapse, Stack, Typography } from "@mui/material";
 import { JSX } from "react";
 import { useAuth } from "../../../../../../auth/hooks/useAuth";
 import { AUTH_STATUS } from "../../../../../../auth/types/auth";
@@ -7,39 +7,46 @@ import {
   OnboardingStatus,
   useAuthenticationForm,
 } from "../../../../../../hooks/authentication/terra/useAuthenticationForm";
+import { STACK_PROPS } from "../../../../../../styles/common/mui/stack";
 import { TYPOGRAPHY_PROPS } from "../../../../../../styles/common/mui/typography";
-import {
-  FluidPaper,
-  GridPaper,
-} from "../../../../../common/Paper/paper.styles";
+import { useTerraSetUpUI } from "../../../../../../terra/setUpUI/provider/hook";
 import { SectionTitle } from "../../../../../common/Section/components/SectionTitle/sectionTitle";
+import { Button } from "./components/Button/button";
 import { AcceptTerraTOS } from "./components/FormStep/components/AcceptTerraTOS/acceptTerraTOS";
 import { ConnectTerraToNIHAccount } from "./components/FormStep/components/ConnectTerraToNIHAccount/connectTerraToNIHAccount";
 import { CreateTerraAccount } from "./components/FormStep/components/CreateTerraAccount/createTerraAccount";
-import { Section, SectionContent } from "./terraSetUpForm.styles";
+import { StyledFluidPaper, StyledStack } from "./terraSetUpForm.styles";
+import { TerraSetUpFormProps } from "./types";
 
-export const TerraSetUpForm = (): JSX.Element | null => {
+export const TerraSetUpForm = ({
+  collapsible = false,
+}: TerraSetUpFormProps): JSX.Element | null => {
   const {
     authState: { isAuthenticated, status },
   } = useAuth();
   const { isComplete, onboardingStatusByStep } = useAuthenticationForm();
+  const { isOpen } = useTerraSetUpUI();
+
   if (!isAuthenticated) return null;
   if (status === AUTH_STATUS.PENDING) return null;
-  return isComplete ? null : (
-    <FluidPaper>
-      <GridPaper>
-        <Section>
-          <SectionContent>
-            <SectionTitle title="Complete your setup" />
-            <Typography
-              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
-              variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}
-            >
-              Follow these steps to unlock the full potential of the data
-              explorer.
-            </Typography>
-          </SectionContent>
-        </Section>
+  if (isComplete) return null;
+
+  return (
+    <StyledFluidPaper>
+      <StyledStack direction={STACK_PROPS.DIRECTION.ROW} useFlexGap>
+        <Stack gap={1} useFlexGap>
+          <SectionTitle title="Complete your setup" />
+          <Typography
+            color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+            variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400_2_LINES}
+          >
+            Follow these steps to unlock the full potential of the data
+            explorer.
+          </Typography>
+        </Stack>
+        <Button collapsible={collapsible} />
+      </StyledStack>
+      <Collapse in={collapsible ? isOpen : true}>
         <CreateTerraAccount
           active={isStepActive(
             onboardingStatusByStep,
@@ -75,8 +82,8 @@ export const TerraSetUpForm = (): JSX.Element | null => {
             step={ONBOARDING_STEP.NIH_ACCOUNT}
           />
         )}
-      </GridPaper>
-    </FluidPaper>
+      </Collapse>
+    </StyledFluidPaper>
   );
 };
 

--- a/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/types.ts
+++ b/src/components/Export/components/ExportToTerra/components/TerraSetUpForm/types.ts
@@ -1,0 +1,3 @@
+export interface TerraSetUpFormProps {
+  collapsible?: boolean;
+}

--- a/src/components/common/Collapse/provider/context.ts
+++ b/src/components/common/Collapse/provider/context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+import { CollapseContextProps } from "./types";
+
+/**
+ * Collapse context. Tracks an in/out boolean and a toggle callback for any
+ * collapsible UI surface that opts in via `CollapseProvider`.
+ */
+export const CollapseContext = createContext<CollapseContextProps>({
+  isIn: false,
+  onChange: () => undefined,
+});

--- a/src/components/common/Collapse/provider/hook.ts
+++ b/src/components/common/Collapse/provider/hook.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { CollapseContext } from "./context";
+import { CollapseContextProps } from "./types";
+
+/**
+ * Returns collapse context.
+ * @returns collapse context.
+ */
+export const useCollapse = (): CollapseContextProps => {
+  return useContext(CollapseContext);
+};

--- a/src/components/common/Collapse/provider/provider.tsx
+++ b/src/components/common/Collapse/provider/provider.tsx
@@ -2,6 +2,16 @@ import { JSX, useCallback, useState } from "react";
 import { CollapseContext } from "./context";
 import { CollapseProviderProps } from "./types";
 
+/**
+ * Holds in-memory collapse state for any UI that opts in. Exposes `isIn`
+ * and a toggle callback to descendants via `CollapseContext`. Accepts a
+ * render-prop child so the value can be passed to a sibling context without
+ * an extra hook consumer.
+ * @param props - Provider props.
+ * @param props.children - React children or a render function receiving the context value.
+ * @param props.initialState - Initial value for `isIn` (defaults to `false`).
+ * @returns Collapse provider component.
+ */
 export function CollapseProvider({
   children,
   initialState = false,

--- a/src/components/common/Collapse/provider/provider.tsx
+++ b/src/components/common/Collapse/provider/provider.tsx
@@ -1,0 +1,18 @@
+import { JSX, useCallback, useState } from "react";
+import { CollapseContext } from "./context";
+import { CollapseProviderProps } from "./types";
+
+export function CollapseProvider({
+  children,
+  initialState = false,
+}: CollapseProviderProps): JSX.Element {
+  const [isIn, setIsIn] = useState<boolean>(initialState);
+
+  const onChange = useCallback(() => setIsIn((prev) => !prev), []);
+
+  return (
+    <CollapseContext.Provider value={{ isIn, onChange }}>
+      {typeof children === "function" ? children({ isIn, onChange }) : children}
+    </CollapseContext.Provider>
+  );
+}

--- a/src/components/common/Collapse/provider/types.ts
+++ b/src/components/common/Collapse/provider/types.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+export type CollapseContextProps = {
+  isIn: boolean;
+  onChange: () => void;
+};
+
+export type CollapseProviderProps = {
+  children: ReactNode | ((props: CollapseContextProps) => ReactNode);
+  initialState?: boolean;
+};

--- a/src/terra/provider.tsx
+++ b/src/terra/provider.tsx
@@ -7,6 +7,7 @@ import { useAuthentication } from "../auth/hooks/useAuthentication";
 import { useCredentials } from "../auth/hooks/useCredentials";
 import { TerraProfileContext } from "./context";
 import { useFetchProfiles } from "./hooks/useFetchProfiles";
+import { TerraSetUpUIProvider } from "./setUpUI/provider/provider";
 import { TerraProfileProviderProps } from "./types/common";
 
 /**
@@ -61,7 +62,7 @@ export function TerraProfileProvider({
         terraTOSLoginStatus,
       }}
     >
-      {children}
+      <TerraSetUpUIProvider>{children}</TerraSetUpUIProvider>
     </TerraProfileContext.Provider>
   );
 }

--- a/src/terra/setUpUI/provider/context.ts
+++ b/src/terra/setUpUI/provider/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+import { TerraSetUpUIContextValue } from "./types";
+
+/**
+ * Terra set-up UI context.
+ */
+export const TerraSetUpUIContext = createContext<TerraSetUpUIContextValue>({
+  isOpen: true,
+  onChange: () => undefined,
+});

--- a/src/terra/setUpUI/provider/hook.ts
+++ b/src/terra/setUpUI/provider/hook.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { TerraSetUpUIContext } from "./context";
+import { TerraSetUpUIContextValue } from "./types";
+
+/**
+ * Returns the terra set-up UI context value.
+ * @returns terra set-up UI context value.
+ */
+export function useTerraSetUpUI(): TerraSetUpUIContextValue {
+  return useContext(TerraSetUpUIContext);
+}

--- a/src/terra/setUpUI/provider/provider.tsx
+++ b/src/terra/setUpUI/provider/provider.tsx
@@ -1,5 +1,5 @@
-import { CollapseProvider } from "@databiosphere/findable-ui/lib/components/common/Collapse/provider/provider";
 import { JSX, ReactNode } from "react";
+import { CollapseProvider } from "../../../components/common/Collapse/provider/provider";
 import { TerraSetUpUIContext } from "./context";
 
 /**

--- a/src/terra/setUpUI/provider/provider.tsx
+++ b/src/terra/setUpUI/provider/provider.tsx
@@ -1,0 +1,29 @@
+import { CollapseProvider } from "@databiosphere/findable-ui/lib/components/common/Collapse/provider/provider";
+import { JSX, ReactNode } from "react";
+import { TerraSetUpUIContext } from "./context";
+
+/**
+ * Provides transient UI state for the `TerraSetUpForm` (e.g. collapsed/expanded).
+ * Mounted automatically inside `TerraProfileProvider`.
+ * @param props - Provider props.
+ * @param props.children - Children components.
+ * @returns terra set-up UI provider.
+ */
+export function TerraSetUpUIProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <CollapseProvider initialState={true}>
+      {({ isIn, onChange }) => {
+        const value = { isOpen: isIn, onChange };
+        return (
+          <TerraSetUpUIContext.Provider value={value}>
+            {children}
+          </TerraSetUpUIContext.Provider>
+        );
+      }}
+    </CollapseProvider>
+  );
+}

--- a/src/terra/setUpUI/provider/types.ts
+++ b/src/terra/setUpUI/provider/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Terra set-up UI context value. Tracks transient UI state for the
+ * `TerraSetUpForm` (e.g. whether the wizard is open or collapsed by the user).
+ *
+ * State is held in-memory in the provider, so it persists across SPA
+ * navigations within a session and resets on full page reload, new tab, or
+ * browser close. No browser storage is used.
+ */
+export interface TerraSetUpUIContextValue {
+  isOpen: boolean;
+  onChange: () => void;
+}

--- a/tests/terraSetUpUIProvider.test.tsx
+++ b/tests/terraSetUpUIProvider.test.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from "@testing-library/react";
+import { JSX } from "react";
+import { useTerraSetUpUI } from "../src/terra/setUpUI/provider/hook";
+import { TerraSetUpUIProvider } from "../src/terra/setUpUI/provider/provider";
+
+const TEST_ID_STATE = "terra-set-up-ui-state";
+const TEST_ID_TOGGLE = "terra-set-up-ui-toggle";
+const TEXT_OPEN = "open";
+const TEXT_CLOSED = "closed";
+
+function Consumer(): JSX.Element {
+  const { isOpen, onChange } = useTerraSetUpUI();
+  return (
+    <>
+      <div data-testid={TEST_ID_STATE}>{isOpen ? TEXT_OPEN : TEXT_CLOSED}</div>
+      <button data-testid={TEST_ID_TOGGLE} onClick={onChange}>
+        toggle
+      </button>
+    </>
+  );
+}
+
+describe("TerraSetUpUIProvider", () => {
+  it("renders children with the initial open state", () => {
+    render(
+      <TerraSetUpUIProvider>
+        <Consumer />
+      </TerraSetUpUIProvider>,
+    );
+    expect(screen.getByTestId(TEST_ID_STATE).textContent).toEqual(TEXT_OPEN);
+  });
+
+  it("toggles isOpen when onChange is invoked", () => {
+    render(
+      <TerraSetUpUIProvider>
+        <Consumer />
+      </TerraSetUpUIProvider>,
+    );
+
+    expect(screen.getByTestId(TEST_ID_STATE).textContent).toEqual(TEXT_OPEN);
+
+    act(() => {
+      screen.getByTestId(TEST_ID_TOGGLE).click();
+    });
+    expect(screen.getByTestId(TEST_ID_STATE).textContent).toEqual(TEXT_CLOSED);
+
+    act(() => {
+      screen.getByTestId(TEST_ID_TOGGLE).click();
+    });
+    expect(screen.getByTestId(TEST_ID_STATE).textContent).toEqual(TEXT_OPEN);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #921.

Adds an opt-in collapse/dismiss affordance to `TerraSetUpForm`. Consumers pass `collapsible: true` to render a "Save & continue later" / "Continue" toggle in the form header; the wizard's step list collapses via MUI `<Collapse>`. State is held in-memory in a React provider (no `sessionStorage` / `localStorage`), so it survives SPA navigation within a session and resets on full page reload, new tab, or browser close — matches the consuming app's session-only requirement.

## What changed

### New generic `CollapseProvider` (`src/components/common/Collapse/provider/`)
Reusable collapse context — `{ isIn, onChange }` shape with optional render-prop children. Mountable around any UI that needs in-memory collapse state.

### New `TerraSetUpUIProvider` (`src/terra/setUpUI/provider/`)
Terra-specific wrapper around `CollapseProvider` that exposes `{ isOpen, onChange }` semantically aligned with the form's open/closed UX. Mounted automatically inside `TerraProfileProvider` (`src/terra/provider.tsx`), so consumers don't wire it themselves.

### `TerraSetUpForm` (`src/components/Export/.../TerraSetUpForm/`)
- New `collapsible?: boolean` prop (default `false`, non-breaking).
- Switched the section header from a grid to a `<Stack direction="row" justify-content="space-between">` housing the title block + toggle button.
- Step list wrapped in `<Collapse in={collapsible ? isOpen : true}>` — non-collapsible consumers see no behavioural change.
- New `Button` subcomponent renders the "Save & continue later" / "Continue" toggle; returns `null` when `collapsible` is false.
- `TerraSetUpFormProps` moved to a local `types.ts`.

### Stories
- `Default` story renders the form with `collapsible: true`.
- `NotCollapsible` story renders with `collapsible: false`.
- Decorators wrap the form in mock `AuthContext` (`isAuthenticated: true, status: SETTLED`), `TerraProfileContext` with three incomplete login statuses, and `TerraSetUpUIProvider`.

## Acceptance criteria

- [x] `collapsible` defaults to false → existing render unchanged.
- [x] `collapsible: true`: toggle button visible, collapse/expand works.
- [x] Collapse state survives SPA navigation within the session.
- [x] Collapse state resets on full reload, tab close, browser close.
- [x] No `sessionStorage` / `localStorage`.
- [x] Provider mounted automatically inside `TerraProfileProvider`.
- [x] Stories cover both `collapsible: true` and `collapsible: false` variants.

## Out of scope

- Consumer (data-biosphere AnVIL) site-config opt-in — separate ticket on that repo.
- Persisting across full reloads — explicitly NOT desired.

## Related

- DataBiosphere/data-browser#4816 (consumer driver).
- clevercanary/cc-design#308 (design spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1585" height="834" alt="image" src="https://github.com/user-attachments/assets/50c0b3cb-5b13-4a02-b4ff-a153c3d049f1" />

<img width="1588" height="840" alt="image" src="https://github.com/user-attachments/assets/43f6872a-7f3b-4435-9d30-440d25ad0d0d" />
