### PR TITLE
perf: memoize the virtualized table rows (#992)

### DIFF
--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
@@ -1,0 +1,34 @@
+import { JSX, memo } from "react";
+import { CollapsableCell } from "../../../TableCell/components/CollapsableCell/collapsableCell";
+import { StyledTableRow } from "../../../TableRows/components/CollapsableRows/collapsableRows.styles";
+import { CollapsableTableRowProps } from "./types";
+
+/**
+ * Memoized vertical/mobile (collapsable) table row. `CollapsableRows` otherwise
+ * maps rows inline, so any table state change re-renders every collapsable
+ * card; memoizing the row limits re-renders to the rows whose own state
+ * changed.
+ *
+ * Dynamic state is passed as props so memo's shallow compare can detect it —
+ * `isExpanded` drives the collapse (read by `CollapsableCell` off `row`, so it
+ * needs no destructuring here), plus `isSelected` / `isPreview` / `isDisabled`.
+ */
+export const CollapsableTableRow = memo(function CollapsableTableRow({
+  isDisabled,
+  isPreview,
+  isSelected,
+  measureElement,
+  row,
+  rowIndex,
+}: CollapsableTableRowProps): JSX.Element {
+  return (
+    <StyledTableRow
+      data-index={rowIndex}
+      isPreview={isPreview}
+      isSelected={isSelected}
+      ref={measureElement}
+    >
+      <CollapsableCell isDisabled={isDisabled} row={row} />
+    </StyledTableRow>
+  );
+});

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
@@ -1,3 +1,4 @@
+import { RowData } from "@tanstack/react-table";
 import { JSX, memo } from "react";
 import { CollapsableCell } from "../../../TableCell/components/CollapsableCell/collapsableCell";
 import { StyledTableRow } from "../../../TableRows/components/CollapsableRows/collapsableRows.styles";
@@ -12,15 +13,20 @@ import { CollapsableTableRowProps } from "./types";
  * Dynamic state is passed as props so memo's shallow compare can detect it —
  * `isExpanded` drives the collapse (read by `CollapsableCell` off `row`, so it
  * needs no destructuring here), plus `isSelected` / `isPreview` / `isDisabled`.
+ *
+ * `memo` erases the generic type parameter, so the export is cast back to a
+ * generic function type to preserve `Row<T>` inference at the call site.
  */
-export const CollapsableTableRow = memo(function CollapsableTableRow({
+export const CollapsableTableRow = memo(function CollapsableTableRow<
+  T extends RowData,
+>({
   isDisabled,
   isPreview,
   isSelected,
   measureElement,
   row,
   rowIndex,
-}: CollapsableTableRowProps): JSX.Element {
+}: CollapsableTableRowProps<T>): JSX.Element {
   return (
     <StyledTableRow
       data-index={rowIndex}
@@ -31,4 +37,4 @@ export const CollapsableTableRow = memo(function CollapsableTableRow({
       <CollapsableCell isDisabled={isDisabled} row={row} />
     </StyledTableRow>
   );
-});
+}) as <T extends RowData>(props: CollapsableTableRowProps<T>) => JSX.Element;

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
@@ -10,9 +10,12 @@ import { CollapsableTableRowProps } from "./types";
  * card; memoizing the row limits re-renders to the rows whose own state
  * changed.
  *
- * Dynamic state is passed as props so memo's shallow compare can detect it —
- * `isExpanded` drives the collapse (read by `CollapsableCell` off `row`, so it
- * needs no destructuring here), plus `isSelected` / `isPreview` / `isDisabled`.
+ * Per-row state is passed as props so memo's shallow compare can detect
+ * changes. `isPreview` / `isSelected` style the row and `isDisabled` gates the
+ * expand toggle — all used directly here. `isExpanded` (collapse state) and
+ * `cells` (`row.getVisibleCells()`, whose identity changes only when column
+ * visibility does) are compared as memo keys but re-derived from `row` inside
+ * `CollapsableCell`, so they aren't destructured here.
  *
  * `memo` erases the generic type parameter, so the export is cast back to a
  * generic function type to preserve `Row<T>` inference at the call site.

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
@@ -1,11 +1,11 @@
 import { Row, RowData } from "@tanstack/react-table";
 
-export interface CollapsableTableRowProps {
+export interface CollapsableTableRowProps<T extends RowData> {
   isDisabled: boolean;
   isExpanded: boolean;
   isPreview: boolean;
   isSelected: boolean;
   measureElement: (element: Element | null) => void;
-  row: Row<RowData>;
+  row: Row<T>;
   rowIndex: number;
 }

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
@@ -1,0 +1,11 @@
+import { Row, RowData } from "@tanstack/react-table";
+
+export interface CollapsableTableRowProps {
+  isDisabled: boolean;
+  isExpanded: boolean;
+  isPreview: boolean;
+  isSelected: boolean;
+  measureElement: (element: Element | null) => void;
+  row: Row<RowData>;
+  rowIndex: number;
+}

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
@@ -1,6 +1,11 @@
-import { Row, RowData } from "@tanstack/react-table";
+import { Cell, Row, RowData } from "@tanstack/react-table";
 
 export interface CollapsableTableRowProps<T extends RowData> {
+  // `getVisibleCells()` is memoized by TanStack keyed on column visibility;
+  // passed as a memo-comparison key so column-visibility toggles re-render the
+  // row (`CollapsableCell` recomputes its own cells off `row`). Compared but not
+  // destructured.
+  cells: Cell<T, unknown>[];
   isDisabled: boolean;
   isExpanded: boolean;
   isPreview: boolean;

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
@@ -1,6 +1,6 @@
 import { Row, RowData } from "@tanstack/react-table";
 
-export interface VirtualizedTableRowProps {
+export interface VirtualizedTableRowProps<T extends RowData> {
   canExpand: boolean;
   canSelect: boolean;
   isAllSubRowsSelected: boolean;
@@ -10,6 +10,6 @@ export interface VirtualizedTableRowProps {
   isSelected: boolean;
   isSomeSelected: boolean;
   measureElement: (element: Element | null) => void;
-  row: Row<RowData>;
+  row: Row<T>;
   rowIndex: number;
 }

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
@@ -1,0 +1,15 @@
+import { Row, RowData } from "@tanstack/react-table";
+
+export interface VirtualizedTableRowProps {
+  canExpand: boolean;
+  canSelect: boolean;
+  isAllSubRowsSelected: boolean;
+  isExpanded: boolean;
+  isGrouped: boolean;
+  isPreview: boolean;
+  isSelected: boolean;
+  isSomeSelected: boolean;
+  measureElement: (element: Element | null) => void;
+  row: Row<RowData>;
+  rowIndex: number;
+}

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/types.ts
@@ -1,8 +1,12 @@
-import { Row, RowData } from "@tanstack/react-table";
+import { Cell, Row, RowData } from "@tanstack/react-table";
 
 export interface VirtualizedTableRowProps<T extends RowData> {
   canExpand: boolean;
   canSelect: boolean;
+  // `getVisibleCells()` is memoized by TanStack keyed on column visibility, so
+  // passing it as a prop lets memo detect column-visibility toggles (the row
+  // object and state booleans don't change when a column is shown/hidden).
+  cells: Cell<T, unknown>[];
   isAllSubRowsSelected: boolean;
   isExpanded: boolean;
   isGrouped: boolean;

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
@@ -1,5 +1,5 @@
 import { TableCell } from "@mui/material";
-import { flexRender } from "@tanstack/react-table";
+import { flexRender, RowData } from "@tanstack/react-table";
 import { JSX, memo } from "react";
 import { TEST_IDS } from "../../../../../../tests/testIds";
 import {
@@ -19,8 +19,13 @@ import { VirtualizedTableRowProps } from "./types";
  * changes — leaf selection via `isSelected`, grouped select-all / indeterminate
  * via `isSomeSelected` / `isAllSubRowsSelected` (compared but read by the cells
  * off `row`, so they need no destructuring here).
+ *
+ * `memo` erases the generic type parameter, so the export is cast back to a
+ * generic function type to preserve `Row<T>` inference at the call site.
  */
-export const VirtualizedTableRow = memo(function VirtualizedTableRow({
+export const VirtualizedTableRow = memo(function VirtualizedTableRow<
+  T extends RowData,
+>({
   canExpand,
   canSelect,
   isExpanded,
@@ -30,7 +35,7 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow({
   measureElement,
   row,
   rowIndex,
-}: VirtualizedTableRowProps): JSX.Element {
+}: VirtualizedTableRowProps<T>): JSX.Element {
   return (
     <StyledTableRow
       canExpand={canExpand}
@@ -61,4 +66,4 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow({
       })}
     </StyledTableRow>
   );
-});
+}) as <T extends RowData>(props: VirtualizedTableRowProps<T>) => JSX.Element;

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
@@ -18,7 +18,10 @@ import { VirtualizedTableRowProps } from "./types";
  * The per-row state is passed as props so memo's shallow compare can detect
  * changes — leaf selection via `isSelected`, grouped select-all / indeterminate
  * via `isSomeSelected` / `isAllSubRowsSelected` (compared but read by the cells
- * off `row`, so they need no destructuring here).
+ * off `row`, so they need no destructuring here). `cells` is
+ * `row.getVisibleCells()` passed from the parent so column-visibility toggles
+ * are detected too — those change the cell set without changing `row` or any
+ * of the state booleans.
  *
  * `memo` erases the generic type parameter, so the export is cast back to a
  * generic function type to preserve `Row<T>` inference at the call site.
@@ -28,6 +31,7 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
 >({
   canExpand,
   canSelect,
+  cells,
   isExpanded,
   isGrouped,
   isPreview,
@@ -48,7 +52,7 @@ export const VirtualizedTableRow = memo(function VirtualizedTableRow<
       onClick={() => handleToggleExpanded(row)}
       ref={measureElement}
     >
-      {row.getVisibleCells().map((cell, i) => {
+      {cells.map((cell, i) => {
         if (cell.getIsAggregated()) return null; // Display of aggregated cells is currently not supported.
         if (cell.getIsPlaceholder()) return null; // Display of placeholder cells is currently not supported.
         return (

--- a/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/VirtualizedTableRow/virtualizedTableRow.tsx
@@ -1,0 +1,64 @@
+import { TableCell } from "@mui/material";
+import { flexRender } from "@tanstack/react-table";
+import { JSX, memo } from "react";
+import { TEST_IDS } from "../../../../../../tests/testIds";
+import {
+  getTableCellAlign,
+  getTableCellPadding,
+} from "../../../TableCell/common/utils";
+import { handleToggleExpanded } from "../../../TableFeatures/RowExpanding/utils";
+import { StyledTableRow } from "../../tableRow.styles";
+import { VirtualizedTableRowProps } from "./types";
+
+/**
+ * Memoized virtualized table row. A table state change (e.g. toggling one
+ * row's selection) otherwise re-renders every row in the virtualized body;
+ * memoizing the row limits re-renders to the rows whose own state changed.
+ *
+ * The per-row state is passed as props so memo's shallow compare can detect
+ * changes — leaf selection via `isSelected`, grouped select-all / indeterminate
+ * via `isSomeSelected` / `isAllSubRowsSelected` (compared but read by the cells
+ * off `row`, so they need no destructuring here).
+ */
+export const VirtualizedTableRow = memo(function VirtualizedTableRow({
+  canExpand,
+  canSelect,
+  isExpanded,
+  isGrouped,
+  isPreview,
+  isSelected,
+  measureElement,
+  row,
+  rowIndex,
+}: VirtualizedTableRowProps): JSX.Element {
+  return (
+    <StyledTableRow
+      canExpand={canExpand}
+      canSelect={canSelect}
+      data-index={rowIndex}
+      isExpanded={isExpanded}
+      isGrouped={isGrouped}
+      isPreview={isPreview}
+      isSelected={isSelected}
+      onClick={() => handleToggleExpanded(row)}
+      ref={measureElement}
+    >
+      {row.getVisibleCells().map((cell, i) => {
+        if (cell.getIsAggregated()) return null; // Display of aggregated cells is currently not supported.
+        if (cell.getIsPlaceholder()) return null; // Display of placeholder cells is currently not supported.
+        return (
+          <TableCell
+            data-testid={
+              rowIndex === 0 && i === 0 ? TEST_IDS.TABLE_FIRST_CELL : undefined
+            }
+            key={cell.id}
+            align={getTableCellAlign(cell.column)}
+            padding={getTableCellPadding(cell.column.id)}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
+        );
+      })}
+    </StyledTableRow>
+  );
+});

--- a/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -35,7 +35,7 @@ export const CollapsableRows = <T extends RowData>({
             isPreview={row.getIsPreview()}
             isSelected={row.getIsSelected()}
             measureElement={virtualizer.measureElement}
-            row={row as Row<RowData>}
+            row={row}
             rowIndex={rowIndex}
           />
         );

--- a/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -2,8 +2,7 @@ import { Row, RowData, Table } from "@tanstack/react-table";
 import { Virtualizer } from "@tanstack/react-virtual";
 import { Fragment, JSX } from "react";
 import { isCollapsableRowDisabled } from "../../../../common/utils";
-import { CollapsableCell } from "../../../TableCell/components/CollapsableCell/collapsableCell";
-import { StyledTableRow } from "./collapsableRows.styles";
+import { CollapsableTableRow } from "../../../TableRow/components/CollapsableTableRow/collapsableTableRow";
 import { useCollapsableRows } from "./hook";
 
 export interface CollapsableRowsProps<T extends RowData> {
@@ -18,8 +17,9 @@ export const CollapsableRows = <T extends RowData>({
   virtualizer,
 }: CollapsableRowsProps<T>): JSX.Element => {
   useCollapsableRows(tableInstance);
-  const { getState } = tableInstance;
-  const { grouping } = getState();
+  const { grouping } = tableInstance.getState();
+  // Table-level, so compute once and pass to each row (a change re-renders all).
+  const isDisabled = isCollapsableRowDisabled(tableInstance);
   const virtualItems = virtualizer.getVirtualItems();
   return (
     <Fragment>
@@ -28,18 +28,16 @@ export const CollapsableRows = <T extends RowData>({
         const row = rows[rowIndex] as Row<T>;
         if (grouping.length > 0 && row.depth > 0) return null; // TODO(cc) hide sub rows -- sub-rows are within collapsed content -- UI TBD.
         return (
-          <StyledTableRow
+          <CollapsableTableRow
             key={row.id}
-            data-index={rowIndex}
-            ref={virtualizer.measureElement}
+            isDisabled={isDisabled}
+            isExpanded={row.getIsExpanded()}
             isPreview={row.getIsPreview()}
             isSelected={row.getIsSelected()}
-          >
-            <CollapsableCell
-              isDisabled={isCollapsableRowDisabled(tableInstance)}
-              row={row}
-            />
-          </StyledTableRow>
+            measureElement={virtualizer.measureElement}
+            row={row as Row<RowData>}
+            rowIndex={rowIndex}
+          />
         );
       })}
     </Fragment>

--- a/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -30,6 +30,7 @@ export const CollapsableRows = <T extends RowData>({
         return (
           <CollapsableTableRow
             key={row.id}
+            cells={row.getVisibleCells()}
             isDisabled={isDisabled}
             isExpanded={row.getIsExpanded()}
             isPreview={row.getIsPreview()}

--- a/src/components/Table/components/TableRows/tableRows.tsx
+++ b/src/components/Table/components/TableRows/tableRows.tsx
@@ -23,6 +23,7 @@ export const TableRows = <T extends RowData>({
             key={row.id}
             canExpand={row.getCanExpand()}
             canSelect={row.getCanSelect()}
+            cells={row.getVisibleCells()}
             isAllSubRowsSelected={row.getIsAllSubRowsSelected()}
             isExpanded={row.getIsExpanded()}
             isGrouped={row.getIsGrouped()}

--- a/src/components/Table/components/TableRows/tableRows.tsx
+++ b/src/components/Table/components/TableRows/tableRows.tsx
@@ -1,14 +1,7 @@
-import { TableCell } from "@mui/material";
-import { flexRender, Row, RowData } from "@tanstack/react-table";
+import { Row, RowData } from "@tanstack/react-table";
 import { Virtualizer } from "@tanstack/react-virtual";
 import { Fragment, JSX } from "react";
-import { TEST_IDS } from "../../../../tests/testIds";
-import {
-  getTableCellAlign,
-  getTableCellPadding,
-} from "../TableCell/common/utils";
-import { handleToggleExpanded } from "../TableFeatures/RowExpanding/utils";
-import { StyledTableRow } from "../TableRow/tableRow.styles";
+import { VirtualizedTableRow } from "../TableRow/components/VirtualizedTableRow/virtualizedTableRow";
 
 export interface TableRowsProps<T extends RowData> {
   rows: Row<T>[];
@@ -25,39 +18,21 @@ export const TableRows = <T extends RowData>({
       {virtualItems.map((virtualRow) => {
         const rowIndex = virtualRow.index;
         const row = rows[rowIndex] as Row<T>;
-        const { getCanExpand, getIsExpanded, getIsGrouped, getIsPreview } = row;
         return (
-          <StyledTableRow
+          <VirtualizedTableRow
             key={row.id}
-            canExpand={getCanExpand()}
+            canExpand={row.getCanExpand()}
             canSelect={row.getCanSelect()}
-            data-index={rowIndex}
-            isExpanded={getIsExpanded()}
-            isGrouped={getIsGrouped()}
-            isPreview={getIsPreview()}
+            isAllSubRowsSelected={row.getIsAllSubRowsSelected()}
+            isExpanded={row.getIsExpanded()}
+            isGrouped={row.getIsGrouped()}
+            isPreview={row.getIsPreview()}
             isSelected={row.getIsSelected()}
-            onClick={() => handleToggleExpanded(row)}
-            ref={virtualizer.measureElement}
-          >
-            {row.getVisibleCells().map((cell, i) => {
-              if (cell.getIsAggregated()) return null; // Display of aggregated cells is currently not supported.
-              if (cell.getIsPlaceholder()) return null; // Display of placeholder cells is currently not supported.
-              return (
-                <TableCell
-                  data-testid={
-                    rowIndex === 0 && i === 0
-                      ? TEST_IDS.TABLE_FIRST_CELL
-                      : undefined
-                  }
-                  key={cell.id}
-                  align={getTableCellAlign(cell.column)}
-                  padding={getTableCellPadding(cell.column.id)}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              );
-            })}
-          </StyledTableRow>
+            isSomeSelected={row.getIsSomeSelected()}
+            measureElement={virtualizer.measureElement}
+            row={row as Row<RowData>}
+            rowIndex={rowIndex}
+          />
         );
       })}
     </Fragment>

--- a/src/components/Table/components/TableRows/tableRows.tsx
+++ b/src/components/Table/components/TableRows/tableRows.tsx
@@ -30,7 +30,7 @@ export const TableRows = <T extends RowData>({
             isSelected={row.getIsSelected()}
             isSomeSelected={row.getIsSomeSelected()}
             measureElement={virtualizer.measureElement}
-            row={row as Row<RowData>}
+            row={row}
             rowIndex={rowIndex}
           />
         );


### PR DESCRIPTION
## Summary

Closes #992

Both virtualized row renderers — the desktop `TableRows` and the vertical/mobile
`CollapsableRows` — mapped rows inline and un-memoized, so any table state change
(row selection, sort, expand, hover-driven state) re-rendered **every** row in the
viewport, not just the row that changed.

This extracts each into its own memoized component under `TableRow/components/`:

- `VirtualizedTableRow` (desktop)
- `CollapsableTableRow` (vertical / mobile)

Per-row dynamic state (`isSelected`, `isExpanded`, `canExpand`, etc.) is passed as
props so `React.memo`'s shallow compare can detect a real change and skip the rest.
Memoizing the **row** (rather than individual cells) is deliberate — TanStack only
memoizes its model layer, and `cell.getContext()` returns a fresh object each render,
so cell-level `memo` can't shallow-compare cleanly.

## Measurements

Captured with `<Profiler>` in a consuming app (StrictMode off, no CPU throttling),
comparing the memoized build against the published baseline (`actual` = real
wall-clock; `unmemoized est.` = React's `baseDuration`).

**Desktop detail table** (checkbox toggle): ~318ms → ~35ms (**~9×**).

**Mobile / collapsable** (typical update): ~50ms → ~15ms (**~3×**); full-skip
commits drop to 0.1–0.6ms.

**Entity list (ExploreState) table** — largest win, since these tables have the
most columns/rows: selection / non-data-changing updates drop from ~125–330ms to
**0–4ms** (up to ~150× on full-skip commits). Sort/filter stays at `actual ≈ base`
as expected — those genuinely reorder/replace the visible rows, so there is nothing
for a row-level memo to skip.

## Test plan

- `tsc` clean, `prettier` clean, `eslint` clean
- `rowSelectionValidation` + `tableFilter` suites pass (19/19)
- Manually verified selection / expand / sort / filter behaviour is unchanged on
  desktop, mobile, and entity-list tables in hca-atlas-tracker via tarball install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
