### PR TITLE
chore: upgrade prettier to latest and reformat (#983)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "next": "^16",
         "next-auth": "^4.24.13",
         "next-mdx-remote": "^6.0.0",
-        "prettier": "^3.7.4",
+        "prettier": "^3.9.5",
         "prettier-plugin-organize-imports": "^4.3.0",
         "storybook": "^10.3.3",
         "ts-jest": "^29.4.6",
@@ -16612,9 +16612,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "next": "^16",
     "next-auth": "^4.24.13",
     "next-mdx-remote": "^6.0.0",
-    "prettier": "^3.7.4",
+    "prettier": "^3.9.5",
     "prettier-plugin-organize-imports": "^4.3.0",
     "storybook": "^10.3.3",
     "ts-jest": "^29.4.6",

--- a/src/apis/azul/common/entities.ts
+++ b/src/apis/azul/common/entities.ts
@@ -141,7 +141,7 @@ export interface AzulTermFacets {
 }
 
 /**
- * Set of possible term types retured from Azul.
+ * Set of possible term types returned from Azul.
  */
 enum AZUL_TERM_TYPE {
   TERMS = "terms",

--- a/src/apis/azul/common/entities.ts
+++ b/src/apis/azul/common/entities.ts
@@ -65,7 +65,7 @@ export interface AzulEntityStaticResponse<T = any> {
  * Set of filter operators accepted by Azul.
  */
 export enum AZUL_FILTER_OPERATOR {
-  "IS" = "is",
+  IS = "is",
 }
 
 /**
@@ -98,8 +98,8 @@ export interface AzulPaginationResponse {
  * Set of valid request params accepted by Azul.
  */
 export enum AZUL_PARAM {
-  "CATALOG" = "catalog",
-  "FILTERS" = "filters",
+  CATALOG = "catalog",
+  FILTERS = "filters",
 }
 
 /**
@@ -144,7 +144,7 @@ export interface AzulTermFacets {
  * Set of possible term types retured from Azul.
  */
 enum AZUL_TERM_TYPE {
-  "TERMS" = "terms",
+  TERMS = "terms",
 }
 
 /**
@@ -161,10 +161,10 @@ export interface FileLocationResponse {
  * Set of labels that values returned from Azul can be sanitized to.
  */
 export enum LABEL {
-  "EMPTY" = "", // TODO(cc) revisit - temp only? required for file download.
-  "ERROR" = "Error",
-  "NONE" = "None",
-  "UNSPECIFIED" = "Unspecified",
+  EMPTY = "", // TODO(cc) revisit - temp only? required for file download.
+  ERROR = "Error",
+  NONE = "None",
+  UNSPECIFIED = "Unspecified",
 }
 
 /**
@@ -176,10 +176,10 @@ export type ManifestDownloadFormat = MANIFEST_DOWNLOAD_FORMAT;
  * Set of possible manifest download formats.
  */
 export enum MANIFEST_DOWNLOAD_FORMAT {
-  "COMPACT" = "compact",
-  "CURL" = "curl",
-  "FULL" = "full",
-  "TERRA_BDBAG" = "terra.bdbag",
-  "TERRA_PFB" = "terra.pfb",
-  "VERBATIM_PFB" = "verbatim.pfb",
+  COMPACT = "compact",
+  CURL = "curl",
+  FULL = "full",
+  TERRA_BDBAG = "terra.bdbag",
+  TERRA_PFB = "terra.pfb",
+  VERBATIM_PFB = "verbatim.pfb",
 }

--- a/src/auth/types/auth.ts
+++ b/src/auth/types/auth.ts
@@ -5,9 +5,7 @@ import { ProviderId } from "./common";
  * Auth action type - union of all possible auth actions.
  */
 export type AuthAction =
-  | RequestAuthAction
-  | AuthResetStateAction
-  | UpdateAuthStateAction;
+  RequestAuthAction | AuthResetStateAction | UpdateAuthStateAction;
 
 /**
  * Auth action kinds.

--- a/src/auth/types/credentials.ts
+++ b/src/auth/types/credentials.ts
@@ -9,8 +9,7 @@ export type Credentials<C = string | undefined> = C;
  * Credentials action type - union of all possible credentials actions.
  */
 export type CredentialsAction =
-  | CredentialsResetStateAction
-  | UpdateCredentialsAction;
+  CredentialsResetStateAction | UpdateCredentialsAction;
 
 /**
  * Credentials action kinds.

--- a/src/common/entities.ts
+++ b/src/common/entities.ts
@@ -129,8 +129,7 @@ export const REQUIREMENT_LEVEL = {
  * Requirement level type.
  */
 export type RequirementLevel =
-  | boolean
-  | (typeof REQUIREMENT_LEVEL)[keyof typeof REQUIREMENT_LEVEL];
+  boolean | (typeof REQUIREMENT_LEVEL)[keyof typeof REQUIREMENT_LEVEL];
 
 /**
  * Internal filter model of a multiselect category (e.g. library construction approach).

--- a/src/components/Export/common/entities.ts
+++ b/src/components/Export/common/entities.ts
@@ -8,8 +8,8 @@ import {
  * Set of supported shells that bulk download curl can be executed on.
  */
 export enum BULK_DOWNLOAD_EXECUTION_ENVIRONMENT {
-  "BASH" = "bash",
-  "CMD_EXE" = "cmd.exe",
+  BASH = "bash",
+  CMD_EXE = "cmd.exe",
 }
 
 /**

--- a/src/components/Filter/components/FilterLabel/filterLabel.styles.ts
+++ b/src/components/Filter/components/FilterLabel/filterLabel.styles.ts
@@ -44,11 +44,13 @@ export const StyledButton = styled(Button, {
     css`
       background-color: ${PALETTE.SMOKE_MAIN};
 
-      ${surfaceType === SURFACE_TYPE.MENU &&
-      css`
-        & .MuiButton-endIcon {
-          transform: rotate(180deg);
-        }
-      `}
+      ${
+        surfaceType === SURFACE_TYPE.MENU &&
+        css`
+          & .MuiButton-endIcon {
+            transform: rotate(180deg);
+          }
+        `
+      }
     `};
 `;

--- a/src/components/Filter/components/SearchAllFilters/common/entites.ts
+++ b/src/components/Filter/components/SearchAllFilters/common/entites.ts
@@ -37,8 +37,6 @@ export interface ValueItem {
 }
 
 export type SearchAllFiltersDynamicItem =
-  | CategoryItem
-  | ValueItem
-  | NoResultsItem;
+  CategoryItem | ValueItem | NoResultsItem;
 
 export type SearchAllFiltersItem = SearchAllFiltersDynamicItem | DividerItem;

--- a/src/components/Layout/components/Header/common/entities.ts
+++ b/src/components/Layout/components/Header/common/entities.ts
@@ -9,8 +9,7 @@ export type Navigation = [
 ]; // [LEFT, CENTER, RIGHT]
 
 export type SelectedMatch =
-  | SELECTED_MATCH
-  | Partial<Record<BreakpointKey, boolean | SELECTED_MATCH>>;
+  SELECTED_MATCH | Partial<Record<BreakpointKey, boolean | SELECTED_MATCH>>;
 
 export enum SELECTED_MATCH {
   EQUALS = "EQUALS",

--- a/src/components/Loading/loading.tsx
+++ b/src/components/Loading/loading.tsx
@@ -11,8 +11,7 @@ import { LoadingPaper, LoadingPositioner } from "./loading.styles";
  */
 
 export type LoadingPanelStyle =
-  | keyof typeof LOADING_PANEL_STYLE
-  | PaperPanelStyle;
+  keyof typeof LOADING_PANEL_STYLE | PaperPanelStyle;
 
 /**
  * Possible set of loading variant "panel" style values.

--- a/src/components/Table/components/TableRow/tableRow.styles.ts
+++ b/src/components/Table/components/TableRow/tableRow.styles.ts
@@ -47,10 +47,12 @@ export const StyledTableRow = styled(MTableRow, {
           background-color: #f8fbfd;
         }
 
-        ${isExpanded &&
-        css`
-          background-color: #f8fbfd;
-        `}
+        ${
+          isExpanded &&
+          css`
+            background-color: #f8fbfd;
+          `
+        }
       `}
 
     ${({ isPreview }) =>

--- a/src/components/common/EllipsisContent/ellipsisContent.tsx
+++ b/src/components/common/EllipsisContent/ellipsisContent.tsx
@@ -6,9 +6,9 @@ import {
 import { Button, Content } from "./ellipsisContent.styles";
 
 enum EllipsisMode {
-  "NONE" = "NONE",
-  "OFF" = "OFF",
-  "ON" = "ON",
+  NONE = "NONE",
+  OFF = "OFF",
+  ON = "ON",
 }
 
 export interface OverviewDescriptionProps {

--- a/src/components/common/ToggleButtonGroup/provider/types.ts
+++ b/src/components/common/ToggleButtonGroup/provider/types.ts
@@ -11,7 +11,6 @@ export type ToggleButtonGroupProviderProps<
   T extends ToggleButtonGroupProps["value"],
 > = {
   children:
-    | ReactNode
-    | ((props: ToggleButtonGroupContextProps<T>) => ReactNode);
+    ReactNode | ((props: ToggleButtonGroupContextProps<T>) => ReactNode);
   initialValue?: T | null;
 };

--- a/src/components/common/Typography/common/entities.ts
+++ b/src/components/common/Typography/common/entities.ts
@@ -1,5 +1,4 @@
 import { TypographyProps as MTypographyProps } from "@mui/material";
 
 export type TypographyProps =
-  | Omit<MTypographyProps, "children" | "component" | "ref">
-  | undefined;
+  Omit<MTypographyProps, "children" | "component" | "ref"> | undefined;

--- a/src/config/entities.ts
+++ b/src/config/entities.ts
@@ -136,8 +136,7 @@ export interface ComponentConfig<
  * This can be an array of @see ComponentConfig or a function that returns an array of @see ComponentConfig
  */
 export type ComponentsConfig =
-  | ComponentConfig[]
-  | ((config: SiteConfig) => ComponentConfig[]);
+  ComponentConfig[] | ((config: SiteConfig) => ComponentConfig[]);
 
 /**
  * Interface to determine the API URL and version.
@@ -313,8 +312,7 @@ export interface AuthorizationCodeFlowProvider<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use of `any` is intentional to allow for flexibility in the model.
 export type OAuthProvider<P = any> =
-  | ImplicitFlowProvider<P>
-  | AuthorizationCodeFlowProvider<P>;
+  ImplicitFlowProvider<P> | AuthorizationCodeFlowProvider<P>;
 
 /**
  * Option Method.

--- a/src/providers/dataDictionaryState/hooks/UseDataDictionaryInitialArgs/hook.ts
+++ b/src/providers/dataDictionaryState/hooks/UseDataDictionaryInitialArgs/hook.ts
@@ -7,8 +7,7 @@ export const useDataDictionaryInitialArgs =
     const { config } = useConfig();
 
     const dataDictionaries = config.dataDictionaries as
-      | DataDictionaryConfig[]
-      | undefined;
+      DataDictionaryConfig[] | undefined;
 
     return { dataDictionaries };
   };

--- a/src/providers/systemStatus.tsx
+++ b/src/providers/systemStatus.tsx
@@ -15,8 +15,8 @@ const DEFAULT_SYSTEM_STATUS: SystemStatus = {
  * Possible values of indexing status check.
  */
 export enum INDEXING_STATUS {
-  "COMPLETE" = "COMPLETE",
-  "FAILED" = "FAILED",
+  COMPLETE = "COMPLETE",
+  FAILED = "FAILED",
 }
 
 /**

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -6,8 +6,7 @@ import { DataSourceConfig } from "../config/entities";
  * @returns application DEFAULT_DETAIL_PARAMS.
  */
 export function getDefaultDetailParams():
-  | DataSourceConfig["defaultDetailParams"]
-  | DataSourceConfig["defaultParams"] {
+  DataSourceConfig["defaultDetailParams"] | DataSourceConfig["defaultParams"] {
   const { dataSource } = getConfig();
   const { defaultDetailParams, defaultParams } = dataSource || {};
   return { ...defaultDetailParams, ...defaultParams };
@@ -18,8 +17,7 @@ export function getDefaultDetailParams():
  * @returns application DEFAULT_LIST_PARAMS.
  */
 export function getDefaultListParams():
-  | DataSourceConfig["defaultListParams"]
-  | DataSourceConfig["defaultParams"] {
+  DataSourceConfig["defaultListParams"] | DataSourceConfig["defaultParams"] {
   const { dataSource } = getConfig();
   const { defaultListParams, defaultParams } = dataSource;
   return { ...defaultListParams, ...defaultParams };

--- a/src/terra/constants.ts
+++ b/src/terra/constants.ts
@@ -7,9 +7,7 @@ import { TerraTermsOfServiceResponse } from "./types/terra-tos";
  * Login response type - union of all Terra response types.
  */
 export type LoginResponse =
-  | TerraResponse
-  | TerraNIHResponse
-  | TerraTermsOfServiceResponse;
+  TerraResponse | TerraNIHResponse | TerraTermsOfServiceResponse;
 
 /**
  * Login status: failed.

--- a/src/views/ResearchView/state/actions/types.ts
+++ b/src/views/ResearchView/state/actions/types.ts
@@ -7,10 +7,7 @@ import { SetStatusAction } from "./setStatus/types";
  * Union of all Chat actions.
  */
 export type ChatAction =
-  | SetErrorAction
-  | SetMessageAction
-  | SetQueryAction
-  | SetStatusAction;
+  SetErrorAction | SetMessageAction | SetQueryAction | SetStatusAction;
 
 /**
  * Action kind identifiers for the Chat reducer.

--- a/src/views/ResearchView/state/types.ts
+++ b/src/views/ResearchView/state/types.ts
@@ -58,10 +58,7 @@ export type Intent = (typeof INTENT)[keyof typeof INTENT] | (string & {});
  * Union type for messages in the chat.
  */
 export type Message<R extends MessageResponse = MessageResponse> =
-  | AssistantMessage<R>
-  | ErrorMessage
-  | PromptMessage
-  | UserMessage;
+  AssistantMessage<R> | ErrorMessage | PromptMessage | UserMessage;
 
 /**
  * Message types for the chat.


### PR DESCRIPTION
## Summary

Closes #983

Follow-up to #981/#982. Bumps `prettier` `^3.7.4` → `^3.9.5` and applies the resulting reformat as its own PR (kept out of the audit PR, which was lockfile-only).

## Changes

- `prettier` `^3.7.4` → `^3.9.5` in `package.json`. Existing plugins are compatible (`prettier-plugin-organize-imports` needs `>=2.0`, `eslint-plugin-prettier` needs `>=3.0.0`).
- `npx prettier --write .` reformatted **21 source files** — all purely cosmetic:
  - fitting union types collapsed to a single line (`A | B | C`)
  - redundant quotes dropped from enum member names (`"IS" = "is"` → `IS = "is"` — semantically identical)
  - minor CSS-in-JS template tidying

No semantic changes; `lib/` output and runtime behavior are unaffected.

## Impact

- **Consumers:** none — `prettier` is a devDependency, not published in the tarball (`lib/` + `types/` only) and never installed by consumers. **Not a breaking change.**
- **This repo:** a large but mechanical formatting diff.

## Validation

`tsc --noEmit`, `eslint`, `prettier --check`, and all 508 jest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)