### PR TITLE
fix: componentcreator: avoid wrapping children in array for createelement (#552)

### DIFF
--- a/src/components/ComponentCreator/ComponentCreator.tsx
+++ b/src/components/ComponentCreator/ComponentCreator.tsx
@@ -63,9 +63,11 @@ export const ComponentCreator = <T,>({
               systemStatus,
             })
           : {};
-        return createElement(c.component, { ...c.props, ...props, key: k }, [
+        return createElement(
+          c.component,
+          { ...c.props, ...props, key: k },
           children ?? props.children,
-        ]);
+        );
       })}
     </>
   );


### PR DESCRIPTION
## Summary

- `ComponentCreator` previously passed children to `React.createElement` wrapped in a one-element array literal. React treats an array third-arg as a "list" of children and requires a `key` on each item, which surfaces as the *"Each child in a list should have a unique 'key' prop"* warning from any wrapping component (MUI `Tooltip` is a common one), and as a *"prop children is not supported"* prop-type warning on components that don't accept children (e.g. `MuiChip`).
- Pass the single child value directly to `createElement` instead. Behavior is unchanged for view builders that return a single child (the common case); view builders that return an array continue to work because React still treats arrays as lists either way.

## Test plan

- [x] `npm run check-format` — clean
- [x] `npm run lint` — clean
- [x] `npm run test-compile` — clean
- [x] `npm test` — 447/447
- [x] Smoke-tested in data-biosphere — Files-tab download tooltip no longer warns. (Surfaced a separate latent bug in `AzulFileDownload` ref-forwarding, tracked in #944.)
- [x] Smoke-tested in brc-analytics — priority-pathogen Tooltip + Chip in organism / genome tables still renders correctly.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)