### PR TITLE
chore: add sideeffects field to package.json to enable bundler tree-shaking (#886)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/DataBiosphere/findable-ui/tree/main/#readme",
   "main": "lib/index.js",
+  "sideEffects": false,
   "files": [
     "lib",
     "types"


### PR DESCRIPTION
## Summary

Adds `"sideEffects": false` to `package.json` to enable webpack/Turbopack tree-shaking in consumer applications. The library is genuinely side-effect free at module load — this is correct metadata to publish.

Closes #886.

## Audit

Verified there are no module-load side effects in `src/`:

- ✅ No `.css` / `.scss` imports
- ✅ No top-level `window` / `global` / `globalThis` mutations
- ✅ No top-level `console.log` / `addEventListener` / IIFEs
- ✅ Module-scope `let` singletons (`dxConfig` in `config/config.ts`, `kyInstance` in `entity/common/client.ts`, `hasInstalledInterceptor` in `services/beforePopState/popStateBus.ts`) only declare initial state; mutation happens lazily via exported functions when called by consumers
- ✅ `src/common/analytics/analytics.ts` is purely function-scoped
- ✅ Providers use `createContext(...)` (pure)
- ✅ Yup schemas (`SCHEMA` in `UseFilterRange`, `VALIDATION_SCHEMA` in `SupportRequestForm`) are pure construction at module scope — bundler can drop them when unused
- ✅ `new Set<BeforePopStateCallback>()` at top of `popStateBus.ts` is pure; interceptor is only installed when `registerPopStateHandler()` is called

Verdict: Option A (`"sideEffects": false`) is safe — no allowlist needed.

## Bundle-analyzer measurement

Tested against **data-biosphere** (anvil-cmg production build) using `@next/bundle-analyzer`:

|                                  | Total client JS gzipped |
| -------------------------------- | ----------------------- |
| Before — 52.2.0 (registry)       | 846.74 KB               |
| After — local tarball + `"sideEffects": false` | 850.77 KB               |

**Net delta: ~0** (slight fluctuation is from unrelated v53 changes — MarkdownRenderer DOMPurify removal — bleeding into the AFTER baseline).

### Why neutral for data-biosphere

`grep` of consumer imports:

- **548** deep imports: `from "@databiosphere/findable-ui/lib/<path>"`
- **0** barrel imports: `from "@databiosphere/findable-ui"`

When a consumer always reaches for specific files via deep imports, the bundler is already loading only what's needed; there's nothing for `sideEffects` to additionally drop. Other findable-ui consumers (anvil-portal, data-browser, etc.) follow the same deep-import convention per `CLAUDE.md` ("External apps import as `@databiosphere/findable-ui/lib/<path>`"), so the picture is the same across the fleet.

### Why land it anyway

- Correct metadata for a side-effect-free library — what tree-shaking-aware bundlers expect.
- Zero cost / zero risk — runtime behavior of the library is unchanged.
- **Latent benefit**: protects consumer bundles the moment any consumer adopts barrel imports, or if a findable-ui barrel index ever starts re-exporting from heavy submodules.
- Defensive future-proofing.

## Test plan

- [x] `npm run check-format` ✓
- [x] `npm run lint` ✓
- [x] `npm run test-compile` ✓
- [x] `npm test` — 49 suites, 425 tests ✓
- [x] `npm run storybook` boots cleanly (HTTP 200, 2.72s preview build, no errors)
- [x] Production build of data-biosphere succeeds against local tarball

## Acceptance criteria

- [x] Audit completed; no offending modules
- [x] `sideEffects` field added to `package.json`
- [x] Lint, tests, and `tsc --noEmit` pass
- [x] Storybook renders cleanly
- [x] Before/after bundle-analyzer numbers from one consumer included above (screenshots can be regenerated on request — local artifacts deleted post-measurement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2009" height="1316" alt="image" src="https://github.com/user-attachments/assets/a73b0d9b-8c7a-46a0-9945-19f3b67be960" />
