### PR TITLE
feat: useRouter().pathname → usePathname() (#928)

### DIFF
--- a/src/hooks/stateSyncManager/hooks/UseStateSync/hook.ts
+++ b/src/hooks/stateSyncManager/hooks/UseStateSync/hook.ts
@@ -1,4 +1,3 @@
-import { usePathname } from "next/navigation";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect } from "react";
 import { ROUTER_METHOD } from "../../../../providers/exploreState/actions/stateToUrl/types";
@@ -11,8 +10,7 @@ export const useStateSync = <Action>({
   dispatch,
   state,
 }: UseStateSyncManagerProps<Action>): void => {
-  const { basePath, isReady, query } = useRouter();
-  const pathname = usePathname() ?? "";
+  const { basePath, isReady, pathname, query } = useRouter();
   const { onClearPopRef, popRef } = useWasPop();
 
   // Extract the query from the state.

--- a/src/hooks/stateSyncManager/hooks/UseStateSync/hook.ts
+++ b/src/hooks/stateSyncManager/hooks/UseStateSync/hook.ts
@@ -1,3 +1,4 @@
+import { usePathname } from "next/navigation";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect } from "react";
 import { ROUTER_METHOD } from "../../../../providers/exploreState/actions/stateToUrl/types";
@@ -10,7 +11,8 @@ export const useStateSync = <Action>({
   dispatch,
   state,
 }: UseStateSyncManagerProps<Action>): void => {
-  const { basePath, isReady, pathname, query } = useRouter();
+  const { basePath, isReady, query } = useRouter();
+  const pathname = usePathname() ?? "";
   const { onClearPopRef, popRef } = useWasPop();
 
   // Extract the query from the state.

--- a/src/hooks/useUpdateURLCatalogParam.ts
+++ b/src/hooks/useUpdateURLCatalogParam.ts
@@ -7,6 +7,14 @@ import { useExploreState } from "./useExploreState";
  */
 export const useUpdateURLCatalogParams = (): void => {
   const { exploreState } = useExploreState();
+  // `pathname` is intentionally still read from useRouter() here so it stays as
+  // the route pattern (e.g. `/[entityListType]/[entityId]`). The pattern is
+  // required by the Router.replace({ pathname, query }) call below — Next.js
+  // interpolates dynamic-param keys (entityListType, entityId, …) out of the
+  // query into the path. usePathname() would return the already-resolved URL,
+  // which on dynamic routes would leave those keys in the query string. The
+  // migration to usePathname()/router.replace() is tracked in #930 and #931
+  // and will be done together with the Router.replace refactor.
   const { basePath, pathname, query } = useRouter();
   const { catalogState } = exploreState;
 

--- a/src/views/ExportMethodView/exportMethodView.tsx
+++ b/src/views/ExportMethodView/exportMethodView.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import { usePathname } from "next/navigation";
 import { JSX } from "react";
 import { ComponentCreator } from "../../components/ComponentCreator/ComponentCreator";
 import { BackPageView } from "../../components/Layout/components/BackPage/backPageView";
@@ -8,7 +8,7 @@ import { useUpdateURLSearchParams } from "../../hooks/useUpdateURLSearchParams";
 
 export const ExportMethodView = (): JSX.Element => {
   useUpdateURLSearchParams();
-  const { pathname } = useRouter();
+  const pathname = usePathname() ?? "";
   const { exportMethods, tabs } = useExportConfig();
   const { sideColumn } = tabs[0];
   const { mainColumn, top } =

--- a/tests/stateSyncManager_utils.test.ts
+++ b/tests/stateSyncManager_utils.test.ts
@@ -8,13 +8,15 @@ import { NextHistoryState } from "../src/services/beforePopState/types";
 
 /**
  * Builds a minimal NextHistoryState for tests.
- * @param url - The resolved URL the browser is navigating to (the form
- *   Next.js stores in history state — always the actual URL, never a route
- *   pattern).
- * @returns NextHistoryState with the given url and no-op as/options.
+ * @param url - The href stored by Next.js in history state (the route
+ *   pattern on dynamic routes, e.g. `/[entityListType]/[entityId]`; the same
+ *   string as the URL on static routes).
+ * @param as - The resolved URL shown to the user. Defaults to `url` for
+ *   static-route cases where the two are identical.
+ * @returns NextHistoryState with the given fields and no-op options.
  */
-function buildHistoryState(url: string): NextHistoryState {
-  return { as: url, options: {}, url };
+function buildHistoryState(url: string, as: string = url): NextHistoryState {
+  return { as, options: {}, url };
 }
 
 describe("wasPop", () => {
@@ -54,25 +56,28 @@ describe("wasPop", () => {
     );
   });
 
-  // Documents the contract the usePathname() migration relies on: pathname is
-  // the resolved URL (e.g. /anvil-cmg/abc-123), not the route pattern
-  // (/[entityListType]/[entityId]). The first matches; the second does not.
-  it("matches when pathname is the resolved URL (post-migration form)", () => {
-    expect(
-      wasPop(
-        "",
-        "/anvil-cmg/abc-123",
-        buildHistoryState("/anvil-cmg/abc-123?filter=foo"),
-      ),
-    ).toBe(true);
-  });
-
-  it("does not match when pathname is a route pattern (pre-migration form on dynamic routes)", () => {
+  // Documents the contract: nextHistoryState.url is the href stored by
+  // Next.js — the route pattern on dynamic routes, the static URL on static
+  // routes. `pathname` must be in the same form for the comparison to match.
+  it("matches on a dynamic route when both sides are the route pattern", () => {
     expect(
       wasPop(
         "",
         "/[entityListType]/[entityId]",
-        buildHistoryState("/anvil-cmg/abc-123"),
+        buildHistoryState(
+          "/[entityListType]/[entityId]?filter=foo",
+          "/anvil-cmg/abc-123?filter=foo",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when pathname is the resolved URL but history url is the route pattern", () => {
+    expect(
+      wasPop(
+        "",
+        "/anvil-cmg/abc-123",
+        buildHistoryState("/[entityListType]/[entityId]", "/anvil-cmg/abc-123"),
       ),
     ).toBe(false);
   });

--- a/tests/stateSyncManager_utils.test.ts
+++ b/tests/stateSyncManager_utils.test.ts
@@ -1,0 +1,133 @@
+import {
+  hasParams,
+  isSynced,
+  stringifyQuery,
+  wasPop,
+} from "../src/hooks/stateSyncManager/hooks/UseStateSync/utils";
+import { NextHistoryState } from "../src/services/beforePopState/types";
+
+/**
+ * Builds a minimal NextHistoryState for tests.
+ * @param url - The resolved URL the browser is navigating to (the form
+ *   Next.js stores in history state — always the actual URL, never a route
+ *   pattern).
+ * @returns NextHistoryState with the given url and no-op as/options.
+ */
+function buildHistoryState(url: string): NextHistoryState {
+  return { as: url, options: {}, url };
+}
+
+describe("wasPop", () => {
+  it("returns false when nextHistoryState is undefined", () => {
+    expect(wasPop("", "/projects", undefined)).toBe(false);
+  });
+
+  it("returns true when pathname matches the path component of the history URL", () => {
+    expect(wasPop("", "/projects", buildHistoryState("/projects"))).toBe(true);
+  });
+
+  it("strips the query string off the history URL before comparing", () => {
+    expect(
+      wasPop("", "/projects", buildHistoryState("/projects?filter=foo")),
+    ).toBe(true);
+  });
+
+  it("returns false when pathname does not match", () => {
+    expect(wasPop("", "/projects", buildHistoryState("/files"))).toBe(false);
+  });
+
+  it("defaults basePath to empty string when not provided", () => {
+    expect(wasPop(undefined, "/projects", buildHistoryState("/projects"))).toBe(
+      true,
+    );
+  });
+
+  it("prepends basePath to pathname before comparing", () => {
+    expect(
+      wasPop("/data", "/projects", buildHistoryState("/data/projects")),
+    ).toBe(true);
+  });
+
+  it("returns false when basePath is set but missing from the history URL", () => {
+    expect(wasPop("/data", "/projects", buildHistoryState("/projects"))).toBe(
+      false,
+    );
+  });
+
+  // Documents the contract the usePathname() migration relies on: pathname is
+  // the resolved URL (e.g. /anvil-cmg/abc-123), not the route pattern
+  // (/[entityListType]/[entityId]). The first matches; the second does not.
+  it("matches when pathname is the resolved URL (post-migration form)", () => {
+    expect(
+      wasPop(
+        "",
+        "/anvil-cmg/abc-123",
+        buildHistoryState("/anvil-cmg/abc-123?filter=foo"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when pathname is a route pattern (pre-migration form on dynamic routes)", () => {
+    expect(
+      wasPop(
+        "",
+        "/[entityListType]/[entityId]",
+        buildHistoryState("/anvil-cmg/abc-123"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("hasParams", () => {
+  it("returns true when any param key has a defined value in the query", () => {
+    expect(hasParams({ filter: "foo" }, ["filter"])).toBe(true);
+  });
+
+  it("returns true when at least one of multiple param keys is present", () => {
+    expect(hasParams({ sort: "asc" }, ["filter", "sort"])).toBe(true);
+  });
+
+  it("returns false when none of the param keys are in the query", () => {
+    expect(hasParams({ other: "x" }, ["filter", "sort"])).toBe(false);
+  });
+
+  it("returns false for an empty paramKeys list", () => {
+    expect(hasParams({ filter: "foo" }, [])).toBe(false);
+  });
+
+  it("returns false when a param key is present but undefined", () => {
+    expect(hasParams({ filter: undefined }, ["filter"])).toBe(false);
+  });
+});
+
+describe("isSynced", () => {
+  it("returns true for two empty queries", () => {
+    expect(isSynced({}, {})).toBe(true);
+  });
+
+  it("returns true when queries have the same keys/values in different order", () => {
+    // eslint-disable-next-line sort-keys -- intentionally unsorted to exercise insertion-order independence.
+    expect(isSynced({ a: "1", b: "2" }, { b: "2", a: "1" })).toBe(true);
+  });
+
+  it("returns false when queries differ in value", () => {
+    expect(isSynced({ a: "1" }, { a: "2" })).toBe(false);
+  });
+
+  it("returns false when one query has extra keys", () => {
+    expect(isSynced({ a: "1" }, { a: "1", b: "2" })).toBe(false);
+  });
+});
+
+describe("stringifyQuery", () => {
+  it("produces identical output regardless of insertion order", () => {
+    expect(stringifyQuery({ a: "1", b: "2" })).toBe(
+      // eslint-disable-next-line sort-keys -- intentionally unsorted to exercise insertion-order independence.
+      stringifyQuery({ b: "2", a: "1" }),
+    );
+  });
+
+  it("produces empty-object JSON for an empty query", () => {
+    expect(stringifyQuery({})).toBe("{}");
+  });
+});

--- a/tests/stateSyncManager_utils.test.ts
+++ b/tests/stateSyncManager_utils.test.ts
@@ -4,7 +4,7 @@ import {
   stringifyQuery,
   wasPop,
 } from "../src/hooks/stateSyncManager/hooks/UseStateSync/utils";
-import { NextHistoryState } from "../src/services/beforePopState/types";
+import type { NextHistoryState } from "../src/services/beforePopState/types";
 
 /**
  * Builds a minimal NextHistoryState for tests.


### PR DESCRIPTION
## Summary

Part of #884 (Next.js 16 upgrade plan).

Migrates one safe call site from `useRouter().pathname` (`next/router`) to `usePathname()` (`next/navigation`):

- `src/views/ExportMethodView/exportMethodView.tsx` — `pathname` is compared against static `exportMethods[].route` strings. These are non-dynamic routes, so resolved URL == route pattern; the migration is behaviour-preserving. Removed the now-unused `useRouter` import.

Uses `usePathname() ?? ""` to handle the `string | null` return type, mirroring the existing pattern in `Header.tsx`.

## Deferrals

Two sites are left on `useRouter().pathname` for the same underlying reason — `pathname` needs to be in the route-pattern form (with bracketed dynamic segments) because the surrounding code interacts with other Next.js APIs that also use the route-pattern form. Migrating only `pathname` would mix forms and break behaviour.

- **`src/hooks/useUpdateURLCatalogParam.ts`** — feeds `pathname` into `Router.replace({ pathname, query })`, which on dynamic routes interpolates dynamic-param keys (`entityListType`, `entityId`, …) out of `query` into the path. Resolved URLs would leak those keys into the URL query string. Migration is coupled with replacing `Router.replace` itself; tracked in #930 and #931. Inline comment added in this PR.
- **`src/hooks/stateSyncManager/hooks/UseStateSync/hook.ts`** — `pathname` is compared against `nextHistoryState.url` inside `wasPop()`. `nextHistoryState.url` is the *href* Next.js stores in history (route pattern on dynamic routes, not the resolved URL). Both sides must remain in the route-pattern form for the comparison to work. Migration here will pair with a `wasPop` refactor to compare against `state.as` (the resolved URL); deferring to the same broader migration tracked in #930. (Thanks to Copilot for catching the regression in the first revision of this PR.)

## Tests

New unit tests in `tests/stateSyncManager_utils.test.ts` cover all four exports of `UseStateSync/utils.ts` (`wasPop`, `hasParams`, `isSynced`, `stringifyQuery`) — 20 cases, including ones that pin the `wasPop` contract: both sides must be in the same form (route pattern or resolved URL).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run check-format` — clean
- [x] `npm run test-compile` — clean
- [x] `npm test` — 447/447 pass (new file: 20 tests)
- [x] Manually verified against data-biosphere (anvil-cmg dev) and brc-analytics on `fran/x-nextjs-test` — filter pages and dynamic detail pages behave the same as before.

Closes #928