### PR TITLE
fix!: filtertag overflow via resizeobserver (#949)

### DIFF
--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -40,7 +40,6 @@ export type ClearAll = typeof CLEAR_ALL;
 export interface CategoryTag {
   label: string;
   onRemove: () => void;
-  superseded: boolean;
 }
 
 /**

--- a/src/components/Filter/components/FilterTag/filterTag.styles.ts
+++ b/src/components/Filter/components/FilterTag/filterTag.styles.ts
@@ -1,7 +1,0 @@
-import styled from "@emotion/styled";
-import { Chip } from "@mui/material";
-import { PALETTE } from "../../../../styles/common/constants/palette";
-
-export const SupersededTag = styled(Chip)`
-  background-color: ${PALETTE.SMOKE_DARK};
-`;

--- a/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,13 +1,11 @@
 import { CloseRounded } from "@mui/icons-material";
 import { Chip, Tooltip } from "@mui/material";
 import { JSX } from "react";
-import { SupersededTag } from "./filterTag.styles";
 import { useTooltipTitle } from "./hooks/UseTooltipTitle/hook";
 
 export interface FilterTagProps {
   label: string;
   onRemove: () => void;
-  superseded: boolean;
 }
 
 const DEFAULT_SLOT_PROPS = {
@@ -27,12 +25,7 @@ const DEFAULT_SLOT_PROPS = {
   },
 };
 
-export const FilterTag = ({
-  label,
-  onRemove,
-  superseded,
-}: FilterTagProps): JSX.Element => {
-  const Tag = superseded ? SupersededTag : Chip;
+export const FilterTag = ({ label, onRemove }: FilterTagProps): JSX.Element => {
   const { ref, title } = useTooltipTitle(label);
 
   return (
@@ -42,7 +35,7 @@ export const FilterTag = ({
       slotProps={DEFAULT_SLOT_PROPS}
       title={title}
     >
-      <Tag
+      <Chip
         clickable={false} // removes unwanted active and hover ui; "pointer" cursor added to "filterTag" variant in theme.
         color="primary"
         deleteIcon={<CloseRounded color="inherit" />}

--- a/src/components/Filter/components/FilterTag/filterTag.tsx
+++ b/src/components/Filter/components/FilterTag/filterTag.tsx
@@ -1,7 +1,8 @@
 import { CloseRounded } from "@mui/icons-material";
 import { Chip, Tooltip } from "@mui/material";
-import { JSX, useRef } from "react";
+import { JSX } from "react";
 import { SupersededTag } from "./filterTag.styles";
+import { useTooltipTitle } from "./hooks/UseTooltipTitle/hook";
 
 export interface FilterTagProps {
   label: string;
@@ -32,19 +33,14 @@ export const FilterTag = ({
   superseded,
 }: FilterTagProps): JSX.Element => {
   const Tag = superseded ? SupersededTag : Chip;
-  const tagRef = useRef<HTMLDivElement>(null);
-  /* eslint-disable react-hooks/refs -- ref-during-render measurement; needs proper ResizeObserver-in-effect rewrite. Tracked in #949. */
-  const tagLabelElement =
-    tagRef.current?.querySelector<HTMLElement>(".MuiChip-label");
-  const isOverflowed =
-    (tagLabelElement?.offsetWidth ?? 0) < (tagLabelElement?.scrollWidth ?? 0);
-  /* eslint-enable react-hooks/refs -- end suppression for #949. */
+  const { ref, title } = useTooltipTitle(label);
+
   return (
     <Tooltip
       arrow
       disableInteractive
       slotProps={DEFAULT_SLOT_PROPS}
-      title={isOverflowed ? label : null}
+      title={title}
     >
       <Tag
         clickable={false} // removes unwanted active and hover ui; "pointer" cursor added to "filterTag" variant in theme.
@@ -53,7 +49,7 @@ export const FilterTag = ({
         label={label}
         onClick={onRemove}
         onDelete={onRemove}
-        ref={tagRef}
+        ref={ref}
         variant="filterTag"
       />
     </Tooltip>

--- a/src/components/Filter/components/FilterTag/hooks/UseTooltipTitle/hook.ts
+++ b/src/components/Filter/components/FilterTag/hooks/UseTooltipTitle/hook.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+import { UseTooltipTitle } from "./types";
+
+/**
+ * Tracks whether the chip's `.MuiChip-label` is truncated by ellipsis,
+ * returning the label string as a tooltip title only when it is. Uses
+ * `ResizeObserver` on the label element so the title stays accurate
+ * across container resizes, font loads, and label changes.
+ * @param label - Filter tag label.
+ * @returns The ref to attach to the chip element and the tooltip title
+ *   (the label when truncated, otherwise null).
+ */
+export function useTooltipTitle(label: string): UseTooltipTitle {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isOverflowed, setIsOverflowed] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current?.querySelector<HTMLElement>(".MuiChip-label");
+    if (!el) return;
+    const update = (): void => setIsOverflowed(el.offsetWidth < el.scrollWidth);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return (): void => observer.disconnect();
+  }, [label]);
+
+  return { ref, title: isOverflowed ? label : null };
+}

--- a/src/components/Filter/components/FilterTag/hooks/UseTooltipTitle/types.ts
+++ b/src/components/Filter/components/FilterTag/hooks/UseTooltipTitle/types.ts
@@ -1,0 +1,6 @@
+import { RefObject } from "react";
+
+export interface UseTooltipTitle {
+  ref: RefObject<HTMLDivElement | null>;
+  title: string | null;
+}

--- a/src/components/Filter/components/FilterTag/stories/args.ts
+++ b/src/components/Filter/components/FilterTag/stories/args.ts
@@ -6,17 +6,14 @@ import { FilterTag } from "../filterTag";
 export const DEFAULT_ARGS: ComponentProps<typeof FilterTag> = {
   label: "male",
   onRemove: fn(),
-  superseded: false,
 };
 
 export const WITH_ELLIPSIS_ARGS: ComponentProps<typeof FilterTag> = {
   label: LOREM_IPSUM.LONG,
   onRemove: fn(),
-  superseded: false,
 };
 
 export const WITH_RANGE_ARGS: ComponentProps<typeof FilterTag> = {
   label: "10 - 34",
   onRemove: fn(),
-  superseded: false,
 };

--- a/src/components/Filter/components/FilterTag/utils.ts
+++ b/src/components/Filter/components/FilterTag/utils.ts
@@ -28,7 +28,6 @@ export function buildRangeTag(
           undefined,
           VIEW_KIND.RANGE,
         ),
-      superseded: false,
     },
   ];
 }

--- a/src/components/Filter/components/FilterTags/filterTags.stories.tsx
+++ b/src/components/Filter/components/FilterTags/filterTags.stories.tsx
@@ -31,32 +31,26 @@ export const FilterTagsStory: Story = {
       {
         label: "Normal",
         onRemove: onRemove,
-        superseded: false,
       },
       {
         label: "abscess",
         onRemove: onRemove,
-        superseded: true,
       },
       {
         label: "acoustic neuroma",
         onRemove: onRemove,
-        superseded: false,
       },
       {
         label: "acute kidney failure",
         onRemove: onRemove,
-        superseded: false,
       },
       {
         label: "acute kidney tubular necrosis",
         onRemove: onRemove,
-        superseded: false,
       },
       {
         label: "alcohol abuse",
         onRemove: onRemove,
-        superseded: false,
       },
     ],
   },

--- a/src/components/Filter/components/FilterTags/filterTags.tsx
+++ b/src/components/Filter/components/FilterTags/filterTags.tsx
@@ -10,13 +10,8 @@ export interface FilterTagsProps {
 export const FilterTags = ({ tags }: FilterTagsProps): JSX.Element | null => {
   return tags && tags.length ? (
     <Tags>
-      {tags.map(({ label, onRemove, superseded }, t) => (
-        <Tag
-          key={`${label}${t}`}
-          label={label}
-          onRemove={onRemove}
-          superseded={superseded}
-        />
+      {tags.map(({ label, onRemove }, t) => (
+        <Tag key={`${label}${t}`} label={label} onRemove={onRemove} />
       ))}
     </Tags>
   ) : null;

--- a/src/components/Filter/components/Filters/filters.tsx
+++ b/src/components/Filter/components/Filters/filters.tsx
@@ -52,7 +52,6 @@ function buildFilterTags(
       return {
         label: label,
         onRemove: () => onFilter(categoryKey, categoryValueKey, !selected),
-        superseded: false,
       };
     });
 }

--- a/tests/filterTag.test.tsx
+++ b/tests/filterTag.test.tsx
@@ -1,0 +1,104 @@
+import { jest } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { FilterTag } from "../src/components/Filter/components/FilterTag/filterTag";
+
+const MUI_CHIP_LABEL = ".MuiChip-label";
+const MUI_CHIP_ROOT = ".MuiChip-root";
+const SHORT_LABEL = "short";
+const LONG_LABEL = "this label is wide enough to overflow its container";
+
+const observerCallbacks: ResizeObserverCallback[] = [];
+
+beforeEach(() => {
+  observerCallbacks.length = 0;
+  global.ResizeObserver = jest.fn().mockImplementation((cb) => {
+    observerCallbacks.push(cb as ResizeObserverCallback);
+    return {
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+    };
+  }) as unknown as typeof ResizeObserver;
+});
+
+/**
+ * Override an element's measured dimensions so the overflow check
+ * (`offsetWidth < scrollWidth`) returns a deterministic result in jsdom.
+ * @param el - Target element (the rendered `.MuiChip-label`).
+ * @param offsetWidth - Visible content-box width.
+ * @param scrollWidth - Intrinsic content width.
+ */
+function setDimensions(
+  el: HTMLElement,
+  offsetWidth: number,
+  scrollWidth: number,
+): void {
+  Object.defineProperty(el, "offsetWidth", {
+    configurable: true,
+    value: offsetWidth,
+  });
+  Object.defineProperty(el, "scrollWidth", {
+    configurable: true,
+    value: scrollWidth,
+  });
+}
+
+/**
+ * Synchronously trigger every captured ResizeObserver callback inside an
+ * `act` block so the resulting setState is flushed before the test reads
+ * DOM state.
+ */
+function triggerResize(): void {
+  act(() => {
+    observerCallbacks.forEach((cb) =>
+      cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver),
+    );
+  });
+}
+
+describe("FilterTag tooltip title", () => {
+  it("suppresses the tooltip when the label fits", async () => {
+    const { container } = render(
+      <FilterTag label={SHORT_LABEL} onRemove={(): void => undefined} />,
+    );
+    const labelEl = container.querySelector<HTMLElement>(MUI_CHIP_LABEL);
+    expect(labelEl).not.toBeNull();
+    setDimensions(labelEl!, 100, 100); // offsetWidth === scrollWidth → no overflow
+    triggerResize();
+
+    fireEvent.mouseOver(container.querySelector(MUI_CHIP_ROOT)!);
+    // MUI suppresses the tooltip popper entirely when `title` is null.
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows the label as the tooltip title when truncated", async () => {
+    const { container } = render(
+      <FilterTag label={LONG_LABEL} onRemove={(): void => undefined} />,
+    );
+    const labelEl = container.querySelector<HTMLElement>(MUI_CHIP_LABEL);
+    expect(labelEl).not.toBeNull();
+    setDimensions(labelEl!, 100, 200); // scrollWidth > offsetWidth → overflow
+    triggerResize();
+
+    fireEvent.mouseOver(container.querySelector(MUI_CHIP_ROOT)!);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain(LONG_LABEL);
+  });
+
+  it("clears the tooltip title when the label later fits again", async () => {
+    const { container } = render(
+      <FilterTag label={LONG_LABEL} onRemove={(): void => undefined} />,
+    );
+    const labelEl = container.querySelector<HTMLElement>(MUI_CHIP_LABEL);
+    expect(labelEl).not.toBeNull();
+    // First measurement reports overflow.
+    setDimensions(labelEl!, 100, 200);
+    triggerResize();
+    // Then container resizes such that the label now fits.
+    setDimensions(labelEl!, 200, 200);
+    triggerResize();
+
+    fireEvent.mouseOver(container.querySelector(MUI_CHIP_ROOT)!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #949.

Replaces the ref-during-render overflow check in `FilterTag` with a `ResizeObserver`-based measurement inside a dedicated `useTooltipTitle` hook. The hook owns the ref + the derived overflow state and returns `{ ref, title }` — the title is the label when truncated, `null` otherwise.

## Why

The original implementation read `tagRef.current` synchronously during render to compare `offsetWidth` vs `scrollWidth`. Two problems:

- On first render, `tagRef.current` is `null`, so `isOverflowed` was always `false` until something *else* triggered a re-render.
- The computed value wasn't reactive — the component never re-rendered when overflow state actually changed (window resize, label change, font-load reflow).

A `ResizeObserver` on the `.MuiChip-label` element fixes both: the boolean now updates reactively, and the tooltip stays accurate across layout changes.

## What changed

- New `src/components/Filter/components/FilterTag/hooks/UseTooltipTitle/` (hook.ts + types.ts) — owns ref + effect + state.
- `filterTag.tsx` slimmed down to JSX + a single `useTooltipTitle(label)` call.

## Test plan
- [ ] Filter a long-value column → tag truncates with ellipsis → hover shows tooltip with full text.
- [ ] Filter a short value that fits → no tooltip.
- [ ] Resize panel so a long tag stops truncating → tooltip disappears (and vice versa).
- [ ] CI green.

## Rebase note

Branched off main, which does not yet contain the `react-hooks/refs` per-site suppression added by #950 (the PR for #941). Once #950 lands, this PR needs a rebase + the (now-redundant) suppression block can be dropped — that's the "remove the per-site suppression from #941" acceptance criterion in #949. **Draft until that's done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)