### PR TITLE
perf: memoize the markdownrenderer unified processor (#971)

### DIFF
--- a/src/components/MarkdownRenderer/markdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/markdownRenderer.tsx
@@ -31,24 +31,31 @@ export const MarkdownRenderer = ({
   const [element, setElement] = useState<ReactElement | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [components] = useState<Components>(componentOptions);
-  const regex = useMemo(() => markdownRegex, [markdownRegex]);
+
+  // The processor only depends on `components` and the highlight `regex` (not
+  // `value`), so memoize it to avoid rebuilding the plugin chain on every value
+  // change. A unified processor freezes on first use and is reusable across
+  // process() calls.
+  const processor = useMemo(
+    () =>
+      unified()
+        .use(remarkParse)
+        .use(remarkGfm)
+        .use(remarkRehype, { allowDangerousHtml: true })
+        .use(rehypeRaw)
+        .use(rehypeSanitize)
+        .use(rehypeHighlight, { regex: markdownRegex })
+        .use(rehypeReact, {
+          Fragment: production.Fragment,
+          components,
+          jsx: production.jsx,
+          jsxs: production.jsxs,
+        }),
+    [components, markdownRegex],
+  );
 
   useEffect(() => {
     let cancelled = false;
-
-    const processor = unified()
-      .use(remarkParse)
-      .use(remarkGfm)
-      .use(remarkRehype, { allowDangerousHtml: true })
-      .use(rehypeRaw)
-      .use(rehypeSanitize)
-      .use(rehypeHighlight, { regex })
-      .use(rehypeReact, {
-        Fragment: production.Fragment,
-        components,
-        jsx: production.jsx,
-        jsxs: production.jsxs,
-      });
 
     processor
       .process(value)
@@ -64,7 +71,7 @@ export const MarkdownRenderer = ({
     return (): void => {
       cancelled = true;
     };
-  }, [components, regex, value]);
+  }, [processor, value]);
 
   if (error)
     return (


### PR DESCRIPTION
## Summary

Closes #971

`MarkdownRenderer` rebuilt the entire `unified()` plugin chain **inside the `useEffect`** on every `value` change. The processor only depends on `components` and `regex` — `value` is just the argument to `.process(value)`. This memoizes the processor on `[components, markdownRegex]` so the chain is built once and reused; the effect now just calls `processor.process(value)`.

A `unified` processor freezes on first use and is reusable across `.process()` calls, so sharing one memoized processor across value changes is safe. **Output is unchanged.**

## Changes

- Move the `unified()` processor construction into a `useMemo` keyed on `[components, markdownRegex]`.
- Effect now depends on `[processor, value]` (per `react-hooks/exhaustive-deps`).
- Drop the redundant no-op `regex` memo (`useMemo(() => markdownRegex, [markdownRegex])` returned its own input) and inline `markdownRegex`.

## Notes

- The `const [components] = useState(componentOptions)` freeze is retained intentionally — `MarkdownCell` passes a fresh `{...COMPONENTS, ...components}` object each render, and freezing it at mount is what keeps the memo effective.
- Shared component — affects `DataDictionary/Description`, `Table/MarkdownCell`, the assistant panel (pending #966), and consumer apps. Verified output is identical.

## Verification

- `tsc` ✓, ESLint ✓ (no `exhaustive-deps` warning), Prettier ✓, full Jest suite ✓ (499 tests)
- High-effort code review: **no findings**.
- `/simplify` pass applied (dropped the no-op regex memo).
- Manually verified in `data-portal` — the data dictionary (`/metadata/[dictionary]`, many `MarkdownRenderer` instances) renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)