### PR TITLE
feat: accept classname on loginview (and login) for consumer styling (#954)

### DIFF
--- a/src/components/Login/login.tsx
+++ b/src/components/Login/login.tsx
@@ -19,6 +19,7 @@ import {
 import { Props } from "./types";
 
 export const Login = ({
+  className,
   providers = [],
   termsOfService,
   text,
@@ -50,7 +51,7 @@ export const Login = ({
   };
 
   return (
-    <LoginWrapper>
+    <LoginWrapper className={className}>
       <RoundedPaper>
         <LoginSection>
           <SectionContent>

--- a/src/components/Login/types.ts
+++ b/src/components/Login/types.ts
@@ -1,7 +1,8 @@
 import { ReactNode } from "react";
 import { LoginProvider } from "../../auth/types/loginProvider";
+import { BaseComponentProps } from "../types";
 
-export interface Props {
+export interface Props extends BaseComponentProps {
   providers?: LoginProvider[];
   termsOfService?: ReactNode;
   text?: ReactNode;

--- a/src/views/LoginView/loginView.tsx
+++ b/src/views/LoginView/loginView.tsx
@@ -1,19 +1,22 @@
 import { JSX } from "react";
 import { LoginProvider } from "../../auth/types/loginProvider";
 import { Login } from "../../components/Login/login";
+import { BaseComponentProps } from "../../components/types";
 import { useAuthenticationConfig } from "../../hooks/authentication/config/useAuthenticationConfig";
 
-export interface LoginViewProps {
+export interface LoginViewProps extends BaseComponentProps {
   providers?: LoginProvider[];
 }
 
 export const LoginView = ({
+  className,
   providers,
 }: LoginViewProps): JSX.Element | null => {
   const authConfig = useAuthenticationConfig();
   if (!authConfig) return null;
   return (
     <Login
+      className={className}
       providers={providers || authConfig.providers}
       termsOfService={authConfig.termsOfService}
       text={authConfig.text}


### PR DESCRIPTION
## Summary

- Extends `Login` `Props` and `LoginViewProps` with `BaseComponentProps`, adding an optional `className`.
- Forwards `className` from `LoginView` → `Login` → root `LoginWrapper`, so consumers can style/position the login card without an extra wrapper element.

Closes #954

## Test plan

- [x] Existing tests still pass (`npm test`)
- [x] `npx tsc` passes
- [x] Consumer usage works:
  ```tsx
  const StyledLoginView = styled(LoginView)\`
    align-self: center;
  \`;
  <StyledLoginView providers={providers} />
  ```
  renders the login card with the styled-component class applied to its root.
- [x] Existing consumers that don't pass `className` see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)