### PR TITLE
feat: logout should navigate by default so middleware can enforce auth on the next render (#956)

### DIFF
--- a/src/nextauth/hooks/useNextAuthService.ts
+++ b/src/nextauth/hooks/useNextAuthService.ts
@@ -1,3 +1,4 @@
+import { SignOutParams } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 import { Service } from "../../auth/types/auth";
@@ -8,12 +9,17 @@ import {
 } from "../../hooks/authentication/session/useSessionActive";
 import { useRouteHistory } from "../../hooks/useRouteHistory";
 import { service } from "../service";
+import { resolveLogoutOptions } from "./utils";
 
 /**
  * NextAuth service hook.
+ * @param logoutCallbackUrl - When set, `requestLogout()` defaults to a
+ *   navigation-driven sign-out (`signOut({ redirect: true, callbackUrl })`)
+ *   so Next middleware re-runs. Callers can still override per-call via
+ *   `options`.
  * @returns auth service.
  */
-export const useNextAuthService = (): Service => {
+export const useNextAuthService = (logoutCallbackUrl?: string): Service => {
   const { query } = useRouter();
   const { callbackUrl } = useRouteHistory(2);
   const queryCallbackUrl = getQueryCallbackUrl(query.callbackUrl);
@@ -28,10 +34,10 @@ export const useNextAuthService = (): Service => {
   );
 
   const onLogout = useCallback(
-    (options?: { callbackUrl?: string; redirect?: boolean }) => {
-      service.logout(options);
+    (options?: SignOutParams<boolean>) => {
+      service.logout(resolveLogoutOptions(options, logoutCallbackUrl));
     },
-    [],
+    [logoutCallbackUrl],
   );
 
   return { requestLogin: onLogin, requestLogout: onLogout };

--- a/src/nextauth/hooks/utils.ts
+++ b/src/nextauth/hooks/utils.ts
@@ -16,7 +16,10 @@ export function resolveLogoutOptions(
   options: SignOutParams<boolean> | undefined,
   logoutCallbackUrl: string | undefined,
 ): SignOutParams<boolean> {
-  const callbackUrl = options?.callbackUrl ?? logoutCallbackUrl;
+  // Caller wins; provider-level value fills in. Normalize an empty string to
+  // `undefined` so we don't default `redirect` to `true` with no target.
+  const resolved = options?.callbackUrl ?? logoutCallbackUrl;
+  const callbackUrl = resolved || undefined;
   const redirect = options?.redirect ?? Boolean(callbackUrl);
   return { callbackUrl, redirect };
 }

--- a/src/nextauth/hooks/utils.ts
+++ b/src/nextauth/hooks/utils.ts
@@ -1,0 +1,22 @@
+import { SignOutParams } from "next-auth/react";
+
+/**
+ * Resolve the options to pass to `service.logout` (NextAuth `signOut`).
+ *
+ * Precedence: caller-supplied options always win; the provider-level
+ * `logoutCallbackUrl` only fills in defaults. `redirect` defaults to `true`
+ * whenever a callbackUrl is resolved (caller or provider), so logout actually
+ * navigates and Next middleware can re-run on the next render.
+ *
+ * @param options - Per-call options forwarded from `requestLogout(options)`.
+ * @param logoutCallbackUrl - Provider-level default callbackUrl.
+ * @returns Resolved `{ callbackUrl, redirect }` for `signOut`.
+ */
+export function resolveLogoutOptions(
+  options: SignOutParams<boolean> | undefined,
+  logoutCallbackUrl: string | undefined,
+): SignOutParams<boolean> {
+  const callbackUrl = options?.callbackUrl ?? logoutCallbackUrl;
+  const redirect = options?.redirect ?? Boolean(callbackUrl);
+  return { callbackUrl, redirect };
+}

--- a/src/nextauth/provider.tsx
+++ b/src/nextauth/provider.tsx
@@ -15,6 +15,7 @@ import { NextAuthAuthenticationProviderProps } from "./types";
  * NextAuth authentication provider.
  * @param props - Provider props.
  * @param props.children - Children components.
+ * @param props.logoutCallbackUrl - When set, the Logout menu action navigates here (so middleware re-runs).
  * @param props.refetchInterval - Session refetch interval in milliseconds.
  * @param props.session - Initial session data.
  * @param props.timeout - Session timeout in milliseconds.
@@ -22,13 +23,14 @@ import { NextAuthAuthenticationProviderProps } from "./types";
  */
 export function NextAuthAuthenticationProvider({
   children,
+  logoutCallbackUrl,
   refetchInterval = 0,
   session,
   timeout,
 }: NextAuthAuthenticationProviderProps): JSX.Element {
   const authReducer = useAuthReducer();
   const authenticationReducer = useAuthenticationReducer();
-  const service = useNextAuthService();
+  const service = useNextAuthService(logoutCallbackUrl);
   const { authDispatch, authState } = authReducer;
   const { isAuthenticated } = authState;
   useLoginTracking(isAuthenticated, authState.status);

--- a/src/nextauth/types.ts
+++ b/src/nextauth/types.ts
@@ -6,6 +6,13 @@ import { ReactNode } from "react";
  */
 export interface NextAuthAuthenticationProviderProps {
   children: ReactNode | ReactNode[];
+  /**
+   * When set, the Logout menu action becomes navigation-driven
+   * (`signOut({ redirect: true, callbackUrl })`) so Next middleware can
+   * re-run and enforce auth on the next render. Callers of
+   * `requestLogout(options)` can still override per-call.
+   */
+  logoutCallbackUrl?: string;
   refetchInterval?: number;
   session?: Session | null;
   timeout?: number;

--- a/tests/resolveLogoutOptions.test.ts
+++ b/tests/resolveLogoutOptions.test.ts
@@ -1,0 +1,52 @@
+import { resolveLogoutOptions } from "../src/nextauth/hooks/utils";
+
+describe("resolveLogoutOptions", () => {
+  test("defaults to no-callbackUrl + redirect:false when neither side supplies one", () => {
+    expect(resolveLogoutOptions(undefined, undefined)).toEqual({
+      callbackUrl: undefined,
+      redirect: false,
+    });
+  });
+
+  test("uses provider logoutCallbackUrl with redirect:true when caller omits options", () => {
+    expect(resolveLogoutOptions(undefined, "/")).toEqual({
+      callbackUrl: "/",
+      redirect: true,
+    });
+  });
+
+  test("caller-supplied callbackUrl overrides provider logoutCallbackUrl", () => {
+    expect(
+      resolveLogoutOptions({ callbackUrl: "/account-disabled" }, "/"),
+    ).toEqual({
+      callbackUrl: "/account-disabled",
+      redirect: true,
+    });
+  });
+
+  test("caller-supplied redirect:false wins even when a callbackUrl is resolved", () => {
+    expect(resolveLogoutOptions({ redirect: false }, "/")).toEqual({
+      callbackUrl: "/",
+      redirect: false,
+    });
+  });
+
+  test("caller-supplied full options pass through unchanged", () => {
+    expect(
+      resolveLogoutOptions(
+        { callbackUrl: "/account-disabled", redirect: true },
+        undefined,
+      ),
+    ).toEqual({
+      callbackUrl: "/account-disabled",
+      redirect: true,
+    });
+  });
+
+  test("caller-supplied callbackUrl alone (no redirect) implies redirect:true", () => {
+    expect(resolveLogoutOptions({ callbackUrl: "/x" }, undefined)).toEqual({
+      callbackUrl: "/x",
+      redirect: true,
+    });
+  });
+});

--- a/tests/resolveLogoutOptions.test.ts
+++ b/tests/resolveLogoutOptions.test.ts
@@ -49,4 +49,18 @@ describe("resolveLogoutOptions", () => {
       redirect: true,
     });
   });
+
+  test("normalizes a caller-supplied empty-string callbackUrl to undefined + redirect:false", () => {
+    expect(resolveLogoutOptions({ callbackUrl: "" }, undefined)).toEqual({
+      callbackUrl: undefined,
+      redirect: false,
+    });
+  });
+
+  test("normalizes a provider-supplied empty-string logoutCallbackUrl to undefined + redirect:false", () => {
+    expect(resolveLogoutOptions(undefined, "")).toEqual({
+      callbackUrl: undefined,
+      redirect: false,
+    });
+  });
 });

--- a/tests/useNextAuthService.test.ts
+++ b/tests/useNextAuthService.test.ts
@@ -2,6 +2,8 @@ import { jest } from "@jest/globals";
 import { act, renderHook } from "@testing-library/react";
 import { TransformRouteFn } from "../src/hooks/useRouteHistory";
 
+const LOGOUT_CALLBACK_URL = "/";
+
 const ROOT_PATH = "/";
 const ROUTES = ["/login", "/route1", "/route2"];
 const PROVIDER_ID = "google";
@@ -28,6 +30,9 @@ const MOCK_USE_ROUTE_HISTORY = useRouteHistory as jest.MockedFunction<
   typeof useRouteHistory
 >;
 const MOCK_LOGIN = service.login as jest.MockedFunction<typeof service.login>;
+const MOCK_LOGOUT = service.logout as jest.MockedFunction<
+  typeof service.logout
+>;
 
 describe("useNextAuthService", () => {
   beforeEach(() => {
@@ -84,6 +89,64 @@ describe("useNextAuthService", () => {
     act(() => result.current.requestLogin(PROVIDER_ID));
     expect(MOCK_LOGIN).toHaveBeenCalledWith(PROVIDER_ID, {
       callbackUrl: ROUTES[1],
+    });
+  });
+
+  test("requestLogout defaults to non-redirecting logout when no logoutCallbackUrl is provided", () => {
+    const { result } = renderHook(() => useNextAuthService());
+    act(() => result.current.requestLogout());
+    expect(MOCK_LOGOUT).toHaveBeenCalledWith({
+      callbackUrl: undefined,
+      redirect: false,
+    });
+  });
+
+  test("requestLogout uses provider-supplied logoutCallbackUrl with redirect:true", () => {
+    const { result } = renderHook(() =>
+      useNextAuthService(LOGOUT_CALLBACK_URL),
+    );
+    act(() => result.current.requestLogout());
+    expect(MOCK_LOGOUT).toHaveBeenCalledWith({
+      callbackUrl: LOGOUT_CALLBACK_URL,
+      redirect: true,
+    });
+  });
+
+  test("requestLogout caller-provided callbackUrl overrides logoutCallbackUrl", () => {
+    const { result } = renderHook(() =>
+      useNextAuthService(LOGOUT_CALLBACK_URL),
+    );
+    act(() =>
+      result.current.requestLogout({ callbackUrl: "/account-disabled" }),
+    );
+    expect(MOCK_LOGOUT).toHaveBeenCalledWith({
+      callbackUrl: "/account-disabled",
+      redirect: true,
+    });
+  });
+
+  test("requestLogout caller-provided redirect:false is respected even when logoutCallbackUrl is set", () => {
+    const { result } = renderHook(() =>
+      useNextAuthService(LOGOUT_CALLBACK_URL),
+    );
+    act(() => result.current.requestLogout({ redirect: false }));
+    expect(MOCK_LOGOUT).toHaveBeenCalledWith({
+      callbackUrl: LOGOUT_CALLBACK_URL,
+      redirect: false,
+    });
+  });
+
+  test("requestLogout caller-provided full options pass through unchanged", () => {
+    const { result } = renderHook(() => useNextAuthService());
+    act(() =>
+      result.current.requestLogout({
+        callbackUrl: "/account-disabled",
+        redirect: true,
+      }),
+    );
+    expect(MOCK_LOGOUT).toHaveBeenCalledWith({
+      callbackUrl: "/account-disabled",
+      redirect: true,
     });
   });
 });

--- a/tests/useNextAuthService.test.ts
+++ b/tests/useNextAuthService.test.ts
@@ -2,8 +2,6 @@ import { jest } from "@jest/globals";
 import { act, renderHook } from "@testing-library/react";
 import { TransformRouteFn } from "../src/hooks/useRouteHistory";
 
-const LOGOUT_CALLBACK_URL = "/";
-
 const ROOT_PATH = "/";
 const ROUTES = ["/login", "/route1", "/route2"];
 const PROVIDER_ID = "google";
@@ -102,20 +100,16 @@ describe("useNextAuthService", () => {
   });
 
   test("requestLogout uses provider-supplied logoutCallbackUrl with redirect:true", () => {
-    const { result } = renderHook(() =>
-      useNextAuthService(LOGOUT_CALLBACK_URL),
-    );
+    const { result } = renderHook(() => useNextAuthService(ROOT_PATH));
     act(() => result.current.requestLogout());
     expect(MOCK_LOGOUT).toHaveBeenCalledWith({
-      callbackUrl: LOGOUT_CALLBACK_URL,
+      callbackUrl: ROOT_PATH,
       redirect: true,
     });
   });
 
   test("requestLogout caller-provided callbackUrl overrides logoutCallbackUrl", () => {
-    const { result } = renderHook(() =>
-      useNextAuthService(LOGOUT_CALLBACK_URL),
-    );
+    const { result } = renderHook(() => useNextAuthService(ROOT_PATH));
     act(() =>
       result.current.requestLogout({ callbackUrl: "/account-disabled" }),
     );
@@ -126,12 +120,10 @@ describe("useNextAuthService", () => {
   });
 
   test("requestLogout caller-provided redirect:false is respected even when logoutCallbackUrl is set", () => {
-    const { result } = renderHook(() =>
-      useNextAuthService(LOGOUT_CALLBACK_URL),
-    );
+    const { result } = renderHook(() => useNextAuthService(ROOT_PATH));
     act(() => result.current.requestLogout({ redirect: false }));
     expect(MOCK_LOGOUT).toHaveBeenCalledWith({
-      callbackUrl: LOGOUT_CALLBACK_URL,
+      callbackUrl: ROOT_PATH,
       redirect: false,
     });
   });


### PR DESCRIPTION
## Summary

- Adds optional `logoutCallbackUrl?: string` prop on `NextAuthAuthenticationProvider`, threaded into `useNextAuthService(logoutCallbackUrl)`.
- When set, `requestLogout()` defaults to `signOut({ redirect: true, callbackUrl })` so the browser actually navigates and Next middleware re-runs on the next render. Without it, behavior is identical to today (`signOut({ redirect: false })`).
- Resolution lives in a pure helper `resolveLogoutOptions(options, logoutCallbackUrl)` under `src/nextauth/hooks/utils.ts`. Caller-supplied options always win (e.g. `requestLogout({ callbackUrl: "/account-disabled", redirect: true })` still routes the disabled user correctly; the inactivity-timer's explicit `{ callbackUrl, redirect: true }` still wins).

Closes #956

## Back-compat

- **Consumers that don't set `logoutCallbackUrl`**: `requestLogout()` falls through to `signOut({ callbackUrl: undefined, redirect: false })` — bit-for-bit identical to current behavior.
- **Explicit callers** (e.g. `AuthorizationProvider` for disabled users, `useSessionIdleTimer` for inactivity logout): their full options pass through unchanged.
- `AuthenticationConfig` shape unchanged — we opted for a provider prop over a config field so the trigger is explicit at the integration site and doesn't require new config plumbing.

## Test plan

- [x] `tests/resolveLogoutOptions.test.ts` — 6 cases covering the pure helper (no-args defaults, provider-only, caller callbackUrl wins, caller redirect:false wins, full pass-through, caller callbackUrl-only implies redirect:true).
- [x] `tests/useNextAuthService.test.ts` — extended with 5 hook-level cases that exercise the new logout matrix.
- [x] `npm run lint`, `npm run check-format`, `npx tsc`, full `npm test` all clean (469 tests).
- [x] Verified end-to-end in hca-atlas-tracker via tarball install: clicking "Logout" on a protected page now triggers a navigation, middleware redirects to the configured `logoutCallbackUrl`, and stale UI no longer lingers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)