### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,10 +22,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # The logic below handles the npm publication:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # These if statements ensure that a publication only occurs when a new release is created:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: "22.13.0"

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
           cache: "npm"
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
           cache: "npm"


### PR DESCRIPTION
Closes #979

Upgrades every action reference in the workflows to its current version and converts all tag pins to commit SHA pins with version comments, exactly per the table in #979. Each SHA was resolved and verified against the upstream tag. Same change already merged and green in anvilproject/anvil-portal#4040.

## Test plan

- Workflows that trigger on pull requests validate the new pins on this PR itself.
- Workflows that only run on push to the default branch or on dispatch complete a green run after merge, via the next natural trigger or a manual dispatch, with no Node deprecation annotations.
- After the green runs, the allowlist tightening described in #979 (remove the actions/* wildcard) is applied and the push/dispatch workflows are re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)