### PR TITLE
fix: azulfiledownload: accept ref so it can be used as a tooltip child without a span wrapper (#944)

### DIFF
--- a/src/components/Index/components/AzulFileDownload/azulFileDownload.tsx
+++ b/src/components/Index/components/AzulFileDownload/azulFileDownload.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { Fragment, JSX, useEffect, useRef, useState } from "react";
+import { JSX, Ref, useEffect, useRef, useState } from "react";
 import { useFileLocation } from "../../../../hooks/useFileLocation";
 import { useLoginGuard } from "../../../../providers/loginGuard/hook";
 import { DownloadIcon } from "../../../common/CustomIcon/components/DownloadIcon/downloadIcon";
@@ -15,6 +15,7 @@ import {
 
 export interface AzulFileDownloadProps {
   entityName: string; // The name of the file downloaded.
+  ref?: Ref<HTMLSpanElement>; // Ref attached to the outer span; allows direct use as a Tooltip child without a span wrapper at the call site.
   relatedEntityId: string; // An array of IDs of the file's datasets / projects
   relatedEntityName: string; // An array of names of the file's datasets / projects
   url?: string; // Original "file fetch URL" as returned from Azul endpoint.
@@ -22,6 +23,7 @@ export interface AzulFileDownloadProps {
 
 export const AzulFileDownload = ({
   entityName,
+  ref,
   relatedEntityId,
   relatedEntityName,
   url,
@@ -51,7 +53,7 @@ export const AzulFileDownload = ({
   };
 
   return (
-    <Fragment>
+    <span ref={ref}>
       {isRequestPending ? (
         <StyledIconButton
           color="primary"
@@ -76,6 +78,6 @@ export const AzulFileDownload = ({
         ref={downloadRef}
         sx={{ display: "none" }}
       />
-    </Fragment>
+    </span>
   );
 };


### PR DESCRIPTION
## Summary

- `AzulFileDownload` returned a `<Fragment>` and didn't accept a `ref`, so MUI `Tooltip` could not forward its anchor ref to a DOM node. Consumers worked around this by wrapping the component in a `<span>` at the call site.
- Wrap the component's contents in a single `<span>` and accept `ref` on the props interface (React 19 ref-as-prop — no `forwardRef` wrapper needed). Consumers can now use `<AzulFileDownload ... />` directly as a Tooltip child.

## Layout impact

None expected. The new `<span>` is inline by default and the IconButton inside is `inline-flex`, so the rendered DOM occupies the same flow position it did when the IconButton was a direct child of the table cell. The hidden anchor is still `display: none`. No findable-ui selectors target a direct-child IconButton in a way that would be affected by the new wrapper.

## Test plan

- [x] `npm run check-format` — clean
- [x] `npm run lint` — clean
- [x] `npm run test-compile` — clean
- [x] `npm test` — all suites pass
- [x] Smoke-test in data-biosphere — Files-column download tooltip renders correctly without a `<span>` wrapper at the call site, button still visually identical, download still triggers.

## Related

- Surfaced by #552 — the `ComponentCreator` children-array fix exposed the ref-forwarding gap.
- After this lands, data-biosphere's `buildFileDownloadWithTooltip` can drop its temporary `<span>` wrapper.

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)