### PR TITLE
fix: re-render grouped mobile card on sub-row selection change (#995)

### DIFF
--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
@@ -12,10 +12,15 @@ import { CollapsableTableRowProps } from "./types";
  *
  * Per-row state is passed as props so memo's shallow compare can detect
  * changes. `isPreview` / `isSelected` style the row and `isDisabled` gates the
- * expand toggle — all used directly here. `isExpanded` (collapse state) and
+ * expand toggle — all used directly here. `isExpanded` (collapse state),
  * `cells` (`row.getVisibleCells()`, whose identity changes only when column
- * visibility does) are compared as memo keys but re-derived from `row` inside
- * `CollapsableCell`, so they aren't destructured here.
+ * visibility does) and `subRowSelection` (the grouped card's per-sub-row
+ * selection signature) are compared as memo keys but re-derived from `row`
+ * inside `CollapsableCell`, so they aren't destructured here. `subRowSelection`
+ * matters because a group card renders its sub-rows' checkboxes, yet the
+ * parent's own `isSelected` only flips when every sub-row is selected — without
+ * it, selecting a second sub-row (or deselecting one of two) changes no
+ * compared prop and the checkbox goes stale.
  *
  * `memo` erases the generic type parameter, so the export is cast back to a
  * generic function type to preserve `Row<T>` inference at the call site.

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/collapsableTableRow.tsx
@@ -14,9 +14,9 @@ import { CollapsableTableRowProps } from "./types";
  * changes. `isPreview` / `isSelected` style the row and `isDisabled` gates the
  * expand toggle — all used directly here. `isExpanded` (collapse state),
  * `cells` (`row.getVisibleCells()`, whose identity changes only when column
- * visibility does) and `subRowSelection` (the grouped card's per-sub-row
+ * visibility does) and `subRowSelectionSignature` (the grouped card's per-sub-row
  * selection signature) are compared as memo keys but re-derived from `row`
- * inside `CollapsableCell`, so they aren't destructured here. `subRowSelection`
+ * inside `CollapsableCell`, so they aren't destructured here. `subRowSelectionSignature`
  * matters because a group card renders its sub-rows' checkboxes, yet the
  * parent's own `isSelected` only flips when every sub-row is selected — without
  * it, selecting a second sub-row (or deselecting one of two) changes no

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
@@ -13,4 +13,12 @@ export interface CollapsableTableRowProps<T extends RowData> {
   measureElement: (element: Element | null) => void;
   row: Row<T>;
   rowIndex: number;
+  // A grouped card renders its sub-rows' checkboxes, but the parent's own
+  // `isSelected` only flips when every sub-row is selected, and boolean
+  // aggregates (`getIsSomeSelected` / `getIsAllSubRowsSelected`) can't tell 1
+  // selected from 2. This per-sub-row selection signature changes on every
+  // sub-row toggle, so it's a memo key that re-renders the card (compared but
+  // read off `row` inside `CollapsableCell`, so not destructured). Empty for
+  // non-grouped rows, whose own checkbox is covered by `isSelected`.
+  subRowSelection: string;
 }

--- a/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
+++ b/src/components/Table/components/TableRow/components/CollapsableTableRow/types.ts
@@ -20,5 +20,5 @@ export interface CollapsableTableRowProps<T extends RowData> {
   // sub-row toggle, so it's a memo key that re-renders the card (compared but
   // read off `row` inside `CollapsableCell`, so not destructured). Empty for
   // non-grouped rows, whose own checkbox is covered by `isSelected`.
-  subRowSelection: string;
+  subRowSelectionSignature: string;
 }

--- a/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -4,6 +4,7 @@ import { Fragment, JSX } from "react";
 import { isCollapsableRowDisabled } from "../../../../common/utils";
 import { CollapsableTableRow } from "../../../TableRow/components/CollapsableTableRow/collapsableTableRow";
 import { useCollapsableRows } from "./hook";
+import { getSubRowSelectionSignature } from "./utils";
 
 export interface CollapsableRowsProps<T extends RowData> {
   rows: Row<T>[];
@@ -38,6 +39,7 @@ export const CollapsableRows = <T extends RowData>({
             measureElement={virtualizer.measureElement}
             row={row}
             rowIndex={rowIndex}
+            subRowSelection={getSubRowSelectionSignature(row)}
           />
         );
       })}

--- a/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows.tsx
@@ -39,7 +39,7 @@ export const CollapsableRows = <T extends RowData>({
             measureElement={virtualizer.measureElement}
             row={row}
             rowIndex={rowIndex}
-            subRowSelection={getSubRowSelectionSignature(row)}
+            subRowSelectionSignature={getSubRowSelectionSignature(row)}
           />
         );
       })}

--- a/src/components/Table/components/TableRows/components/CollapsableRows/utils.ts
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/utils.ts
@@ -1,19 +1,33 @@
 import { Row, RowData } from "@tanstack/react-table";
 
 /**
- * Returns a per-sub-row selection signature for a grouped row: a "1"/"0" string,
- * one character per sub-row's selection state. Used as a memo key for the
- * grouped card (which renders its sub-rows' checkboxes) so it re-renders
- * whenever any sub-row toggles — boolean aggregates (`getIsSomeSelected` /
- * `getIsAllSubRowsSelected`) can't distinguish 1 selected from 2. Empty string
- * for non-grouped rows (no sub-rows), whose own checkbox is covered elsewhere.
+ * Returns a per-sub-row selection signature for a grouped row: one character per
+ * sub-row encoding its selection as "2" (all/selected), "1" (some) or "0"
+ * (none). Used as a memo key for the grouped card (which renders its sub-rows'
+ * checkboxes via `CollapsableCell.getRowVisibleCells`) so it re-renders whenever
+ * any sub-row's checkbox state changes — boolean aggregates (`getIsSomeSelected`
+ * / `getIsAllSubRowsSelected`) can't distinguish 1 selected from 2. The
+ * tri-state (rather than binary) encoding also catches a nested subgroup's
+ * indeterminate transition under multi-level grouping. Built with a loop to
+ * avoid allocating an intermediate array on every render.
+ *
+ * Gated on `row.getIsGrouped()` to match where a card actually renders sub-row
+ * checkboxes: only grouped rows do. Any other row — including a non-grouped
+ * expandable/tree row that happens to have `subRows` — renders its own checkbox
+ * as its own card (covered by `isSelected`), so it returns an empty signature
+ * and contributes nothing to the memo key.
  * @param row - Row.
- * @returns Sub-row selection signature.
+ * @returns Sub-row selection signature, or "" when the row isn't grouped.
  */
 export function getSubRowSelectionSignature<T extends RowData>(
   row: Row<T>,
 ): string {
-  return row.subRows
-    .map((subRow) => (subRow.getIsSelected() ? "1" : "0"))
-    .join("");
+  if (!row.getIsGrouped()) return "";
+  let signature = "";
+  for (const subRow of row.subRows) {
+    if (subRow.getIsSelected()) signature += "2";
+    else if (subRow.getIsSomeSelected()) signature += "1";
+    else signature += "0";
+  }
+  return signature;
 }

--- a/src/components/Table/components/TableRows/components/CollapsableRows/utils.ts
+++ b/src/components/Table/components/TableRows/components/CollapsableRows/utils.ts
@@ -1,0 +1,19 @@
+import { Row, RowData } from "@tanstack/react-table";
+
+/**
+ * Returns a per-sub-row selection signature for a grouped row: a "1"/"0" string,
+ * one character per sub-row's selection state. Used as a memo key for the
+ * grouped card (which renders its sub-rows' checkboxes) so it re-renders
+ * whenever any sub-row toggles — boolean aggregates (`getIsSomeSelected` /
+ * `getIsAllSubRowsSelected`) can't distinguish 1 selected from 2. Empty string
+ * for non-grouped rows (no sub-rows), whose own checkbox is covered elsewhere.
+ * @param row - Row.
+ * @returns Sub-row selection signature.
+ */
+export function getSubRowSelectionSignature<T extends RowData>(
+  row: Row<T>,
+): string {
+  return row.subRows
+    .map((subRow) => (subRow.getIsSelected() ? "1" : "0"))
+    .join("");
+}

--- a/tests/collapsableRowsSelection.test.tsx
+++ b/tests/collapsableRowsSelection.test.tsx
@@ -1,0 +1,118 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getGroupedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { JSX, useState } from "react";
+import { CollapsableRows } from "../src/components/Table/components/TableRows/components/CollapsableRows/collapsableRows";
+import { ROW_PREVIEW } from "../src/components/Table/features/RowPreview/constants";
+
+interface RowData {
+  group: string;
+  name: string;
+}
+
+// Three rows in one group, so a sub-row can be some-but-not-all selected — the
+// case the binary memo props couldn't distinguish (1 vs 2 selected).
+const DATA: RowData[] = [
+  { group: "A", name: "a1" },
+  { group: "A", name: "a2" },
+  { group: "A", name: "a3" },
+];
+
+// Stable references so they never perturb the CollapsableTableRow memo: a
+// new grouping array would rebuild the grouped row model (fresh `row` objects),
+// and a new measureElement would change a compared prop — either would re-render
+// the card regardless of the selection signature and mask a broken memo key.
+const GROUPING = ["group"];
+const measureElement = (): undefined => undefined;
+
+const columnHelper = createColumnHelper<RowData>();
+
+const COLUMNS = [
+  columnHelper.display({
+    cell: ({ row }) => (
+      <input
+        aria-label={`select ${row.original.name}`}
+        checked={row.getIsSelected()}
+        onChange={row.getToggleSelectedHandler()}
+        type="checkbox"
+      />
+    ),
+    id: "select",
+  }),
+  columnHelper.accessor("group", { header: "Group" }),
+  columnHelper.accessor("name", { header: "Name" }),
+];
+
+/**
+ * Renders a grouped collapsable table body so a grouped card draws its
+ * sub-rows' checkboxes (via CollapsableCell). Row selection is React state, so
+ * a toggle re-renders CollapsableRows and re-computes the memo's
+ * subRowSelectionSignature.
+ * @returns Grouped collapsable table.
+ */
+function TestTable(): JSX.Element {
+  const [rowSelection, setRowSelection] = useState({});
+  const table = useReactTable<RowData>({
+    _features: [ROW_PREVIEW],
+    columns: COLUMNS,
+    data: DATA,
+    enableRowSelection: true,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getGroupedRowModel: getGroupedRowModel(),
+    onRowSelectionChange: setRowSelection,
+    state: { expanded: true, grouping: GROUPING, rowSelection },
+  });
+  const rows = table.getRowModel().rows;
+  // Stub virtualizer that renders every row (the real one measures a scroll
+  // container that doesn't exist in jsdom). `measureElement` is the only
+  // virtualizer value passed into the memoized row, and it's a stable
+  // module-level reference so it can't defeat the memo.
+  const virtualizer = {
+    getVirtualItems: () => rows.map((_, index) => ({ index, key: index })),
+    measureElement,
+  } as unknown as Virtualizer<HTMLDivElement, Element>;
+  return (
+    <table>
+      <tbody>
+        <CollapsableRows
+          rows={rows}
+          tableInstance={table}
+          virtualizer={virtualizer}
+        />
+      </tbody>
+    </table>
+  );
+}
+
+describe("CollapsableRows - grouped mobile sub-row selection", () => {
+  it("reflects each sub-row's checkbox as selections toggle (memo wiring)", () => {
+    render(<TestTable />);
+    const a1 = screen.getByLabelText("select a1") as HTMLInputElement;
+    const a2 = screen.getByLabelText("select a2") as HTMLInputElement;
+
+    expect(a1.checked).toBe(false);
+    expect(a2.checked).toBe(false);
+
+    // First selection.
+    fireEvent.click(a1);
+    expect(a1.checked).toBe(true);
+
+    // Second selection — the regression this guards: with the memo key removed,
+    // the grouped card wouldn't re-render here and a2 would stay unchecked.
+    fireEvent.click(a2);
+    expect(a1.checked).toBe(true);
+    expect(a2.checked).toBe(true);
+
+    // Deselect one of two.
+    fireEvent.click(a1);
+    expect(a1.checked).toBe(false);
+    expect(a2.checked).toBe(true);
+  });
+});

--- a/tests/getSubRowSelectionSignature.test.ts
+++ b/tests/getSubRowSelectionSignature.test.ts
@@ -1,0 +1,79 @@
+import { Row, RowData } from "@tanstack/react-table";
+import { getSubRowSelectionSignature } from "../src/components/Table/components/TableRows/components/CollapsableRows/utils";
+
+interface SubRowState {
+  isSelected: boolean;
+  isSomeSelected?: boolean;
+}
+
+/**
+ * Builds a minimal Row stub exposing only the members
+ * getSubRowSelectionSignature reads.
+ * @param isGrouped - Whether the row is a grouping row.
+ * @param subRows - Selection state for each sub-row.
+ * @returns Row stub.
+ */
+function mockRow(
+  isGrouped: boolean,
+  subRows: SubRowState[] = [],
+): Row<RowData> {
+  return {
+    getIsGrouped: () => isGrouped,
+    subRows: subRows.map((state) => ({
+      getIsSelected: () => state.isSelected,
+      getIsSomeSelected: () => state.isSomeSelected ?? false,
+    })),
+  } as unknown as Row<RowData>;
+}
+
+describe("getSubRowSelectionSignature", () => {
+  it("returns an empty string for non-grouped rows (even with sub-rows)", () => {
+    expect(
+      getSubRowSelectionSignature(mockRow(false, [{ isSelected: true }])),
+    ).toBe("");
+  });
+
+  it("distinguishes 0, 1 and 2 selected sub-rows (the reported regression)", () => {
+    const none = mockRow(true, [
+      { isSelected: false },
+      { isSelected: false },
+      { isSelected: false },
+    ]);
+    const one = mockRow(true, [
+      { isSelected: true },
+      { isSelected: false },
+      { isSelected: false },
+    ]);
+    const two = mockRow(true, [
+      { isSelected: true },
+      { isSelected: true },
+      { isSelected: false },
+    ]);
+    expect(getSubRowSelectionSignature(none)).toBe("000");
+    expect(getSubRowSelectionSignature(one)).toBe("200");
+    expect(getSubRowSelectionSignature(two)).toBe("220");
+    // The bug: selecting a second sub-row must change the signature.
+    expect(getSubRowSelectionSignature(one)).not.toBe(
+      getSubRowSelectionSignature(two),
+    );
+  });
+
+  it("encodes a partially-selected nested subgroup as tri-state '1'", () => {
+    const partial = mockRow(true, [
+      { isSelected: false, isSomeSelected: true },
+      { isSelected: false },
+    ]);
+    expect(getSubRowSelectionSignature(partial)).toBe("10");
+    // Distinct from both none-selected and fully-selected.
+    expect(getSubRowSelectionSignature(partial)).not.toBe(
+      getSubRowSelectionSignature(
+        mockRow(true, [{ isSelected: false }, { isSelected: false }]),
+      ),
+    );
+    expect(getSubRowSelectionSignature(partial)).not.toBe(
+      getSubRowSelectionSignature(
+        mockRow(true, [{ isSelected: true }, { isSelected: false }]),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #995

In grouped **mobile / collapsable** mode, toggling a sub-row's selection checkbox inside an expanded group card updated the selection state but the checkbox stayed **stale** — a regression from the row memoization (#992 / #993).

Sub-rows render inside the parent group's card (`CollapsableCell.getRowVisibleCells` flattens `row.subRows`) and are skipped in the `CollapsableRows` loop, so a sub-row toggle changed no prop compared by the memoized `CollapsableTableRow`. Boolean aggregates don't fix it: `getIsSomeSelected()` is already `true` at 1 selected and stays `true` at 2, so selecting a *second* sub-row (or deselecting one of two) still bailed the memo — the flaky behaviour reported.

## Fix

Add a **per-sub-row selection signature** (`getSubRowSelectionSignature`) as the memo key: a `"2"/"1"/"0"` string (tri-state: all/some/none), one char per sub-row's selection state. The tri-state (vs binary) also captures a nested subgroup's indeterminate transition under multi-level grouping. It changes on every sub-row toggle — and on group-level select-all/none, where several bits flip at once. Non-grouped rows have no sub-rows → empty string, so their own `isSelected` still covers them and the memo win is preserved.

## Test plan

Verified in hca-atlas-tracker (Reports view, mobile width, Group By: Source Study):

- Expand a group with 2+ sub-rows; select one, select a second, deselect one, deselect the other — checkbox updates on every toggle.
- Non-grouped mobile selection, column-visibility toggle, and desktop paths unchanged.
- `tsc` / `prettier` / `eslint` clean; `rowSelectionValidation` + `tableFilter` suites pass (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

