### PR TITLE
feat: searchbar: reset pagination param when submitting a new search (#973)

### DIFF
--- a/src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants.ts
+++ b/src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants.ts
@@ -1,4 +1,5 @@
 export const SEARCH_PARAMETERS = {
   CATEGORY: "category",
   QUERY: "q",
+  START: "start",
 };

--- a/src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/utils.ts
+++ b/src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/utils.ts
@@ -15,6 +15,8 @@ function getNewURLSearchParams(
 
 /**
  * Return the search params, for the given search string.
+ * Submitting a new search resets pagination to the first page (the start param
+ * is dropped) while preserving any active category filter.
  * @param searchParams - Current search params.
  * @param searchStr - Search string.
  * @returns updated search params.
@@ -25,5 +27,6 @@ export function getSearchParams(
 ): URLSearchParams {
   const params = getNewURLSearchParams(searchParams);
   params.set(SEARCH_PARAMETERS.QUERY, searchStr);
+  params.delete(SEARCH_PARAMETERS.START);
   return params;
 }

--- a/tests/searchBarUtils.test.ts
+++ b/tests/searchBarUtils.test.ts
@@ -1,0 +1,40 @@
+import { ReadonlyURLSearchParams } from "next/navigation";
+import { SEARCH_PARAMETERS } from "../src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants";
+import { getSearchParams } from "../src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/utils";
+
+/**
+ * Builds ReadonlyURLSearchParams from a query string for test input.
+ * @param init - Query string.
+ * @returns readonly search params.
+ */
+function params(init?: string): ReadonlyURLSearchParams {
+  return new URLSearchParams(init) as unknown as ReadonlyURLSearchParams;
+}
+
+describe("getSearchParams", () => {
+  it("sets the query param when search params are null", () => {
+    const result = getSearchParams(null, "lung");
+    expect(result.get(SEARCH_PARAMETERS.QUERY)).toBe("lung");
+    expect(result.has(SEARCH_PARAMETERS.START)).toBe(false);
+  });
+
+  it("overwrites an existing query param", () => {
+    const result = getSearchParams(params("q=lung"), "heart");
+    expect(result.get(SEARCH_PARAMETERS.QUERY)).toBe("heart");
+  });
+
+  it("removes the start param on a new search", () => {
+    const result = getSearchParams(params("q=lung&start=11"), "heart");
+    expect(result.has(SEARCH_PARAMETERS.START)).toBe(false);
+  });
+
+  it("preserves the category while removing start and setting the new query", () => {
+    const result = getSearchParams(
+      params("q=lung&category=projects&start=11"),
+      "heart",
+    );
+    expect(result.get(SEARCH_PARAMETERS.QUERY)).toBe("heart");
+    expect(result.get(SEARCH_PARAMETERS.CATEGORY)).toBe("projects");
+    expect(result.has(SEARCH_PARAMETERS.START)).toBe(false);
+  });
+});

--- a/tests/searchBarUtils.test.ts
+++ b/tests/searchBarUtils.test.ts
@@ -1,4 +1,4 @@
-import { ReadonlyURLSearchParams } from "next/navigation";
+import type { ReadonlyURLSearchParams } from "next/navigation";
 import { SEARCH_PARAMETERS } from "../src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/constants";
 import { getSearchParams } from "../src/components/Layout/components/Header/components/Content/components/Actions/components/Search/components/SearchBar/common/utils";
 


### PR DESCRIPTION
## Summary

The header `SearchBar`'s `getSearchParams` preserved all existing URL search params and only overwrote `q`. This is intentional for `category` (a new search keeps the active filter), but it also preserved any pagination index a consumer encodes in the URL, so a new search could land on a stale results page.

This adds a `START` key to `SEARCH_PARAMETERS` and drops it in `getSearchParams` when a new query is submitted, so a new search resets to the first page while `category` is preserved. The submit handler is the only place that can distinguish a real user-initiated search from a browser back/forward navigation, so resetting here keeps back/forward intact.

Enables the URL-driven pagination refactor in DataBiosphere/data-portal#3088.

Closes #973

## Changes
- `SEARCH_PARAMETERS` gains `START: "start"`.
- `getSearchParams` deletes the `start` param after setting the new query.

Additive and non-breaking for other consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)