### PR TITLE
feat: add cached seeddatabase utility to avoid re-parsing catalogs per page (#987)

### DIFF
--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -5,10 +5,12 @@ import { database } from "./database";
 // Intended for static-export builds. Reading, parsing and mapping the catalog
 // file is the expensive part (multi-MB files, and getStaticProps runs once per
 // prerendered page), so memoize that per entity type — the file is read, parsed
-// and mapped once regardless of how many pages seed the type. The memoized
-// entities are held for the process lifetime and are NOT re-read if the file
-// changes on disk, so this is unsuitable for long-lived servers that must
-// reflect catalog edits.
+// and mapped once regardless of how many pages seed the type. Keying by entity
+// type is safe because each type resolves to a single entity config (one
+// static-load file, one mapper) via getEntityConfig, so a type is never seeded
+// from a different file or mapping. The memoized entities are held for the
+// process lifetime and are NOT re-read if the file changes on disk, so this is
+// unsuitable for long-lived servers that must reflect catalog edits.
 //
 // The database seed write is cheap and runs on EVERY call, deliberately not
 // memoized: other build-time code may seed the same entity type with a

--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -82,7 +82,17 @@ async function readEntities(
   // or a top-level array of entities (brc-analytics); Object.values handles
   // both. Only reject null/non-object values, which would otherwise throw a
   // raw TypeError or silently seed an empty list.
-  const object: unknown = JSON.parse(jsonText);
+  let object: unknown;
+  try {
+    object = JSON.parse(jsonText);
+  } catch (error) {
+    // Point parse failures (malformed/truncated catalog) at the offending file
+    // and type, preserving the SyntaxError as the cause.
+    throw new Error(
+      `Failed to parse file ${staticLoadFile} for entity type "${entityListType}"`,
+      { cause: error },
+    );
+  }
   if (typeof object !== "object" || object === null) {
     throw new Error(
       `File ${staticLoadFile} for entity type "${entityListType}" is not a JSON object or array`,
@@ -91,9 +101,10 @@ async function readEntities(
 
   // Client-side fetched entities are mapped prior to dispatch to explore state.
   // Object.values on the guarded `object` type infers any[], so annotate the
-  // result to keep the entities typed as unknown[] end-to-end.
+  // result to keep the entities typed as unknown[] end-to-end. Wrap the mapper
+  // so it only ever receives the entity, not map's (value, index, array).
   const values: unknown[] = Object.values(object);
-  return entityMapper ? values.map(entityMapper) : values;
+  return entityMapper ? values.map((value) => entityMapper(value)) : values;
 }
 
 /**
@@ -101,7 +112,7 @@ async function readEntities(
  * and map are memoized per type (see loadEntities) so they happen once during a
  * static export, but the seed write runs on every call so the seeded shape is
  * always correct even when other build-time code seeds the same type with a
- * different shape.
+ * different shape. Server-only: call from build-time code (e.g. getStaticProps).
  * @param entityListType - Entity list type.
  * @param entityConfig - Entity config.
  * @returns Promise that resolves once the database has been seeded.

--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -12,9 +12,9 @@ import { database } from "./database";
 //
 // The database seed write is cheap and runs on EVERY call, deliberately not
 // memoized: other build-time code may seed the same entity type with a
-// different shape (e.g. a list page that seeds unmapped entities for
-// client-side mapping) and build workers interleave pages, so skipping the seed
-// on a cache hit could leave the wrong shape in the database.
+// different shape (e.g. a list page seeding unmapped entities for client-side
+// mapping) and build workers interleave pages, so skipping the seed on a cache
+// hit could leave the wrong shape in the database.
 //
 // Server-only: uses Node fs; import only from build-time code (e.g. getStaticProps).
 const entitiesByType = new Map<string, Promise<unknown[]>>();
@@ -35,10 +35,12 @@ function loadEntities(
   if (!entities) {
     // Don't cache a failed read — evict on rejection, but re-throw so awaiters
     // (and unhandled-rejection tracking) still see the failure.
-    entities = readEntities(entityConfig).catch((error: unknown) => {
-      entitiesByType.delete(entityListType);
-      throw error;
-    });
+    entities = readEntities(entityListType, entityConfig).catch(
+      (error: unknown) => {
+        entitiesByType.delete(entityListType);
+        throw error;
+      },
+    );
     entitiesByType.set(entityListType, entities);
   }
   return entities;
@@ -46,24 +48,30 @@ function loadEntities(
 
 /**
  * Reads, parses and maps the entity config's catalog file.
+ * @param entityListType - Entity list type, used in error messages.
  * @param entityConfig - Entity config.
  * @returns Promise resolving to the mapped entities.
  */
-async function readEntities(entityConfig: EntityConfig): Promise<unknown[]> {
-  const { entityMapper, label, staticLoadFile } = entityConfig;
+async function readEntities(
+  entityListType: string,
+  entityConfig: EntityConfig,
+): Promise<unknown[]> {
+  const { entityMapper, staticLoadFile } = entityConfig;
 
   if (!staticLoadFile) {
-    throw new Error(`staticLoadFile not found for entity ${label}`);
+    throw new Error(
+      `staticLoadFile not found for entity type "${entityListType}"`,
+    );
   }
 
-  let jsonText;
+  let jsonText: string;
   try {
     jsonText = await fsp.readFile(staticLoadFile, "utf8");
   } catch (error) {
     // Preserve the underlying cause (e.g. EACCES, EISDIR, EMFILE) rather than
     // relabelling every read failure as a missing file.
     throw new Error(
-      `Failed to read file ${staticLoadFile} for entity ${label}`,
+      `Failed to read file ${staticLoadFile} for entity type "${entityListType}"`,
       { cause: error },
     );
   }
@@ -75,7 +83,7 @@ async function readEntities(entityConfig: EntityConfig): Promise<unknown[]> {
   const object: unknown = JSON.parse(jsonText);
   if (typeof object !== "object" || object === null) {
     throw new Error(
-      `File ${staticLoadFile} for entity ${label} is not a JSON object or array`,
+      `File ${staticLoadFile} for entity type "${entityListType}" is not a JSON object or array`,
     );
   }
 

--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -1,0 +1,99 @@
+import fsp from "fs/promises";
+import type { EntityConfig } from "../config/entities";
+import { database } from "./database";
+
+// Intended for static-export builds. Reading, parsing and mapping the catalog
+// file is the expensive part (multi-MB files, and getStaticProps runs once per
+// prerendered page), so memoize that per entity type — the file is read, parsed
+// and mapped once regardless of how many pages seed the type. The memoized
+// entities are held for the process lifetime and are NOT re-read if the file
+// changes on disk, so this is unsuitable for long-lived servers that must
+// reflect catalog edits.
+//
+// The database seed write is cheap and runs on EVERY call, deliberately not
+// memoized: other build-time code may seed the same entity type with a
+// different shape (e.g. a list page that seeds unmapped entities for
+// client-side mapping) and build workers interleave pages, so skipping the seed
+// on a cache hit could leave the wrong shape in the database.
+//
+// Server-only: uses Node fs; import only from build-time code (e.g. getStaticProps).
+const entitiesByType = new Map<string, Promise<unknown[]>>();
+
+/**
+ * Returns the entities for an entity type, reading, parsing and mapping the
+ * catalog file once per type and caching the result for the process lifetime.
+ * A failed read is not cached, so a later call retries.
+ * @param entityListType - Entity list type.
+ * @param entityConfig - Entity config.
+ * @returns Promise resolving to the mapped entities.
+ */
+function loadEntities(
+  entityListType: string,
+  entityConfig: EntityConfig,
+): Promise<unknown[]> {
+  let entities = entitiesByType.get(entityListType);
+  if (!entities) {
+    // Don't cache a failed read — evict on rejection, but re-throw so awaiters
+    // (and unhandled-rejection tracking) still see the failure.
+    entities = readEntities(entityConfig).catch((error: unknown) => {
+      entitiesByType.delete(entityListType);
+      throw error;
+    });
+    entitiesByType.set(entityListType, entities);
+  }
+  return entities;
+}
+
+/**
+ * Reads, parses and maps the entity config's catalog file.
+ * @param entityConfig - Entity config.
+ * @returns Promise resolving to the mapped entities.
+ */
+async function readEntities(entityConfig: EntityConfig): Promise<unknown[]> {
+  const { entityMapper, label, staticLoadFile } = entityConfig;
+
+  if (!staticLoadFile) {
+    throw new Error(`staticLoadFile not found for entity ${label}`);
+  }
+
+  let jsonText;
+  try {
+    jsonText = await fsp.readFile(staticLoadFile, "utf8");
+  } catch (error) {
+    // Preserve the underlying cause (e.g. EACCES, EISDIR, EMFILE) rather than
+    // relabelling every read failure as a missing file.
+    throw new Error(
+      `Failed to read file ${staticLoadFile} for entity ${label}`,
+      { cause: error },
+    );
+  }
+
+  const object: unknown = JSON.parse(jsonText);
+  if (typeof object !== "object" || object === null) {
+    throw new Error(
+      `File ${staticLoadFile} for entity ${label} is not a JSON object`,
+    );
+  }
+
+  // Client-side fetched entities are mapped prior to dispatch to explore state.
+  const values = Object.values(object);
+  return entityMapper ? values.map(entityMapper) : values;
+}
+
+/**
+ * Seeds the database for an entity type from its catalog file. The read, parse
+ * and map are memoized per type (see loadEntities) so they happen once during a
+ * static export, but the seed write runs on every call so the seeded shape is
+ * always correct even when other build-time code seeds the same type with a
+ * different shape.
+ * @param entityListType - Entity list type.
+ * @param entityConfig - Entity config.
+ * @returns Promise that resolves once the database has been seeded.
+ */
+export async function seedDatabase(
+  entityListType: string,
+  entityConfig: EntityConfig,
+): Promise<void> {
+  const entities = await loadEntities(entityListType, entityConfig);
+  database.get().seed(entityListType, entities);
+}

--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -68,10 +68,14 @@ async function readEntities(entityConfig: EntityConfig): Promise<unknown[]> {
     );
   }
 
+  // Catalog files are either an object map keyed by id (data-biosphere, ncpi)
+  // or a top-level array of entities (brc-analytics); Object.values handles
+  // both. Only reject null/non-object values, which would otherwise throw a
+  // raw TypeError or silently seed an empty list.
   const object: unknown = JSON.parse(jsonText);
   if (typeof object !== "object" || object === null) {
     throw new Error(
-      `File ${staticLoadFile} for entity ${label} is not a JSON object`,
+      `File ${staticLoadFile} for entity ${label} is not a JSON object or array`,
     );
   }
 

--- a/src/utils/seedDatabase.ts
+++ b/src/utils/seedDatabase.ts
@@ -90,7 +90,9 @@ async function readEntities(
   }
 
   // Client-side fetched entities are mapped prior to dispatch to explore state.
-  const values = Object.values(object);
+  // Object.values on the guarded `object` type infers any[], so annotate the
+  // result to keep the entities typed as unknown[] end-to-end.
+  const values: unknown[] = Object.values(object);
   return entityMapper ? values.map(entityMapper) : values;
 }
 

--- a/tests/seedDatabase.test.ts
+++ b/tests/seedDatabase.test.ts
@@ -7,12 +7,17 @@ import { seedDatabase } from "../src/utils/seedDatabase";
 const seed = jest.fn();
 
 /**
- * Builds a minimal entity config for a test with the given static-load file.
+ * Builds a minimal entity config for a test with the given static-load file and
+ * optional entity mapper.
  * @param staticLoadFile - Static-load file path.
+ * @param entityMapper - Optional entity mapper.
  * @returns Entity config.
  */
-const config = (staticLoadFile: string): EntityConfig =>
-  ({ staticLoadFile }) as unknown as EntityConfig;
+const config = (
+  staticLoadFile: string,
+  entityMapper?: (input: unknown) => unknown,
+): EntityConfig =>
+  ({ entityMapper, staticLoadFile }) as unknown as EntityConfig;
 
 // seedDatabase's cache is module-level and keyed by entity type, persisting for
 // the file's lifetime, so each test uses a unique entityListType to stay
@@ -43,6 +48,25 @@ describe("seedDatabase", () => {
     expect(seed).toHaveBeenCalledTimes(5);
   });
 
+  it("applies the config's entityMapper, mapping once per entity across calls", async () => {
+    readFile.mockResolvedValue('{"a":{"id":1},"b":{"id":2}}');
+    const entityMapper = jest.fn((input: unknown) => ({
+      mapped: (input as { id: number }).id,
+    }));
+    const mapped = config("mapped.json", entityMapper);
+    await seedDatabase("mapped", mapped);
+    await seedDatabase("mapped", mapped);
+    // seed receives the mapped output.
+    expect(seed).toHaveBeenLastCalledWith("mapped", [
+      { mapped: 1 },
+      { mapped: 2 },
+    ]);
+    // The mapper receives only the entity, not map's (value, index, array).
+    expect(entityMapper).toHaveBeenNthCalledWith(1, { id: 1 });
+    // Mapping is inside the memoized region: two entities, not two per call.
+    expect(entityMapper).toHaveBeenCalledTimes(2);
+  });
+
   it("reads once per entity type", async () => {
     await seedDatabase("typeA", config("typeA.json"));
     await seedDatabase("typeB", config("typeB.json"));
@@ -60,9 +84,24 @@ describe("seedDatabase", () => {
     expect(seed).toHaveBeenCalledTimes(10);
   });
 
-  it("does not cache a failed read; a later call retries", async () => {
-    readFile.mockRejectedValueOnce(new Error("boom"));
-    await expect(seedDatabase("retry", config("retry.json"))).rejects.toThrow();
+  it("throws when staticLoadFile is missing", async () => {
+    const noFile = {} as unknown as EntityConfig;
+    await expect(seedDatabase("nofile", noFile)).rejects.toThrow(
+      /staticLoadFile not found/,
+    );
+    expect(seed).not.toHaveBeenCalled();
+  });
+
+  it("does not cache a failed read; a later call retries with the error wrapped", async () => {
+    const cause = new Error("boom");
+    readFile.mockRejectedValueOnce(cause);
+    // The failure is wrapped with the file path and preserves the cause.
+    await expect(
+      seedDatabase("retry", config("retry.json")),
+    ).rejects.toMatchObject({
+      cause,
+      message: expect.stringContaining("retry.json"),
+    });
     await seedDatabase("retry", config("retry.json"));
     expect(readFile).toHaveBeenCalledTimes(2);
     expect(seed).toHaveBeenCalledTimes(1);

--- a/tests/seedDatabase.test.ts
+++ b/tests/seedDatabase.test.ts
@@ -69,4 +69,10 @@ describe("seedDatabase", () => {
     ).rejects.toThrow(/not a JSON object/);
     expect(seed).not.toHaveBeenCalled();
   });
+
+  it("seeds the elements of a top-level array catalog (e.g. brc-analytics)", async () => {
+    readFile.mockResolvedValueOnce('[{ "id": 1 }, { "id": 2 }]');
+    await seedDatabase("array", config("array.json"));
+    expect(seed).toHaveBeenCalledWith("array", [{ id: 1 }, { id: 2 }]);
+  });
 });

--- a/tests/seedDatabase.test.ts
+++ b/tests/seedDatabase.test.ts
@@ -6,11 +6,17 @@ import { seedDatabase } from "../src/utils/seedDatabase";
 
 const seed = jest.fn();
 
+/**
+ * Builds a minimal entity config for a test with the given static-load file.
+ * @param staticLoadFile - Static-load file path.
+ * @returns Entity config.
+ */
 const config = (staticLoadFile: string): EntityConfig =>
-  ({ label: staticLoadFile, staticLoadFile }) as unknown as EntityConfig;
+  ({ staticLoadFile }) as unknown as EntityConfig;
 
-// seedDatabase's read cache is module-level and persists for the file's
-// lifetime, so each test uses a unique entityListType key to stay isolated.
+// seedDatabase's cache is module-level and keyed by entity type, persisting for
+// the file's lifetime, so each test uses a unique entityListType to stay
+// isolated.
 describe("seedDatabase", () => {
   let readFile: jest.Mock;
 

--- a/tests/seedDatabase.test.ts
+++ b/tests/seedDatabase.test.ts
@@ -1,0 +1,72 @@
+import { jest } from "@jest/globals";
+import fsp from "fs/promises";
+import type { EntityConfig } from "../src/config/entities";
+import { database } from "../src/utils/database";
+import { seedDatabase } from "../src/utils/seedDatabase";
+
+const seed = jest.fn();
+
+const config = (staticLoadFile: string): EntityConfig =>
+  ({ label: staticLoadFile, staticLoadFile }) as unknown as EntityConfig;
+
+// seedDatabase's read cache is module-level and persists for the file's
+// lifetime, so each test uses a unique entityListType key to stay isolated.
+describe("seedDatabase", () => {
+  let readFile: jest.Mock;
+
+  beforeEach(() => {
+    seed.mockReset();
+    jest
+      .spyOn(database, "get")
+      .mockReturnValue({ seed } as unknown as ReturnType<typeof database.get>);
+    readFile = jest.spyOn(fsp, "readFile") as unknown as jest.Mock;
+    readFile.mockResolvedValue('{"a":{"id":1}}');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reads and maps once but seeds on every call for the same entity type", async () => {
+    for (let i = 0; i < 5; i++) {
+      await seedDatabase("repeat", config("repeat.json"));
+    }
+    // The expensive read/parse/map is memoized...
+    expect(readFile).toHaveBeenCalledTimes(1);
+    // ...but the seed write runs on every call so the shape is always correct.
+    expect(seed).toHaveBeenCalledTimes(5);
+  });
+
+  it("reads once per entity type", async () => {
+    await seedDatabase("typeA", config("typeA.json"));
+    await seedDatabase("typeB", config("typeB.json"));
+    await seedDatabase("typeA", config("typeA.json"));
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares a single read across a concurrent burst but seeds each call", async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        seedDatabase("burst", config("burst.json")),
+      ),
+    );
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(seed).toHaveBeenCalledTimes(10);
+  });
+
+  it("does not cache a failed read; a later call retries", async () => {
+    readFile.mockRejectedValueOnce(new Error("boom"));
+    await expect(seedDatabase("retry", config("retry.json"))).rejects.toThrow();
+    await seedDatabase("retry", config("retry.json"));
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(seed).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when the catalog JSON is not an object", async () => {
+    readFile.mockResolvedValueOnce("null");
+    await expect(
+      seedDatabase("notobject", config("notobject.json")),
+    ).rejects.toThrow(/not a JSON object/);
+    expect(seed).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a framework-level `seedDatabase` utility so consumers stop re-reading and re-parsing their catalog JSON once per static page during `next build`. Today each portal wraps `database.get().seed()` itself, and `getStaticProps` calls it **per page**, so a large export re-parses the multi-MB catalog thousands of times (brc-analytics measured ~172s of avoidable build time).

`import { seedDatabase } from "@databiosphere/findable-ui/lib/utils/seedDatabase"`

```ts
await seedDatabase(entityListType, entityConfig); // read+parse+map once; seed every call
```

## Design

- **Memoizes the read + parse + map per entity type** — the expensive part (the issue's own analysis: the dominant cost is `readFile` + `JSON.parse` before `seed()`). Done once per type regardless of how many pages seed it.
- **Performs the `database.seed()` write on every call, deliberately not memoized.** Other build-time code may seed the same type with a different shape (e.g. a list page seeding *unmapped* entities for client-side mapping) and build workers interleave pages, so skipping the seed on a cache hit could leave the wrong shape in the database. This mirrors the pattern already shipping in **ncpi-dataset-catalog** (`loadEntities` memoized + `seedDatabase` always-writes).
- A failed read is not cached (evict on rejection → retry). The read error preserves its underlying cause (EACCES/EISDIR/EMFILE) rather than relabelling everything "not found". Non-object JSON throws a clear error instead of a raw `TypeError` or a silent empty seed.
- **`database.ts` is unchanged** — fully backwards-compatible.

## Server-only

Uses Node `fs/promises`; intended for build-time code (`getStaticProps`) only, consistent with findable-ui's existing MDX utils. The memoized read is held for the process lifetime and not re-read on disk changes, so it's for immutable static-export catalogs, not long-lived servers.

## Verification

- **Unit tests** (`tests/seedDatabase.test.ts`): reads once but seeds on every call for a type; reads once per type; single read across a concurrent burst (still seeds each call); no caching of a failed read; clear error on non-object JSON.
- **End-to-end**: built data-biosphere's anvil-catalog static export against this util (with its detail/list seeding migrated to it) — the build produced all 159 pages and the `/consortia/1000G` detail page pre-rendered with correct mapped data (seed → `database.find()` path).

## Migration (downstream, out of scope here)

Consumers replace their local `seedDatabase` wrapper with this util (separate PRs per consumer). The hardening here (memoize-read/always-seed, error `cause`, non-object guard) should also be backported to brc-analytics' local copy.

Closes #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
