### PR TITLE
fix!: error component: "to homepage" button does not return the user to the home page (#963)

### DIFF
--- a/src/components/Error/error.tsx
+++ b/src/components/Error/error.tsx
@@ -61,6 +61,11 @@ export const Error = ({
   const { dimensions } = useLayoutDimensions();
 
   const handleToHomePageClicked = (): void => {
+    // Explicitly clear the caught error so recovery also works when "To
+    // Homepage" targets the current route (rootPath === the current path),
+    // where the ErrorBoundary's route-change reset would not fire. For
+    // cross-route navigation the ErrorBoundary additionally resets on the
+    // route change once navigation completes.
     onReset?.();
     exploreDispatch({
       payload: "",

--- a/src/components/ErrorBoundary/errorBoundary.tsx
+++ b/src/components/ErrorBoundary/errorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, PropsWithChildren, PropsWithRef, ReactNode } from "react";
+import { useRouter } from "next/router";
+import { Component, JSX, PropsWithChildren, ReactNode } from "react";
 
 interface ErrorBoundaryState {
   error?: Error;
@@ -13,15 +14,19 @@ interface ErrorBoundaryProps {
   fallbackRender: (props: FallbackRenderProps) => ReactNode;
 }
 
-type ErrorBoundaryPropsType = PropsWithRef<
-  PropsWithChildren<ErrorBoundaryProps>
->;
+interface ErrorBoundaryClassProps extends ErrorBoundaryProps {
+  resetKey: string;
+}
 
-export class ErrorBoundary extends Component<
-  ErrorBoundaryPropsType,
+type ErrorBoundaryPropsType = PropsWithChildren<ErrorBoundaryProps>;
+
+type ErrorBoundaryClassPropsType = PropsWithChildren<ErrorBoundaryClassProps>;
+
+class ErrorBoundaryClass extends Component<
+  ErrorBoundaryClassPropsType,
   ErrorBoundaryState
 > {
-  constructor(props: ErrorBoundaryPropsType) {
+  constructor(props: ErrorBoundaryClassPropsType) {
     super(props);
     this.reset = this.reset.bind(this);
     this.state = {};
@@ -31,11 +36,20 @@ export class ErrorBoundary extends Component<
     return { error };
   }
 
-  reset(): void {
-    this.setState({});
+  componentDidUpdate(prevProps: ErrorBoundaryClassPropsType): void {
+    // Reset the caught error when the route changes, so navigating away from
+    // the error (e.g. via the "To Homepage" button) renders the new route
+    // instead of remaining on the error screen.
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.reset();
+    }
   }
 
-  render(): React.ReactNode {
+  reset(): void {
+    this.setState({ error: undefined });
+  }
+
+  render(): ReactNode {
     if (this.state.error) {
       const fallbackProps = { error: this.state.error, reset: this.reset };
       return this.props.fallbackRender(fallbackProps);
@@ -43,4 +57,17 @@ export class ErrorBoundary extends Component<
 
     return this.props.children;
   }
+}
+
+/**
+ * Error boundary that renders a fallback when a descendant throws during
+ * render, and automatically resets when the route changes.
+ * @param props - Component props.
+ * @param props.children - Descendants guarded by the boundary.
+ * @param props.fallbackRender - Renders the fallback UI for a caught error.
+ * @returns Error boundary element.
+ */
+export function ErrorBoundary(props: ErrorBoundaryPropsType): JSX.Element {
+  const { asPath } = useRouter();
+  return <ErrorBoundaryClass {...props} resetKey={asPath} />;
 }

--- a/tests/errorBoundary.test.tsx
+++ b/tests/errorBoundary.test.tsx
@@ -1,0 +1,164 @@
+import { jest } from "@jest/globals";
+import { act, fireEvent, render } from "@testing-library/react";
+import { NextRouter } from "next/router";
+import { JSX, ReactNode } from "react";
+
+let mockAsPath = "/broken";
+
+jest.unstable_mockModule("next/router", () => {
+  return {
+    ...jest.requireActual<typeof import("next/router")>("next/router"),
+    useRouter: jest.fn(() => ({ asPath: mockAsPath })),
+  };
+});
+
+const { useRouter } = await import("next/router");
+const { ErrorBoundary } =
+  await import("../src/components/ErrorBoundary/errorBoundary");
+
+const MOCK_USE_ROUTER = useRouter as jest.MockedFunction<
+  () => Partial<NextRouter>
+>;
+
+const ERROR_MESSAGE = "boom";
+
+/**
+ * Test component that throws during render.
+ * @returns Never; always throws.
+ */
+function Thrower(): JSX.Element {
+  throw new Error(ERROR_MESSAGE);
+}
+
+/**
+ * Renders the fallback UI for a caught error.
+ * @param props - Fallback render props.
+ * @param props.error - The caught error.
+ * @returns Fallback element.
+ */
+function fallbackRender({ error }: { error: Error }): ReactNode {
+  return <div>Fallback: {error.message}</div>;
+}
+
+describe("ErrorBoundary", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    mockAsPath = "/broken";
+    MOCK_USE_ROUTER.mockClear();
+    // Suppress the expected React error boundary console output.
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders children when no error is thrown", () => {
+    const { queryByText } = render(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <div>Child content</div>
+      </ErrorBoundary>,
+    );
+    expect(queryByText("Child content")).not.toBeNull();
+  });
+
+  it("renders the fallback when a child throws", () => {
+    const { queryByText } = render(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(queryByText(`Fallback: ${ERROR_MESSAGE}`)).not.toBeNull();
+  });
+
+  it("resets and renders the new route when the route changes", () => {
+    const { queryByText, rerender } = render(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(queryByText(`Fallback: ${ERROR_MESSAGE}`)).not.toBeNull();
+
+    // Simulate navigation: the route changes and the new route renders a
+    // working component in place of the thrower.
+    mockAsPath = "/home";
+    rerender(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <div>Home page</div>
+      </ErrorBoundary>,
+    );
+
+    expect(queryByText("Home page")).not.toBeNull();
+    expect(queryByText(`Fallback: ${ERROR_MESSAGE}`)).toBeNull();
+  });
+
+  it("keeps showing the fallback when the route is unchanged", () => {
+    const { queryByText, rerender } = render(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(queryByText(`Fallback: ${ERROR_MESSAGE}`)).not.toBeNull();
+
+    // Re-render without a route change: the boundary must not reset.
+    rerender(
+      <ErrorBoundary fallbackRender={fallbackRender}>
+        <div>Home page</div>
+      </ErrorBoundary>,
+    );
+
+    expect(queryByText(`Fallback: ${ERROR_MESSAGE}`)).not.toBeNull();
+    expect(queryByText("Home page")).toBeNull();
+  });
+
+  it("clears the error via the fallback reset callback without a route change", () => {
+    let shouldThrow = true;
+
+    /**
+     * Throws until reset, then renders successfully.
+     * @returns Recovered content once no longer throwing.
+     */
+    function ConditionalThrower(): JSX.Element {
+      if (shouldThrow) throw new Error(ERROR_MESSAGE);
+      return <div>Recovered</div>;
+    }
+
+    /**
+     * Fallback exposing a button that stops throwing and calls reset.
+     * @param props - Fallback render props.
+     * @param props.reset - Clears the caught error.
+     * @returns Fallback element with a retry button.
+     */
+    function fallbackWithReset({ reset }: { reset: () => void }): ReactNode {
+      return (
+        <button
+          onClick={(): void => {
+            shouldThrow = false;
+            reset();
+          }}
+        >
+          Retry
+        </button>
+      );
+    }
+
+    const { getByText, queryByText } = render(
+      <ErrorBoundary fallbackRender={fallbackWithReset}>
+        <ConditionalThrower />
+      </ErrorBoundary>,
+    );
+    expect(getByText("Retry")).not.toBeNull();
+
+    // asPath is unchanged, so recovery must come from the explicit reset
+    // callback rather than the route-change reset.
+    act(() => {
+      fireEvent.click(getByText("Retry"));
+    });
+
+    expect(queryByText("Recovered")).not.toBeNull();
+    expect(queryByText("Retry")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #963.

The `Error` component's **"To Homepage"** button updated the URL but left the user stuck on the error screen. Root cause was two compounding bugs in `ErrorBoundary`:

- `reset()` used `this.setState({})`, which **merges** partial state and so **never cleared** the caught `error` — the reset wired to "To Homepage" was a no-op.
- Even with `reset()` fixed, resetting synchronously on click re-rendered the still-broken current route, re-throwing before navigation completed and re-arming the boundary — so after the URL changed, the error screen persisted.

## Fix

- `reset()` now clears the error explicitly (`setState({ error: undefined })`).
- `ErrorBoundary` **auto-resets on route change**: a thin functional wrapper reads `useRouter().asPath` and passes it as a `resetKey`; the class resets in `componentDidUpdate` when the key changes while an error is present. This gives clean cross-route recovery with no synchronous re-throw (the `react-error-boundary` `resetKeys` pattern).
- The `Error` component keeps its explicit `onReset()` call so recovery also works when "To Homepage" targets the **current** route (`rootPath` === current path), where the route-change reset would not fire (the `react-error-boundary` `reset` callback pattern).

Public API is unchanged and no consumer edits are required.

## Tests

Adds `tests/errorBoundary.test.tsx` covering: renders children with no error, renders fallback on throw, resets on route change, holds fallback when the route is unchanged, and clears via the explicit reset callback without a route change. Full suite (508 tests), lint, prettier, and `tsc` all pass.

## Notes / known limitations (accepted)

- `ErrorBoundary` is now a **function component** (was a class) so it can read the router. It no longer supports a `ref` to a class instance — no consumer uses this. Treated as immaterial for our Next-only ecosystem; shipping as a patch.
- It now requires a Next router context (`useRouter`), already implied since Next is a peer dependency and it's always rendered inside `_app`.
- A programmatic **shallow** navigation that keeps `asPath` identical won't trigger the route-change reset — an edge case outside the button flow (`asPath` includes the query string, so most param corrections do reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)